### PR TITLE
fix: Check for undefined `next` property on window

### DIFF
--- a/packages/nuqs/src/update-queue.ts
+++ b/packages/nuqs/src/update-queue.ts
@@ -160,7 +160,7 @@ function flushUpdateQueue(router: Router): [URLSearchParams, null | unknown] {
     // miss pushed history updates.
     // The router adapter imported from next/navigation also doesn't support
     // passing an asPath, causing issues in dynamic routes in the pages router.
-    const nextRouter = window.next.router
+    const nextRouter = window.next?.router
     const isPagesRouter = typeof nextRouter?.state?.asPath === 'string'
     if (isPagesRouter) {
       const url = renderURL(nextRouter.state.asPath.split('?')[0] ?? '', search)


### PR DESCRIPTION
In test environment where Next.js isn't actually used but the router is mocked, this internal property isn't set, and accessing it causes a "Type error: cannot read properties of undefined (reading 'router')" error.

Closes #454.