### PR TITLE
fix: localStorage availability check update

### DIFF
--- a/packages/nuqs/src/debug.ts
+++ b/packages/nuqs/src/debug.ts
@@ -1,4 +1,4 @@
-import { isLocalStorageAvailable } from './utils';
+import { isLocalStorageAvailable } from './utils'
 
 // todo: Remove check for `next-usequerystate` in v2
 let enabled = false

--- a/packages/nuqs/src/debug.ts
+++ b/packages/nuqs/src/debug.ts
@@ -1,9 +1,11 @@
+import { isLocalStorageAvailable } from './utils';
+
 // todo: Remove check for `next-usequerystate` in v2
 let enabled = false
 
 try {
   enabled =
-    (typeof localStorage === 'object' &&
+    (isLocalStorageAvailable() &&
       (localStorage.getItem('debug')?.includes('next-usequerystate') ||
         localStorage.getItem('debug')?.includes('nuqs'))) ||
     false

--- a/packages/nuqs/src/utils.ts
+++ b/packages/nuqs/src/utils.ts
@@ -38,3 +38,22 @@ export function getDefaultThrottle() {
     return 320
   }
 }
+
+/**
+ * Check if localStorage is available
+ */
+export function isLocalStorageAvailable(){
+  try {
+    const test = 'test';
+
+    window.localStorage.setItem(test, test);
+
+    const isValueAvailable = window.localStorage.getItem(test) === test;
+
+    window.localStorage.removeItem(test);
+
+    return isValueAvailable;
+  } catch (_) {
+    return false;
+  }
+};

--- a/packages/nuqs/src/utils.ts
+++ b/packages/nuqs/src/utils.ts
@@ -44,14 +44,10 @@ export function getDefaultThrottle() {
  */
 export function isLocalStorageAvailable(){
   try {
-    const test = 'test';
-
+    const test = 'nuqs-localStorage-test';
     window.localStorage.setItem(test, test);
-
     const isValueAvailable = window.localStorage.getItem(test) === test;
-
     window.localStorage.removeItem(test);
-
     return isValueAvailable;
   } catch (_) {
     return false;

--- a/packages/nuqs/src/utils.ts
+++ b/packages/nuqs/src/utils.ts
@@ -40,16 +40,20 @@ export function getDefaultThrottle() {
 }
 
 /**
- * Check if localStorage is available
+ * Check if localStorage is available.
+ *
+ * It may be unavailable in some environments, like Safari in private browsing
+ * mode.
+ * See https://github.com/47ng/nuqs/pull/588
  */
-export function isLocalStorageAvailable(){
+export function isLocalStorageAvailable() {
   try {
-    const test = 'nuqs-localStorage-test';
-    window.localStorage.setItem(test, test);
-    const isValueAvailable = window.localStorage.getItem(test) === test;
-    window.localStorage.removeItem(test);
-    return isValueAvailable;
+    const test = 'nuqs-localStorage-test'
+    window.localStorage.setItem(test, test)
+    const isValueAvailable = window.localStorage.getItem(test) === test
+    window.localStorage.removeItem(test)
+    return isValueAvailable
   } catch (_) {
-    return false;
+    return false
   }
-};
+}


### PR DESCRIPTION
When in Safari set Block All cookies then local storage also will not work. But window.localStorage object itself will be available and when we will try set or get something from local storage we will get `SecurityError: The operation is insecure.` error and it is crashing the application for users with disabled cookies and local storage.