### PR TITLE
chore: ESM only (drop CJS support)

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -32,19 +32,16 @@
   ],
   "type": "module",
   "sideEffects": true,
-  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     },
     "./parsers": {
       "types": "./dist/parsers.d.ts",
-      "import": "./dist/parsers.js",
-      "require": "./dist/parsers.cjs"
+      "import": "./dist/parsers.js"
     }
   },
   "scripts": {
@@ -82,7 +79,7 @@
   },
   "size-limit": [
     {
-      "name": "Client (ESM)",
+      "name": "Client",
       "path": "dist/index.js",
       "limit": "4 kB",
       "ignore": [
@@ -90,7 +87,7 @@
       ]
     },
     {
-      "name": "Parsers (ESM)",
+      "name": "Parsers",
       "path": "dist/parsers.js",
       "limit": "2 kB",
       "ignore": [

--- a/packages/nuqs/scripts/prepack.sh
+++ b/packages/nuqs/scripts/prepack.sh
@@ -13,8 +13,8 @@ VERSION=$(cat package.json | jq -r '.version')
 
 if [[ "$(uname)" == "Darwin" ]]; then
   # macOS requires an empty string as the backup extension
-  sed -i '' "s/0.0.0-inject-version-here/${VERSION}/g" dist/index.{js,cjs}
+  sed -i '' "s/0.0.0-inject-version-here/${VERSION}/g" dist/index.js
 else
   # Ubuntu (CI/CD) doesn't
-  sed -i "s/0.0.0-inject-version-here/${VERSION}/g" dist/index.{js,cjs}
+  sed -i "s/0.0.0-inject-version-here/${VERSION}/g" dist/index.js
 fi

--- a/packages/nuqs/tsup.config.ts
+++ b/packages/nuqs/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     index: 'src/index.ts',
     parsers: 'src/index.parsers.ts'
   },
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   outDir: 'dist',
   splitting: true,


### PR DESCRIPTION
BREAKING CHANGE: drop CJS support.

Since Next has ESM support since v12, it should not really be a breaking change for most.