### PR TITLE
fix: next/router causes issue with react compiler

### DIFF
--- a/packages/nuqs/src/update-queue.ts
+++ b/packages/nuqs/src/update-queue.ts
@@ -1,4 +1,3 @@
-import type { NextRouter } from 'next/router'
 import { debug } from './debug'
 import type { Options, Router } from './defs'
 import { error } from './errors'
@@ -123,7 +122,7 @@ declare global {
   interface Window {
     next?: {
       version: string
-      router?: NextRouter & {
+      router?: Router & {
         state: {
           asPath: string
         }
@@ -170,7 +169,7 @@ function flushUpdateQueue(router: Router): [URLSearchParams, null | unknown] {
       debug('[nuqs queue (pages)] Updating url: %s', url)
       const method =
         options.history === 'push' ? nextRouter.push : nextRouter.replace
-      method.call(nextRouter, url, url, {
+      method.call(nextRouter, url, {
         scroll: options.scroll,
         shallow: options.shallow
       })


### PR DESCRIPTION
I came across this issue as well when trying out the react compiler: https://github.com/47ng/nuqs/issues/566

What I tried to debug and fix:

1. Setup eslint in `packages/nuqs` and check for violations of the [rules of react](https://react.dev/reference/rules)
    I tried this because in theory, the react compiler should only result in a break if these rules are being violated, from what I understand of it so far. This however, did not seem to call out any issues that would result in the build errors. I'll open a second PR to show the addition of the lint setup, but the two changesets can be considered separately.

2. When running `next dev` locally I noticed the following errors upon request of a page:
<img width="1197" alt="image" src="https://github.com/47ng/nuqs/assets/26290074/0e10e6a8-5b4c-47bb-b23d-015695ccc227">
This led me to find the import to `next/router`. This was just an import for the type of the router, so it seems very safe to change over to `next/navigation` for support with the app router. FWIW I only tested the changes on a project with the app router, but I can't think of a way this would break anything unless the call to `method.call` broke somehow.

Happy to make changes/adjustments as necessary with this, but hopefully this just fixes the issue :)