### PR TITLE
feat: Add literal parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ import {
   parseAsIsoDateTime,
   parseAsArrayOf,
   parseAsJson,
-  parseAsStringEnum
+  parseAsStringEnum,
+  parseAsStringConst
 } from 'nuqs'
 
 useQueryState('tag') // defaults to string
@@ -127,6 +128,15 @@ const [direction, setDirection] = useQueryState(
   'direction',
   parseAsStringEnum<Direction>(Object.values(Direction)) // pass a list of allowed values
     .withDefault(Direction.up)
+)
+
+// readonly Array (string-based only)
+const colors = ['red', 'green', 'blue'] as const
+
+const [color, setColor] = useQueryState(
+  'color',
+  parseAsStringConst(colors) // pass a readonly list of allowed values
+    .withDefault('red')
 )
 ```
 
@@ -594,7 +604,7 @@ export function Server() {
 
 // client.tsx
 // prettier-ignore
-;'use client'
+'use client'
 
 import { useQueryStates } from 'nuqs'
 import { coordinatesParsers } from './searchParams'

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ import {
   parseAsArrayOf,
   parseAsJson,
   parseAsStringEnum,
-  parseAsLiteral
+  parseAsStringLiteral,
+  parseAsNumberLiteral
 } from 'nuqs'
 
 useQueryState('tag') // defaults to string
@@ -130,12 +131,21 @@ const [direction, setDirection] = useQueryState(
     .withDefault(Direction.up)
 )
 
-// Literals (string- or number-based only)
+// Literals (string-based only)
 const colors = ['red', 'green', 'blue'] as const
 
 const [color, setColor] = useQueryState(
   'color',
-  parseAsLiteral(colors) // pass a readonly list of allowed values
+  parseAsStringLiteral(colors) // pass a readonly list of allowed values
+    .withDefault('red')
+)
+
+// Literals (number-based only)
+const diceSides = [1, 2, 3, 4, 5, 6] as const
+
+const [side, setSide] = useQueryState(
+  'side',
+  parseAsNumberLiteral(diceSides) // pass a readonly list of allowed values
     .withDefault('red')
 )
 ```

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ const diceSides = [1, 2, 3, 4, 5, 6] as const
 const [side, setSide] = useQueryState(
   'side',
   parseAsNumberLiteral(diceSides) // pass a readonly list of allowed values
-    .withDefault('red')
+    .withDefault(4)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import {
   parseAsArrayOf,
   parseAsJson,
   parseAsStringEnum,
-  parseAsStringConst
+  parseAsLiteral
 } from 'nuqs'
 
 useQueryState('tag') // defaults to string
@@ -130,12 +130,12 @@ const [direction, setDirection] = useQueryState(
     .withDefault(Direction.up)
 )
 
-// readonly Array (string-based only)
+// Literals (string- or number-based only)
 const colors = ['red', 'green', 'blue'] as const
 
 const [color, setColor] = useQueryState(
   'color',
-  parseAsStringConst(colors) // pass a readonly list of allowed values
+  parseAsLiteral(colors) // pass a readonly list of allowed values
     .withDefault('red')
 )
 ```

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -137,7 +137,7 @@ const diceSides = [1, 2, 3, 4, 5, 6] as const
 const [side, setSide] = useQueryState(
   'side',
   parseAsNumberLiteral(diceSides) // pass a readonly list of allowed values
-    .withDefault('red')
+    .withDefault(4)
 )
 ```
 

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -94,7 +94,8 @@ import {
   parseAsIsoDateTime,
   parseAsArrayOf,
   parseAsJson,
-  parseAsStringEnum
+  parseAsStringEnum,
+  parseAsStringConst
 } from 'nuqs'
 
 useQueryState('tag') // defaults to string
@@ -118,6 +119,15 @@ const [direction, setDirection] = useQueryState(
   'direction',
   parseAsStringEnum<Direction>(Object.values(Direction)) // pass a list of allowed values
     .withDefault(Direction.up)
+)
+
+// readonly Array (string-based only)
+const colors = ['red', 'green', 'blue'] as const
+
+const [color, setColor] = useQueryState(
+  'color',
+  parseAsStringConst(colors) // pass a readonly list of allowed values
+    .withDefault('red')
 )
 ```
 

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -95,7 +95,8 @@ import {
   parseAsArrayOf,
   parseAsJson,
   parseAsStringEnum,
-  parseAsLiteral
+  parseAsStringLiteral,
+  parseAsNumberLiteral
 } from 'nuqs'
 
 useQueryState('tag') // defaults to string
@@ -121,12 +122,21 @@ const [direction, setDirection] = useQueryState(
     .withDefault(Direction.up)
 )
 
-// Literals (string- or number-based only)
+// Literals (string-based only)
 const colors = ['red', 'green', 'blue'] as const
 
 const [color, setColor] = useQueryState(
   'color',
-  parseAsLiteral(colors) // pass a readonly list of allowed values
+  parseAsStringLiteral(colors) // pass a readonly list of allowed values
+    .withDefault('red')
+)
+
+// Literals (number-based only)
+const diceSides = [1, 2, 3, 4, 5, 6] as const
+
+const [side, setSide] = useQueryState(
+  'side',
+  parseAsNumberLiteral(diceSides) // pass a readonly list of allowed values
     .withDefault('red')
 )
 ```

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -95,7 +95,7 @@ import {
   parseAsArrayOf,
   parseAsJson,
   parseAsStringEnum,
-  parseAsStringConst
+  parseAsLiteral
 } from 'nuqs'
 
 useQueryState('tag') // defaults to string
@@ -121,12 +121,12 @@ const [direction, setDirection] = useQueryState(
     .withDefault(Direction.up)
 )
 
-// readonly Array (string-based only)
+// Literals (string- or number-based only)
 const colors = ['red', 'green', 'blue'] as const
 
 const [color, setColor] = useQueryState(
   'color',
-  parseAsStringConst(colors) // pass a readonly list of allowed values
+  parseAsLiteral(colors) // pass a readonly list of allowed values
     .withDefault('red')
 )
 ```

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -276,7 +276,7 @@ export function parseAsStringLiteral<Literal extends string>(
  * const [side, setSide] = useQueryState(
  *   'side',
  *    parseAsNumberLiteral(diceSides) // pass a readonly list of allowed values
- *      .withDefault("red")
+ *      .withDefault(4)
  * )
  * ```
  *

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -191,7 +191,7 @@ export const parseAsIsoDateTime = createParser({
 
 /**
  * String-based enums provide better type-safety for known sets of values.
- * You will need to pass the stringEnum function a list of your enum values
+ * You will need to pass the parseAsStringEnum function a list of your enum values
  * in order to validate the query string. Anything else will return `null`,
  * or your default value if specified.
  *
@@ -206,9 +206,8 @@ export const parseAsIsoDateTime = createParser({
  *
  * const [direction, setDirection] = useQueryState(
  *   'direction',
- *   queryTypes
- *     .stringEnum<Direction>(Object.values(Direction))
- *     .withDefault(Direction.up)
+ *    parseAsStringEnum<Direction>(Object.values(Direction)) // pass a list of allowed values
+ *      .withDefault(Direction.up)
  * )
  * ```
  *
@@ -227,6 +226,40 @@ export function parseAsStringEnum<Enum extends string>(validValues: Enum[]) {
       return null
     },
     serialize: (value: Enum) => value.toString()
+  })
+}
+
+/**
+ * String-based readonly lists provide better type-safety for known sets of values.
+ * You will need to pass the parseAsStringConst function a list of your string values
+ * in order to validate the query string. Anything else will return `null`,
+ * or your default value if specified.
+ *
+ * Example:
+ * ```ts
+ * const colors = ["red", "green", "blue"] as const
+ *
+ * const [color, setColor] = useQueryState(
+ *   'color',
+ *    parseAsStringConst(colors) // pass a readonly list of allowed values
+ *      .withDefault("red")
+ * )
+ * ```
+ *
+ * @param validValues The values you want to accept
+ */
+export function parseAsStringConst<Const extends string>(
+  validValues: readonly Const[]
+) {
+  return createParser({
+    parse: (query: string) => {
+      const asConst = query as unknown as Const
+      if (validValues.includes(asConst)) {
+        return asConst
+      }
+      return null
+    },
+    serialize: (value: Const) => value.toString()
   })
 }
 

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -230,8 +230,8 @@ export function parseAsStringEnum<Enum extends string>(validValues: Enum[]) {
 }
 
 /**
- * String-based readonly lists provide better type-safety for known sets of values.
- * You will need to pass the parseAsStringConst function a list of your string values
+ * String- or number-based readonly lists provide better type-safety for known sets of values.
+ * You will need to pass the parseAsLiteral function a list of your string or number values
  * in order to validate the query string. Anything else will return `null`,
  * or your default value if specified.
  *
@@ -241,25 +241,25 @@ export function parseAsStringEnum<Enum extends string>(validValues: Enum[]) {
  *
  * const [color, setColor] = useQueryState(
  *   'color',
- *    parseAsStringConst(colors) // pass a readonly list of allowed values
+ *    parseAsLiteral(colors) // pass a readonly list of allowed values
  *      .withDefault("red")
  * )
  * ```
  *
  * @param validValues The values you want to accept
  */
-export function parseAsStringConst<Const extends string>(
-  validValues: readonly Const[]
+export function parseAsLiteral<Literal extends string | number>(
+  validValues: readonly Literal[]
 ) {
   return createParser({
     parse: (query: string) => {
-      const asConst = query as unknown as Const
+      const asConst = query as unknown as Literal
       if (validValues.includes(asConst)) {
         return asConst
       }
       return null
     },
-    serialize: (value: Const) => value.toString()
+    serialize: (value: Literal) => value.toString()
   })
 }
 

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -230,8 +230,8 @@ export function parseAsStringEnum<Enum extends string>(validValues: Enum[]) {
 }
 
 /**
- * String- or number-based readonly lists provide better type-safety for known sets of values.
- * You will need to pass the parseAsLiteral function a list of your string or number values
+ * String-based literals provide better type-safety for known sets of values.
+ * You will need to pass the parseAsStringLiteral function a list of your string values
  * in order to validate the query string. Anything else will return `null`,
  * or your default value if specified.
  *
@@ -241,19 +241,53 @@ export function parseAsStringEnum<Enum extends string>(validValues: Enum[]) {
  *
  * const [color, setColor] = useQueryState(
  *   'color',
- *    parseAsLiteral(colors) // pass a readonly list of allowed values
+ *    parseAsStringLiteral(colors) // pass a readonly list of allowed values
  *      .withDefault("red")
  * )
  * ```
  *
  * @param validValues The values you want to accept
  */
-export function parseAsLiteral<Literal extends string | number>(
+export function parseAsStringLiteral<Literal extends string>(
   validValues: readonly Literal[]
 ) {
   return createParser({
     parse: (query: string) => {
       const asConst = query as unknown as Literal
+      if (validValues.includes(asConst)) {
+        return asConst
+      }
+      return null
+    },
+    serialize: (value: Literal) => value.toString()
+  })
+}
+
+/**
+ * Number-based literals provide better type-safety for known sets of values.
+ * You will need to pass the parseAsNumberLiteral function a list of your number values
+ * in order to validate the query string. Anything else will return `null`,
+ * or your default value if specified.
+ *
+ * Example:
+ * ```ts
+ * const diceSides = [1, 2, 3, 4, 5, 6] as const
+ *
+ * const [side, setSide] = useQueryState(
+ *   'side',
+ *    parseAsNumberLiteral(diceSides) // pass a readonly list of allowed values
+ *      .withDefault("red")
+ * )
+ * ```
+ *
+ * @param validValues The values you want to accept
+ */
+export function parseAsNumberLiteral<Literal extends number>(
+  validValues: readonly Literal[]
+) {
+  return createParser({
+    parse: (query: string) => {
+      const asConst = parseFloat(query) as unknown as Literal
       if (validValues.includes(asConst)) {
         return asConst
       }


### PR DESCRIPTION
Hello, while testing with the package I noticed that there is no support for as const string arrays.

Since I am one of those people who don't like enums, these are better for me to use.

I thought this parser might be interesting for everyone.

I have also extended the documentation and adapted outdated documentation for parseAsStringEnum.