### PR TITLE
fix: Equality check for non-primitives in clearOnDefault

### DIFF
--- a/packages/e2e/cypress/e2e/clearOnDefault.cy.js
+++ b/packages/e2e/cypress/e2e/clearOnDefault.cy.js
@@ -1,7 +1,9 @@
 /// <reference types="cypress" />
 
 it('Clears the URL when setting the default value when `clearOnDefault` is used', () => {
-  cy.visit('/app/clearOnDefault?a=a&b=b')
+  cy.visit(
+    '/app/clearOnDefault?a=a&b=b&array=1,2,3&json-ref={"egg":"spam"}&json-new={"egg":"spam"}'
+  )
   cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
   cy.get('button').click()
   cy.location('search').should('eq', '?a=')

--- a/packages/e2e/src/app/app/clearOnDefault/page.tsx
+++ b/packages/e2e/src/app/app/clearOnDefault/page.tsx
@@ -1,6 +1,11 @@
 'use client'
 
-import { useQueryState } from 'nuqs'
+import {
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsJson,
+  useQueryState
+} from 'nuqs'
 import { Suspense } from 'react'
 
 export default function Page() {
@@ -11,18 +16,37 @@ export default function Page() {
   )
 }
 
+const defaultJSON = { foo: 'bar' }
+
 function Client() {
   const [, setA] = useQueryState('a')
   const [, setB] = useQueryState('b', {
     defaultValue: '',
     clearOnDefault: true
   })
+  const [, setArray] = useQueryState(
+    'array',
+    parseAsArrayOf(parseAsInteger)
+      .withDefault([])
+      .withOptions({ clearOnDefault: true })
+  )
+  const [, setJsonRef] = useQueryState(
+    'json-ref',
+    parseAsJson().withDefault(defaultJSON).withOptions({ clearOnDefault: true })
+  )
+  const [, setJsonNew] = useQueryState(
+    'json-new',
+    parseAsJson().withDefault(defaultJSON).withOptions({ clearOnDefault: true })
+  )
   return (
     <>
       <button
         onClick={() => {
           setA('')
           setB('')
+          setArray([])
+          setJsonRef(defaultJSON)
+          setJsonNew({ ...defaultJSON })
         }}
       >
         Clear

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -91,7 +91,7 @@
     {
       "name": "Client (ESM)",
       "path": "dist/index.js",
-      "limit": "4 kB",
+      "limit": "5 kB",
       "ignore": [
         "react"
       ]

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -96,3 +96,14 @@ describe('parsers', () => {
     expect(p.parseServerSide(undefined)).toBe('bar')
   })
 })
+
+describe('parsers/equality', () => {
+  test('parseAsArrayOf', () => {
+    const eq = parseAsArrayOf(parseAsString).eq!
+    expect(eq([], [])).toBe(true)
+    expect(eq(['foo'], ['foo'])).toBe(true)
+    expect(eq(['foo', 'bar'], ['foo', 'bar'])).toBe(true)
+    expect(eq([], ['foo'])).toBe(false)
+    expect(eq(['foo'], ['bar'])).toBe(false)
+  })
+})

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -4,8 +4,28 @@ import { safeParse } from './utils'
 type Require<T, Keys extends keyof T> = Pick<Required<T>, Keys> & Omit<T, Keys>
 
 export type Parser<T> = {
+  /**
+   * Convert a query string value into a state value.
+   *
+   * If the string value does not represent a valid state value,
+   * the parser should return `null`. Throwing an error is also supported.
+   */
   parse: (value: string) => T | null
+
+  /**
+   * Render the state value into a query string value.
+   */
   serialize?: (value: T) => string
+
+  /**
+   * Check if two state values are equal.
+   *
+   * This is used when using the `clearOnDefault` value, to compare the default
+   * value with the set value.
+   *
+   * It makes sense to provide this function when the state value is an object
+   * or an array, as the default referential equality check will not work.
+   */
   eq?: (a: T, b: T) => boolean
 }
 

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -204,6 +204,7 @@ export function useQueryState<T = string>(
     throttleMs = FLUSH_RATE_LIMIT_MS,
     parse = x => x as unknown as T,
     serialize = String,
+    eq = (a, b) => a === b,
     defaultValue = undefined,
     clearOnDefault = false,
     startTransition
@@ -216,6 +217,7 @@ export function useQueryState<T = string>(
     throttleMs: FLUSH_RATE_LIMIT_MS,
     parse: x => x as unknown as T,
     serialize: String,
+    eq: (a, b) => a === b,
     clearOnDefault: false,
     defaultValue: undefined
   }
@@ -285,7 +287,9 @@ export function useQueryState<T = string>(
         : stateUpdater
       if (
         (options.clearOnDefault || clearOnDefault) &&
-        newValue === defaultValue
+        newValue !== null &&
+        defaultValue !== undefined &&
+        eq(newValue, defaultValue)
       ) {
         newValue = null
       }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -153,7 +153,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         }
         if (
           (options.clearOnDefault || clearOnDefault) &&
-          value === config.defaultValue
+          value !== null &&
+          config.defaultValue !== undefined &&
+          (config.eq ?? ((a, b) => a === b))(value, config.defaultValue)
         ) {
           value = null
         }


### PR DESCRIPTION
As reported by @Kavan72 in https://github.com/47ng/nuqs/discussions/462#discussioncomment-8554053

Testing only for referential equality is not enough for types like arrays and objects.

This introduces a new property of the parsers to specify an equality function to use when comparing against the default value.

- [x] Add jsdoc to the Parser type to reflect when to specify the `eq` property.