### PR TITLE
fix: Regression in mounting components

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,6 +29,7 @@ jobs:
           - '14.0.1'
           # 14.0.2 is not compatible due to a prefetch issue
           - latest
+          - '14.0.5-canary.54' # WHS stabilised
         include:
           # 14.0.3 requires the WHS flag
           - next-version: '14.0.3'

--- a/packages/e2e/cypress/e2e/repro-359.cy.js
+++ b/packages/e2e/cypress/e2e/repro-359.cy.js
@@ -11,6 +11,7 @@ it.only('repro-359', () => {
   cy.get('#nuqss-component').should('have.text', '')
 
   cy.contains('Component 1 (nuqs)').click()
+  cy.wait(100)
   cy.location('search').should('eq', '?param=comp1&component=comp1')
   cy.get('#comp1').should('have.text', 'comp1')
   cy.get('#comp2').should('not.exist')
@@ -20,6 +21,7 @@ it.only('repro-359', () => {
   cy.get('#nuqss-component').should('have.text', 'comp1')
 
   cy.contains('Component 2 (nuqs)').click()
+  cy.wait(100)
   cy.location('search').should('eq', '?param=comp2&component=comp2')
   cy.get('#comp1').should('not.exist')
   cy.get('#comp2').should('have.text', 'comp2')
@@ -29,6 +31,7 @@ it.only('repro-359', () => {
   cy.get('#nuqss-component').should('have.text', 'comp2')
 
   cy.contains('Component 1 (nuq+)').click()
+  cy.wait(100)
   cy.location('search').should('eq', '?param=comp1&component=comp1')
   cy.get('#comp1').should('have.text', 'comp1')
   cy.get('#comp2').should('not.exist')
@@ -38,6 +41,7 @@ it.only('repro-359', () => {
   cy.get('#nuqss-component').should('have.text', 'comp1')
 
   cy.contains('Component 2 (nuq+)').click()
+  cy.wait(100)
   cy.location('search').should('eq', '?param=comp2&component=comp2')
   cy.get('#comp1').should('not.exist')
   cy.get('#comp2').should('have.text', 'comp2')

--- a/packages/e2e/cypress/e2e/repro-359.cy.js
+++ b/packages/e2e/cypress/e2e/repro-359.cy.js
@@ -1,0 +1,48 @@
+/// <reference types="cypress" />
+
+it.only('repro-359', () => {
+  cy.visit('/app/repro-359')
+  cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+
+  cy.location('search').should('eq', '')
+  cy.get('#nuqs-param').should('have.text', 'null')
+  cy.get('#nuqs-component').should('have.text', '')
+  cy.get('#nuqss-param').should('have.text', 'null')
+  cy.get('#nuqss-component').should('have.text', '')
+
+  cy.contains('Component 1 (nuqs)').click()
+  cy.location('search').should('eq', '?param=comp1&component=comp1')
+  cy.get('#comp1').should('have.text', 'comp1')
+  cy.get('#comp2').should('not.exist')
+  cy.get('#nuqs-param').should('have.text', 'comp1')
+  cy.get('#nuqs-component').should('have.text', 'comp1')
+  cy.get('#nuqss-param').should('have.text', 'comp1')
+  cy.get('#nuqss-component').should('have.text', 'comp1')
+
+  cy.contains('Component 2 (nuqs)').click()
+  cy.location('search').should('eq', '?param=comp2&component=comp2')
+  cy.get('#comp1').should('not.exist')
+  cy.get('#comp2').should('have.text', 'comp2')
+  cy.get('#nuqs-param').should('have.text', 'comp2')
+  cy.get('#nuqs-component').should('have.text', 'comp2')
+  cy.get('#nuqss-param').should('have.text', 'comp2')
+  cy.get('#nuqss-component').should('have.text', 'comp2')
+
+  cy.contains('Component 1 (nuq+)').click()
+  cy.location('search').should('eq', '?param=comp1&component=comp1')
+  cy.get('#comp1').should('have.text', 'comp1')
+  cy.get('#comp2').should('not.exist')
+  cy.get('#nuqs-param').should('have.text', 'comp1')
+  cy.get('#nuqs-component').should('have.text', 'comp1')
+  cy.get('#nuqss-param').should('have.text', 'comp1')
+  cy.get('#nuqss-component').should('have.text', 'comp1')
+
+  cy.contains('Component 2 (nuq+)').click()
+  cy.location('search').should('eq', '?param=comp2&component=comp2')
+  cy.get('#comp1').should('not.exist')
+  cy.get('#comp2').should('have.text', 'comp2')
+  cy.get('#nuqs-param').should('have.text', 'comp2')
+  cy.get('#nuqs-component').should('have.text', 'comp2')
+  cy.get('#nuqss-param').should('have.text', 'comp2')
+  cy.get('#nuqss-component').should('have.text', 'comp2')
+})

--- a/packages/e2e/src/app/app/repro-359/page.tsx
+++ b/packages/e2e/src/app/app/repro-359/page.tsx
@@ -1,0 +1,86 @@
+// https://github.com/47ng/nuqs/issues/359
+
+'use client'
+
+import Link from 'next/link'
+import {
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryState,
+  useQueryStates
+} from 'nuqs'
+
+const paramParser = parseAsString.withDefault('null')
+const components = ['comp1', 'comp2'] as const
+const componentParser = parseAsStringLiteral(components)
+
+const Component = (props: React.ComponentProps<'span'>) => {
+  const [param] = useQueryState('param', paramParser)
+  return <span {...props}>{param}</span>
+}
+
+export default function Wolf359() {
+  const [param, setParam] = useQueryState('param', paramParser)
+  const [component, seComponent] = useQueryState('component', componentParser)
+  const [multiple, setMultiple] = useQueryStates({
+    param: paramParser,
+    component: componentParser
+  })
+  return (
+    <>
+      <div>
+        {component === 'comp1' && <Component id="comp1" />}
+        {component === 'comp2' && <Component id="comp2" />}
+      </div>
+      <div>
+        <span id="nuqs-param">{param}</span>
+        <span id="nuqs-component">{component}</span>
+        <span id="nuqss-param">{multiple.param}</span>
+        <span id="nuqss-component">{multiple.component}</span>
+      </div>
+      <div>
+        <button
+          onClick={() => {
+            setParam('comp1')
+            seComponent('comp1')
+          }}
+        >
+          Component 1 (nuqs)
+        </button>
+        <button
+          onClick={() => {
+            setParam('comp2')
+            seComponent('comp2')
+          }}
+        >
+          Component 2 (nuqs)
+        </button>
+        <br />
+        <button
+          onClick={() => {
+            setMultiple({
+              param: 'comp1',
+              component: 'comp1'
+            })
+          }}
+        >
+          Component 1 (nuq+)
+        </button>
+        <button
+          onClick={() => {
+            setMultiple({
+              param: 'comp2',
+              component: 'comp2'
+            })
+          }}
+        >
+          Component 2 (nuq+)
+        </button>
+      </div>
+      <nav>
+        <Link href="?param=comp1&component=comp1">Comp 1</Link>
+        <Link href="?param=comp2&component=comp2">Comp 2</Link>
+      </nav>
+    </>
+  )
+}

--- a/packages/nuqs/src/update-queue.ts
+++ b/packages/nuqs/src/update-queue.ts
@@ -120,6 +120,7 @@ export function scheduleFlushToURL(router: Router) {
 declare global {
   interface Window {
     next: {
+      version: string
       router?: NextRouter & {
         state: {
           asPath: string

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -241,6 +241,8 @@ export function useQueryState<T = string>(
   )
 
   React.useEffect(() => {
+    // This will be removed in v2 which will drop support for
+    // partially-functional shallow routing (14.0.2 and 14.0.3)
     if (window.next.version !== '14.0.3') {
       return
     }

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -240,13 +240,13 @@ export function useQueryState<T = string>(
     initialSearchParams?.get(key) ?? null
   )
 
-  React.useEffect(() => {
-    const value = initialSearchParams.get(key) ?? null
-    const state = value === null ? null : safeParse(parse, value, key)
-    debug('[nuqs `%s`] syncFromUseSearchParams %O', key, state)
-    stateRef.current = state
-    setInternalState(state)
-  }, [initialSearchParams?.get(key), key])
+  // React.useEffect(() => {
+  //   const value = initialSearchParams.get(key) ?? null
+  //   const state = value === null ? null : safeParse(parse, value, key)
+  //   debug('[nuqs `%s`] syncFromUseSearchParams %O', key, state)
+  //   stateRef.current = state
+  //   setInternalState(state)
+  // }, [initialSearchParams?.get(key), key])
 
   // Sync all hooks together & with external URL changes
   React.useInsertionEffect(() => {

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -240,13 +240,16 @@ export function useQueryState<T = string>(
     initialSearchParams?.get(key) ?? null
   )
 
-  // React.useEffect(() => {
-  //   const value = initialSearchParams.get(key) ?? null
-  //   const state = value === null ? null : safeParse(parse, value, key)
-  //   debug('[nuqs `%s`] syncFromUseSearchParams %O', key, state)
-  //   stateRef.current = state
-  //   setInternalState(state)
-  // }, [initialSearchParams?.get(key), key])
+  React.useEffect(() => {
+    if (window.next.version !== '14.0.3') {
+      return
+    }
+    const value = initialSearchParams.get(key) ?? null
+    const state = value === null ? null : safeParse(parse, value, key)
+    debug('[nuqs `%s`] syncFromUseSearchParams %O', key, state)
+    stateRef.current = state
+    setInternalState(state)
+  }, [initialSearchParams?.get(key), key])
 
   // Sync all hooks together & with external URL changes
   React.useInsertionEffect(() => {


### PR DESCRIPTION
Regression introduced by #457 was detected in the repro-359 test case, where components with a `useQueryState` failed to capture the correct value on mount, and trailed behind.

- [x] Add an e2e test case to track across versions & configuration
- [x] Investigate a fix

## Root of the issue

The `useEffect` introduced in #394 to sync internal state against a reactive `useSearchParams` hook in order to support WHS in 14.0.3 had a flaw. Actually, 14.0.3 had a flaw too, but we'll come to that in a bit.

The test in #359 exposes differences between the internal state of the `useQueryState` hook and the URL state (as reflected in a reactive `useSearchParams`): when a component mounts because of a query state change, and that component also listens for the same query key, its internal state will be fine on mount (due to the state initialisation function taking into account the URL update queue), but the initial `useSearchParams` will still reflect the stale, not-yet-updated URL. Attempting to sync on that on mount causes the value to trail behind.

Now onto the issue in `next@14.0.3`: implementation of the WHS had a bug that didn't call patched history methods made in third party modules like `nuqs` (and other analytics packages). This caused a [known issue](https://github.com/47ng/nuqs/issues/423#issuecomment-1846226763) to be published, with the resolution of "enable WHS". This would only help make the `useSearchParams` hook reactive, and we can sync to it, but only in 14.0.3, leading to the ugly hack of version detection that will be removed entirely in v2 (along with support for 14.0.3).

So is 14.0.3, with WHS, subject to 359? Turns out, no. For some reason the tests pass fine there. No idea why, as it theoretically should fail, but since we're going to drop it anyway.. 🤷 