### PR TITLE
fix: Mark global `next` internal as optional

### DIFF
--- a/packages/nuqs/src/update-queue.ts
+++ b/packages/nuqs/src/update-queue.ts
@@ -119,7 +119,7 @@ export function scheduleFlushToURL(router: Router) {
 
 declare global {
   interface Window {
-    next: {
+    next?: {
       version: string
       router?: NextRouter & {
         state: {

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -243,7 +243,7 @@ export function useQueryState<T = string>(
   React.useEffect(() => {
     // This will be removed in v2 which will drop support for
     // partially-functional shallow routing (14.0.2 and 14.0.3)
-    if (window.next.version !== '14.0.3') {
+    if (window.next?.version !== '14.0.3') {
       return
     }
     const value = initialSearchParams.get(key) ?? null


### PR DESCRIPTION
Closes #464.