### PR TITLE
doc: Enable ISR invalidation for latest version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -108,3 +108,5 @@ jobs:
         continue-on-error: true
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Invalidate ISR cache for NPM in the docs
+        run: curl -s "https://nuqs.47ng.com/api/isr?tag=npm&token=${{ secrets.ISR_TOKEN }}"

--- a/packages/docs/src/app/api/isr/route.ts
+++ b/packages/docs/src/app/api/isr/route.ts
@@ -1,7 +1,7 @@
 import { revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
 
-const ACCEPTED_TAGS = ['github', 'github-actions-status']
+const ACCEPTED_TAGS = ['github', 'github-actions-status', 'npm']
 
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')

--- a/packages/docs/src/app/docs/layout.tsx
+++ b/packages/docs/src/app/docs/layout.tsx
@@ -43,6 +43,10 @@ async function SidebarFooter() {
 }
 
 async function getLatestVersion() {
-  const res = await fetch('https://registry.npmjs.org/nuqs').then(r => r.json())
+  const res = await fetch('https://registry.npmjs.org/nuqs', {
+    next: {
+      tags: ['npm']
+    }
+  }).then(r => r.json())
   return res['dist-tags'].latest
 }


### PR DESCRIPTION
Because the Vercel deployment happens in parallel with CI/CD which publishes to NPM, it always shows a stale version.