### PR TITLE
fix: Serialization of default values in `createSerializer`

### DIFF
--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import { parseAsBoolean, parseAsInteger, parseAsString } from './parsers'
+import {
+  parseAsBoolean,
+  parseAsInteger,
+  parseAsString,
+  parseAsJson,
+  parseAsArrayOf
+} from './parsers'
 import { createSerializer } from './serializer'
 
 const parsers = {
@@ -61,5 +67,28 @@ describe('serializer', () => {
     const serialize = createSerializer(parsers)
     const result = serialize('?str=bar&int=-1', { str: 'foo', int: null })
     expect(result).toBe('?str=foo')
+  })
+  test('clears value when setting the default value when `clearOnDefault` is used', () => {
+    const serialize = createSerializer({
+      int: parseAsInteger.withOptions({ clearOnDefault: true }).withDefault(0),
+      str: parseAsString.withOptions({ clearOnDefault: true }).withDefault(''),
+      bool: parseAsBoolean
+        .withOptions({ clearOnDefault: true })
+        .withDefault(false),
+      arr: parseAsArrayOf(parseAsString)
+        .withOptions({ clearOnDefault: true })
+        .withDefault([]),
+      json: parseAsJson()
+        .withOptions({ clearOnDefault: true })
+        .withDefault({ foo: 'bar' })
+    })
+    const result = serialize({
+      int: 0,
+      str: '',
+      bool: false,
+      arr: [],
+      json: { foo: 'bar' }
+    })
+    expect(result).toBe('')
   })
 })

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import {
+  parseAsArrayOf,
   parseAsBoolean,
   parseAsInteger,
-  parseAsString,
   parseAsJson,
-  parseAsArrayOf
+  parseAsString
 } from './parsers'
 import { createSerializer } from './serializer'
 

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -10,9 +10,10 @@ type Base = string | URLSearchParams | URL
 type Values<Parsers extends Record<string, ParserBuilder<any>>> = Partial<{
   [K in keyof Parsers]?: ExtractParserType<Parsers[K]>
 }>
+type ParserWithOptionalDefault<T> = ParserBuilder<T> & { defaultValue?: T }
 
 export function createSerializer<
-  Parsers extends Record<string, ParserBuilder<any>>
+  Parsers extends Record<string, ParserWithOptionalDefault<any>>
 >(parsers: Parsers) {
   /**
    * Generate a query string for the given values.
@@ -42,9 +43,7 @@ export function createSerializer<
         continue
       }
       const isMatchingDefault =
-        // @ts-expect-error
         parser.defaultValue !== undefined &&
-        // @ts-expect-error
         (parser.eq ?? ((a, b) => a === b))(value, parser.defaultValue)
 
       if (value === null || (parser.clearOnDefault && isMatchingDefault)) {

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -41,7 +41,13 @@ export function createSerializer<
       if (!parser || value === undefined) {
         continue
       }
-      if (value === null) {
+      const isMatchingDefault =
+        // @ts-expect-error
+        parser.defaultValue !== undefined &&
+        // @ts-expect-error
+        (parser.eq ?? ((a, b) => a === b))(value, parser.defaultValue)
+
+      if (value === null || (parser.clearOnDefault && isMatchingDefault)) {
         search.delete(key)
       } else {
         search.set(key, parser.serialize(value))


### PR DESCRIPTION
When using parsers in `createSerializer` it would not respect the `clearOnDefault` option properly when serializing, thus adding key-value pairs to the string that shouldn't be there.

An example:
```ts
const serialize = createSerializer({
    int: parseAsInteger.withOptions({ clearOnDefault: true }).withDefault(0)
})
const result = serialize({ int: 0 })
//    ^ Result is `?int=0` instead of empty string
```

Closes https://github.com/47ng/nuqs/issues/641.