### PR TITLE
fix: Shallow equality check on cache parsing input

### DIFF
--- a/packages/e2e/cypress/e2e/cache.cy.js
+++ b/packages/e2e/cypress/e2e/cache.cy.js
@@ -2,7 +2,7 @@
 
 describe('cache', () => {
   it('works in app router', () => {
-    cy.visit('/app/cache?str=foo&num=42&bool=true')
+    cy.visit('/app/cache?str=foo&num=42&bool=true&multi=foo&multi=bar')
     cy.get('#parse-str').should('have.text', 'foo')
     cy.get('#parse-num').should('have.text', '42')
     cy.get('#parse-bool').should('have.text', 'true')

--- a/packages/nuqs/src/cache.test.ts
+++ b/packages/nuqs/src/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createSearchParamsCache, stringify } from './cache'
+import { compareSearchParams, createSearchParamsCache } from './cache'
 import { parseAsString } from './parsers'
 
 // provide a simple mock for React cache
@@ -61,15 +61,29 @@ describe('cache', () => {
     })
   })
 
-  describe('stringify', () => {
-    it('works on string values', () => {
-      expect(stringify({ foo: 'bar' })).toEqual('foo=bar')
+  describe('compareSearchParams', () => {
+    it('works on empty search params', () => {
+      expect(compareSearchParams({}, {})).toBe(true)
     })
-    it('works on array values', () => {
-      expect(stringify({ foo: ['bar', 'baz'] })).toEqual('foo=bar%2Cbaz')
+    it('rejects different lengths', () => {
+      expect(compareSearchParams({ a: 'a' }, { a: 'a', b: 'b' })).toBe(false)
     })
-    it('works on undefined values', () => {
-      expect(stringify({ foo: undefined })).toEqual('foo=undefined')
+    it('rejects different values', () => {
+      expect(compareSearchParams({ x: 'a' }, { x: 'b' })).toBe(false)
+    })
+    it('does not care about order', () => {
+      expect(compareSearchParams({ x: 'a', y: 'b' }, { y: 'b', x: 'a' })).toBe(
+        true
+      )
+    })
+    it('supports array values (referentially stable)', () => {
+      const array = ['a', 'b']
+      expect(compareSearchParams({ x: array }, { x: array })).toBe(true)
+    })
+    it('does not do deep comparison', () => {
+      expect(compareSearchParams({ x: ['a', 'b'] }, { x: ['a', 'b'] })).toBe(
+        false
+      )
     })
   })
 })

--- a/packages/nuqs/src/cache.test.ts
+++ b/packages/nuqs/src/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createSearchParamsCache } from './cache'
+import { createSearchParamsCache, stringify } from './cache'
 import { parseAsString } from './parsers'
 
 // provide a simple mock for React cache
@@ -22,7 +22,7 @@ describe('cache', () => {
       string: "I'm a string"
     }
 
-    it('allows parsing same object multiple times in a request', () => {
+    it('allows parsing the same object multiple times in a request', () => {
       const cache = createSearchParamsCache({
         string: parseAsString
       })
@@ -37,6 +37,15 @@ describe('cache', () => {
       expect(cache.all()).toBe(all)
     })
 
+    it('allows parsing the same content with different references', () => {
+      const cache = createSearchParamsCache({
+        string: parseAsString
+      })
+      const copy = { ...input }
+      expect(cache.parse(input).string).toBe(input.string)
+      expect(cache.parse(copy).string).toBe(input.string)
+    })
+
     it('disallows parsing different objects in a request', () => {
       const cache = createSearchParamsCache({
         string: parseAsString
@@ -49,6 +58,18 @@ describe('cache', () => {
 
       // cache still works though
       expect(cache.all()).toBe(all)
+    })
+  })
+
+  describe('stringify', () => {
+    it('works on string values', () => {
+      expect(stringify({ foo: 'bar' })).toEqual('foo=bar')
+    })
+    it('works on array values', () => {
+      expect(stringify({ foo: ['bar', 'baz'] })).toEqual('foo=bar%2Cbaz')
+    })
+    it('works on undefined values', () => {
+      expect(stringify({ foo: undefined })).toEqual('foo=undefined')
     })
   })
 })

--- a/packages/nuqs/src/index.server.ts
+++ b/packages/nuqs/src/index.server.ts
@@ -1,3 +1,3 @@
-export * from './cache'
+export { createSearchParamsCache, type SearchParams } from './cache'
 export * from './parsers'
 export { createSerializer } from './serializer'


### PR DESCRIPTION
A change introduced in Next.js 15.0.0-canary.41 (precisely vercel/next.js#67105) broke the referential stability that the cache.parse method was expecting to detect `parse` being called with the same search params.

Now we're using a shallow equality check, as the values seem to still be referentially stable.