### PR TITLE
chore: Fix anchor nav in docs breaking interactive demos

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
       "isarray": "npm:@nolyfill/isarray@latest",
       "side-channel": "npm:@nolyfill/side-channel@latest",
       "string.prototype.padend": "npm:@nolyfill/string.prototype.padend@latest"
+    },
+    "patchedDependencies": {
+      "next@14.1.1-canary.0": "patches/next@14.1.1-canary.0.patch"
     }
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.1.0",
     "dayjs": "^1.11.10",
     "lucide-react": "^0.323.0",
-    "next": "14.1.0",
+    "next": "14.1.1-canary.0",
     "next-docs-mdx": "6.0.2",
     "next-docs-ui": "6.0.2",
     "next-docs-zeta": "6.0.2",

--- a/patches/next@14.1.1-canary.0.patch
+++ b/patches/next@14.1.1-canary.0.patch
@@ -1,0 +1,20 @@
+diff --git a/.prettierignore b/.prettierignore
+new file mode 100644
+index 0000000000000000000000000000000000000000..fa29cdfff915566d202c195607a42b9445919261
+--- /dev/null
++++ b/.prettierignore
+@@ -0,0 +1 @@
++**
+\ No newline at end of file
+diff --git a/dist/client/components/app-router.js b/dist/client/components/app-router.js
+index aa2818d8ead9ed713077ff715a411d04dc149ee5..b15f914df85079a31870b0a09279be08019e503f 100644
+--- a/dist/client/components/app-router.js
++++ b/dist/client/components/app-router.js
+@@ -376,6 +376,7 @@ function Head(param) {
+         const originalReplaceState = window.history.replaceState.bind(window.history);
+         // Ensure the canonical URL in the Next.js Router is updated when the URL is changed so that `usePathname` and `useSearchParams` hold the pushed values.
+         const applyUrlFromHistoryPushReplace = (url)=>{
++            if (!window.history.state) return;
+             const href = window.location.href;
+             (0, _react.startTransition)(()=>{
+                 dispatch({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,11 @@ overrides:
   side-channel: npm:@nolyfill/side-channel@latest
   string.prototype.padend: npm:@nolyfill/string.prototype.padend@latest
 
+patchedDependencies:
+  next@14.1.1-canary.0:
+    hash: jmj7qk37k7cq22c7437u6n6ism
+    path: patches/next@14.1.1-canary.0.patch
+
 importers:
 
   .:
@@ -84,17 +89,17 @@ importers:
         specifier: ^0.323.0
         version: 0.323.0(react@18.2.0)
       next:
-        specifier: 14.1.0
-        version: 14.1.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.1.1-canary.0
+        version: 14.1.1-canary.0(patch_hash=jmj7qk37k7cq22c7437u6n6ism)(react-dom@18.2.0)(react@18.2.0)
       next-docs-mdx:
         specifier: 6.0.2
-        version: 6.0.2(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.0.2(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)
       next-docs-ui:
         specifier: 6.0.2
-        version: 6.0.2(@types/react-dom@18.2.18)(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.4.1)
+        version: 6.0.2(@types/react-dom@18.2.18)(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.4.1)
       next-docs-zeta:
         specifier: 6.0.2
-        version: 6.0.2(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.0.2(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)
       nuqs:
         specifier: workspace:*
         version: link:../nuqs
@@ -825,6 +830,10 @@ packages:
     resolution: {integrity: sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw==}
     dev: false
 
+  /@next/env@14.1.1-canary.0:
+    resolution: {integrity: sha512-eXiA6VpPRhxaklCZqJZ1/WSTVmLC67dFA1N3wWTbRheuvoAk3fDteZlMmY/dD+aE9OH3pAkJI11zcRINIMspYA==}
+    dev: false
+
   /@next/swc-darwin-arm64@14.0.1:
     resolution: {integrity: sha512-JyxnGCS4qT67hdOKQ0CkgFTp+PXub5W1wsGvIq98TNbF3YEIN7iDekYhYsZzc8Ov0pWEsghQt+tANdidITCLaw==}
     engines: {node: '>= 10'}
@@ -836,6 +845,15 @@ packages:
 
   /@next/swc-darwin-arm64@14.1.0:
     resolution: {integrity: sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-arm64@14.1.1-canary.0:
+    resolution: {integrity: sha512-VEH2ephkoTbKLnybfTLMWAtj4NUjfEeJkJm7j+7sSBNiks4MMQpvCFGtWpsTAsyD78SSzbUwRrBC+dUvR5qxzg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -861,6 +879,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-darwin-x64@14.1.1-canary.0:
+    resolution: {integrity: sha512-F39VcbYV3LZF+OvW0qUH987MauniHI368L/KW8121/1MT+YRIGz5QsqXWSO4ngxTEjDHle23aOA9d6Vku1zarw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-arm64-gnu@14.0.1:
     resolution: {integrity: sha512-iVpn3KG3DprFXzVHM09kvb//4CNNXBQ9NB/pTm8LO+vnnnaObnzFdS5KM+w1okwa32xH0g8EvZIhoB3fI3mS1g==}
     engines: {node: '>= 10'}
@@ -872,6 +899,15 @@ packages:
 
   /@next/swc-linux-arm64-gnu@14.1.0:
     resolution: {integrity: sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-gnu@14.1.1-canary.0:
+    resolution: {integrity: sha512-ZuxLtHz1VFK9DrqD3PCiCqL1vPflmzYrJ4G/YGwN7sGyxOol9jVKdLcLU27zlgqmspy6886GBbcO26GLJJKe8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -897,6 +933,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-linux-arm64-musl@14.1.1-canary.0:
+    resolution: {integrity: sha512-OYzZH51AH2FcQP7orSyEOAe598+MA0Uq4rqwWyJLCBECTr60cANLr83pJtvOF8prxDhGGn1QbvXD/1FA3bRing==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-linux-x64-gnu@14.0.1:
     resolution: {integrity: sha512-wMqf90uDWN001NqCM/auRl3+qVVeKfjJdT9XW+RMIOf+rhUzadmYJu++tp2y+hUbb6GTRhT+VjQzcgg/QTD9NQ==}
     engines: {node: '>= 10'}
@@ -908,6 +953,15 @@ packages:
 
   /@next/swc-linux-x64-gnu@14.1.0:
     resolution: {integrity: sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-gnu@14.1.1-canary.0:
+    resolution: {integrity: sha512-2G+nCZOPYlJVrfvIF6o7OQIP1Lqbt1FoSg/q7g80KIY87b3gqGt9HydU2ch4Dn2IX/U7OJbsz2wNOuoQYuowKA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -933,6 +987,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-linux-x64-musl@14.1.1-canary.0:
+    resolution: {integrity: sha512-F3znkB3nnWpuqC7WIdSoW1cOHOufOh25Ewkr5cjkVcQe6HenaWEjoyPdjm9wOmkSoerrqVKL89JExCMUx2a78A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-arm64-msvc@14.0.1:
     resolution: {integrity: sha512-WEmTEeWs6yRUEnUlahTgvZteh5RJc4sEjCQIodJlZZ5/VJwVP8p2L7l6VhzQhT4h7KvLx/Ed4UViBdne6zpIsw==}
     engines: {node: '>= 10'}
@@ -944,6 +1007,15 @@ packages:
 
   /@next/swc-win32-arm64-msvc@14.1.0:
     resolution: {integrity: sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-arm64-msvc@14.1.1-canary.0:
+    resolution: {integrity: sha512-MNYUQAbKbo10Y5r/KfFEvhyAUC81RE/CmyuPSKrZyeFDui5QKwcS10+yyIDAq8O8pMEdb2b2Q5VsxuXvXzfL+w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -969,6 +1041,15 @@ packages:
     dev: false
     optional: true
 
+  /@next/swc-win32-ia32-msvc@14.1.1-canary.0:
+    resolution: {integrity: sha512-CjDNY82g5PMOKrVAciMdhvQ/uK588vIl+wpLREro+r1Ge7F13SpQUmgiX8FGSVNDkh8t817ueLQvzOaoulskJw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@next/swc-win32-x64-msvc@14.0.1:
     resolution: {integrity: sha512-FFp3nOJ/5qSpeWT0BZQ+YE1pSMk4IMpkME/1DwKBwhg4mJLB9L+6EXuJi4JEwaJdl5iN+UUlmUD3IsR1kx5fAg==}
     engines: {node: '>= 10'}
@@ -980,6 +1061,15 @@ packages:
 
   /@next/swc-win32-x64-msvc@14.1.0:
     resolution: {integrity: sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-x64-msvc@14.1.1-canary.0:
+    resolution: {integrity: sha512-lW7P7w5sIxkcGzlonrkQy6XkWWbgRl54AyH2Tdkm1qxs1v49XF0FZHiqp32D7bfGkFMzo94LHWSFsPzECKTXdQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -6127,7 +6217,7 @@ packages:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
     dev: true
 
-  /next-docs-mdx@6.0.2(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0):
+  /next-docs-mdx@6.0.2(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-AaONK2jAKog94OTXt6Gfoh5rp351G4FxMlGN2dSNfrkJ10yNBUMw25MBvJum9tsq/TUrRxSU4AW07ZVkiu8Cmg==}
     peerDependencies:
       next: '>= 13.4'
@@ -6136,8 +6226,8 @@ packages:
       estree-util-value-to-estree: 3.0.1
       fast-glob: 3.3.2
       gray-matter: 4.0.3
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)
-      next-docs-zeta: 6.0.2(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.1-canary.0(patch_hash=jmj7qk37k7cq22c7437u6n6ism)(react-dom@18.2.0)(react@18.2.0)
+      next-docs-zeta: 6.0.2(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)
       zod: 3.22.4
     transitivePeerDependencies:
       - '@types/react'
@@ -6146,7 +6236,7 @@ packages:
       - supports-color
     dev: false
 
-  /next-docs-ui@6.0.2(@types/react-dom@18.2.18)(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.4.1):
+  /next-docs-ui@6.0.2(@types/react-dom@18.2.18)(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.4.1):
     resolution: {integrity: sha512-UfhibJaQT/FB/mkdADJksbM3JVlx/OvAhnZn7/cUc696oThgwXWCFgavyTuTouxSD4iZjMbK3jMJKyqFQrtIaA==}
     peerDependencies:
       next: '>= 13'
@@ -6165,9 +6255,9 @@ packages:
       clsx: 2.1.0
       cmdk: 0.2.0(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       lucide-react: 0.294.0(react@18.2.0)
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)
-      next-docs-zeta: 6.0.2(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
-      next-themes: 0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.1-canary.0(patch_hash=jmj7qk37k7cq22c7437u6n6ism)(react-dom@18.2.0)(react@18.2.0)
+      next-docs-zeta: 6.0.2(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)
+      next-themes: 0.2.1(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-medium-image-zoom: 5.1.8(react-dom@18.2.0)(react@18.2.0)
@@ -6180,7 +6270,7 @@ packages:
       - tailwindcss
     dev: false
 
-  /next-docs-zeta@6.0.2(@types/react@18.2.55)(next@14.1.0)(react-dom@18.2.0)(react@18.2.0):
+  /next-docs-zeta@6.0.2(@types/react@18.2.55)(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-OEhzFDq5r4ejTG/FbDJgvsnKOuUwT5qHR/jFGe4CrJWlpigYDSRqyNVuDtJD9FbrudSLNudz5Xx/8Kyim/Wr2w==}
     peerDependencies:
       next: '>= 13.4'
@@ -6191,7 +6281,7 @@ packages:
       flexsearch: 0.7.21
       github-slugger: 2.0.0
       negotiator: 0.6.3
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.1-canary.0(patch_hash=jmj7qk37k7cq22c7437u6n6ism)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-remove-scroll: 2.5.7(@types/react@18.2.55)(react@18.2.0)
@@ -6209,14 +6299,14 @@ packages:
       - supports-color
     dev: false
 
-  /next-themes@0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0):
+  /next-themes@0.2.1(next@14.1.1-canary.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}
     peerDependencies:
       next: '*'
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 14.1.0(react-dom@18.2.0)(react@18.2.0)
+      next: 14.1.1-canary.0(patch_hash=jmj7qk37k7cq22c7437u6n6ism)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -6298,6 +6388,46 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
+
+  /next@14.1.1-canary.0(patch_hash=jmj7qk37k7cq22c7437u6n6ism)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pDNr1u6hG8Ny8bS40jO1QOQi5pMmcU2PWPKetVIbGA28BxHj1LXM0+DwmWkt0CFiYjE28Xef3bOwlM2IT8lNgw==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 14.1.1-canary.0
+      '@swc/helpers': 0.5.2
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001579
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.1.1-canary.0
+      '@next/swc-darwin-x64': 14.1.1-canary.0
+      '@next/swc-linux-arm64-gnu': 14.1.1-canary.0
+      '@next/swc-linux-arm64-musl': 14.1.1-canary.0
+      '@next/swc-linux-x64-gnu': 14.1.1-canary.0
+      '@next/swc-linux-x64-musl': 14.1.1-canary.0
+      '@next/swc-win32-arm64-msvc': 14.1.1-canary.0
+      '@next/swc-win32-ia32-msvc': 14.1.1-canary.0
+      '@next/swc-win32-x64-msvc': 14.1.1-canary.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+    patched: true
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}


### PR DESCRIPTION
Using `next@14.1.1-canary.0` as the base for the docs in order to patch it without breaking the e2e test playground.