### PR TITLE
chore: Alias nuqs/server to nuqs/parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,13 @@ export default () => {
 > section for a more user-friendly way to achieve type-safety.
 
 If you wish to parse the searchParams in server components, you'll need to
-import the parsers from `nuqs/parsers`, which doesn't include
+import the parsers from `nuqs/server`, which doesn't include
 the `"use client"` directive.
 
 You can then use the `parseServerSide` method:
 
 ```tsx
-import { parseAsInteger } from 'nuqs/parsers'
+import { parseAsInteger } from 'nuqs/server'
 
 type PageProps = {
   searchParams: {
@@ -394,7 +394,7 @@ You can get this pattern for your custom parsers too, and compose them
 with others:
 
 ```ts
-import { createParser, parseAsHex } from 'nuqs/parsers'
+import { createParser, parseAsHex } from 'nuqs'
 
 // Wrapping your parser/serializer in `createParser`
 // gives it access to the builder pattern & server-side
@@ -529,7 +529,7 @@ import {
   createSearchParamsCache,
   parseAsInteger,
   parseAsString
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 // Note: import from '…/parsers' to avoid the "use client" directive
 
 export const searchParamsCache = createSearchParamsCache({
@@ -572,7 +572,7 @@ parser declaration with `useQueryStates` for type-safety in client components:
 
 ```tsx
 // searchParams.ts
-import { parseAsFloat, createSearchParamsCache } from 'nuqs/parsers'
+import { parseAsFloat, createSearchParamsCache } from 'nuqs/server'
 
 export const coordinatesParsers = {
   lat: parseAsFloat.withDefault(45.18),
@@ -642,7 +642,7 @@ import {
   parseAsIsoDateTime,
   parseAsString,
   parseAsStringLiteral
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 
 const searchParams = {
   search: parseAsString,
@@ -751,7 +751,7 @@ use `useQueryState` to read it:
 // page.tsx
 import type { Metadata, ResolvingMetadata } from 'next'
 import { useQueryState } from 'nuqs'
-import { parseAsString } from 'nuqs/parsers'
+import { parseAsString } from 'nuqs/server'
 
 type Props = {
   searchParams: { [key: string]: string | string[] | undefined }

--- a/errors/NUQS-500.md
+++ b/errors/NUQS-500.md
@@ -26,7 +26,7 @@ import {
   createSearchParamsCache,
   parseAsInteger,
   parseAsString
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 
 const cache = createSearchParamsCache({
   q: parseAsString,

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -162,13 +162,13 @@ export default () => {
 > section for a more user-friendly way to achieve type-safety.
 
 If you wish to parse the searchParams in server components, you'll need to
-import the parsers from `nuqs/parsers`, which doesn't include
+import the parsers from `nuqs/server`, which doesn't include
 the `"use client"` directive.
 
 You can then use the `parseServerSide` method:
 
 ```tsx
-import { parseAsInteger } from 'nuqs/parsers'
+import { parseAsInteger } from 'nuqs/server'
 
 type PageProps = {
   searchParams: {
@@ -388,7 +388,7 @@ You can get this pattern for your custom parsers too, and compose them
 with others:
 
 ```ts
-import { createParser, parseAsHex } from 'nuqs/parsers'
+import { createParser, parseAsHex } from 'nuqs/server'
 
 // Wrapping your parser/serializer in `createParser`
 // gives it access to the builder pattern & server-side
@@ -523,7 +523,7 @@ import {
   createSearchParamsCache,
   parseAsInteger,
   parseAsString
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 // Note: import from '…/parsers' to avoid the "use client" directive
 
 export const searchParamsCache = createSearchParamsCache({
@@ -569,7 +569,7 @@ parser declaration with `useQueryStates` for type-safety in client components:
 import {
   parseAsFloat,
   createSearchParamsCache
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 
 export const coordinatesParsers = {
   lat: parseAsFloat.withDefault(45.18),
@@ -639,7 +639,7 @@ import {
   parseAsIsoDateTime,
   parseAsString,
   parseAsStringLiteral
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 
 const searchParams = {
   search: parseAsString,
@@ -748,7 +748,7 @@ use `useQueryState` to read it:
 // page.tsx
 import type { Metadata, ResolvingMetadata } from 'next'
 import { useQueryState } from 'nuqs'
-import { parseAsString } from 'nuqs/parsers'
+import { parseAsString } from 'nuqs/server'
 
 type Props = {
   searchParams: { [key: string]: string | string[] | undefined }

--- a/packages/docs/src/app/playground/(demos)/pagination/page.tsx
+++ b/packages/docs/src/app/playground/(demos)/pagination/page.tsx
@@ -1,6 +1,6 @@
 import { Description } from '@/src/components/typography'
 import { Separator } from '@/src/components/ui/separator'
-import type { SearchParams } from 'nuqs/parsers'
+import type { SearchParams } from 'nuqs/server'
 import { Suspense } from 'react'
 import { SourceOnGitHub } from '../_components/source-on-github'
 import { getMetadata } from '../demos'

--- a/packages/docs/src/app/playground/(demos)/pagination/searchParams.ts
+++ b/packages/docs/src/app/playground/(demos)/pagination/searchParams.ts
@@ -3,7 +3,7 @@ import {
   createSerializer,
   parseAsInteger,
   parseAsStringLiteral
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 
 export const renderingOptions = ['server', 'client'] as const
 export type RenderingOptions = (typeof renderingOptions)[number]

--- a/packages/docs/src/app/playground/_demos/server-side-parsing/parser.ts
+++ b/packages/docs/src/app/playground/_demos/server-side-parsing/parser.ts
@@ -1,3 +1,3 @@
-import { parseAsInteger } from 'nuqs/parsers'
+import { parseAsInteger } from 'nuqs/server'
 
 export const counterParser = parseAsInteger.withDefault(0)

--- a/packages/docs/src/app/playground/_demos/throttling/parsers.ts
+++ b/packages/docs/src/app/playground/_demos/throttling/parsers.ts
@@ -1,4 +1,4 @@
-import { parseAsInteger, parseAsString } from 'nuqs/parsers'
+import { parseAsInteger, parseAsString } from 'nuqs/server'
 
 export const delayParser = parseAsInteger.withDefault(0)
 export const queryParser = parseAsString.withDefault('')

--- a/packages/e2e/src/app/app/cache/searchParams.ts
+++ b/packages/e2e/src/app/app/cache/searchParams.ts
@@ -3,7 +3,7 @@ import {
   parseAsBoolean,
   parseAsInteger,
   parseAsString
-} from 'nuqs/parsers'
+} from 'nuqs/server'
 
 export const parsers = {
   str: parseAsString,

--- a/packages/e2e/src/app/app/push/searchParams.ts
+++ b/packages/e2e/src/app/app/push/searchParams.ts
@@ -1,4 +1,4 @@
-import { parseAsInteger } from 'nuqs/server'
+import { parseAsInteger } from 'nuqs'
 
 export const parser = parseAsInteger.withDefault(0).withOptions({
   history: 'push'

--- a/packages/e2e/src/app/app/push/searchParams.ts
+++ b/packages/e2e/src/app/app/push/searchParams.ts
@@ -1,4 +1,4 @@
-import { parseAsInteger } from 'nuqs'
+import { parseAsInteger } from 'nuqs/server'
 
 export const parser = parseAsInteger.withDefault(0).withOptions({
   history: 'push'

--- a/packages/e2e/src/app/app/rewrites/destination/page.tsx
+++ b/packages/e2e/src/app/app/rewrites/destination/page.tsx
@@ -1,4 +1,4 @@
-import type { SearchParams } from 'nuqs/parsers'
+import type { SearchParams } from 'nuqs/server'
 import { Suspense } from 'react'
 import { RewriteDestinationClient } from './client'
 import { cache } from './searchParams'

--- a/packages/e2e/src/app/app/rewrites/destination/searchParams.ts
+++ b/packages/e2e/src/app/app/rewrites/destination/searchParams.ts
@@ -1,4 +1,4 @@
-import { createSearchParamsCache, parseAsString } from 'nuqs/parsers'
+import { createSearchParamsCache, parseAsString } from 'nuqs/server'
 
 export const searchParams = {
   injected: parseAsString.withDefault('null'),

--- a/packages/e2e/src/app/app/routing-tour/_components/parsers.ts
+++ b/packages/e2e/src/app/app/routing-tour/_components/parsers.ts
@@ -1,4 +1,4 @@
-import { parseAsInteger, parseAsString } from 'nuqs/parsers'
+import { parseAsInteger, parseAsString } from 'nuqs/server'
 
 export const counterParser = parseAsInteger.withDefault(0)
 export const fromParser = parseAsString

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -28,7 +28,8 @@
   },
   "files": [
     "dist/",
-    "parsers.d.ts"
+    "parsers.d.ts",
+    "server.d.ts"
   ],
   "type": "module",
   "sideEffects": true,
@@ -40,6 +41,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
     },
     "./parsers": {
       "types": "./dist/parsers.d.ts",
@@ -91,8 +97,8 @@
       ]
     },
     {
-      "name": "Parsers (ESM)",
-      "path": "dist/parsers.js",
+      "name": "Server (ESM)",
+      "path": "dist/server.js",
       "limit": "2 kB",
       "ignore": [
         "react"

--- a/packages/nuqs/server.d.ts
+++ b/packages/nuqs/server.d.ts
@@ -1,0 +1,7 @@
+// This file is needed for projects that have `moduleResolution` set to `node`
+// in their tsconfig.json to be able to `import {} from 'nuqs/server'`.
+// Other module resolutions strategies will look for the `exports` in `package.json`,
+// but with `node`, TypeScript will look for a .d.ts file with that name at the
+// root of the package.
+
+export * from './dist/server'

--- a/packages/nuqs/src/index.parsers.ts
+++ b/packages/nuqs/src/index.parsers.ts
@@ -1,5 +1,5 @@
 console.warn(
-  'Please update your import from `nuqs/parsers` to `nuqs/server`. Importing from `nuqs/parsers` is deprecated, and will be removed in v2.0.0.'
+  'Please update your imports from `nuqs/parsers` to `nuqs/server`. Importing from `nuqs/parsers` is deprecated, and will be removed in v2.0.0.'
 )
 
 export * from './cache'

--- a/packages/nuqs/src/index.parsers.ts
+++ b/packages/nuqs/src/index.parsers.ts
@@ -1,3 +1,7 @@
+console.warn(
+  'Please update your import from `nuqs/parsers` to `nuqs/server`. Importing from `nuqs/parsers` is deprecated, and will be removed in v2.0.0.'
+)
+
 export * from './cache'
 export * from './parsers'
 export { createSerializer } from './serializer'

--- a/packages/nuqs/src/index.server.ts
+++ b/packages/nuqs/src/index.server.ts
@@ -1,0 +1,3 @@
+export * from './cache'
+export * from './parsers'
+export { createSerializer } from './serializer'

--- a/packages/nuqs/tsup.config.ts
+++ b/packages/nuqs/tsup.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: {
     index: 'src/index.ts',
-    parsers: 'src/index.parsers.ts'
+    parsers: 'src/index.parsers.ts',
+    server: 'src/index.server.ts'
   },
   format: ['esm', 'cjs'],
   dts: true,


### PR DESCRIPTION
In preparation for v2.0.0 move, might as well give folks time to update.