### PR TITLE
fix: WHS stabilisation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,6 +30,10 @@ jobs:
           # 14.0.2 is not compatible due to a prefetch issue
           - latest
         include:
+          # 14.0.3 requires the WHS flag
+          - next-version: '14.0.3'
+            window-history-support: true
+          # Current latest is 14.0.4
           - next-version: latest
             window-history-support: true
           - next-version: latest

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -30,5 +30,8 @@ function supportsWHS() {
   const pkgPath = new URL('./package.json', import.meta.url)
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
   const nextVersion: string = pkg.dependencies.next
-  return semver.gte(nextVersion, '14.0.3-canary.6')
+  return (
+    semver.gte(nextVersion, '14.0.3-canary.6') &&
+    semver.lt(nextVersion, '14.0.5-canary.54')
+  )
 }

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -240,15 +240,13 @@ export function useQueryState<T = string>(
     initialSearchParams?.get(key) ?? null
   )
 
-  if (process.env.__NEXT_WINDOW_HISTORY_SUPPORT) {
-    React.useEffect(() => {
-      const value = initialSearchParams.get(key) ?? null
-      const state = value === null ? null : safeParse(parse, value, key)
-      debug('[nuqs `%s`] syncFromUseSearchParams %O', key, state)
-      stateRef.current = state
-      setInternalState(state)
-    }, [initialSearchParams?.get(key), key])
-  }
+  React.useEffect(() => {
+    const value = initialSearchParams.get(key) ?? null
+    const state = value === null ? null : safeParse(parse, value, key)
+    debug('[nuqs `%s`] syncFromUseSearchParams %O', key, state)
+    stateRef.current = state
+    setInternalState(state)
+  }, [initialSearchParams?.get(key), key])
 
   // Sync all hooks together & with external URL changes
   React.useInsertionEffect(() => {


### PR DESCRIPTION
`next@14.0.5-canary.54` stabilised the WHS flag in PR https://github.com/vercel/next.js/pull/60557

This updates the e2e test suite to no longer check for it in the canaries, and removes the check in useQueryState, as useEffect-ing over a non-reactive useSearchParams before WHS is a noop anyway.

We still need the history patch to support the pages router, as useSearchParams is not reactive there (yet?).