### PR TITLE
fix(serializer): Allow serializers to operate on derived `UrlSearchParams` classes

### DIFF
--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -51,6 +51,14 @@ describe('serializer', () => {
     const result = serialize(search, { str: 'foo' })
     expect(result).toBe('?bar=egg&str=foo')
   })
+  test('Does not mutate existing params with URLSearchParams base', () => {
+    const serialize = createSerializer(parsers)
+    const searchBefore = new URLSearchParams('?str=foo')
+    expect(searchBefore.get("str")).toBe("foo")
+    const result = serialize(searchBefore, { str: 'bar' })
+    expect(result).toBe('?str=bar')
+    expect(searchBefore.get("str")).toBe("foo")
+  })
   test('with URL base', () => {
     const serialize = createSerializer(parsers)
     const url = new URL('https://example.com/path')

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -54,10 +54,9 @@ describe('serializer', () => {
   test('Does not mutate existing params with URLSearchParams base', () => {
     const serialize = createSerializer(parsers)
     const searchBefore = new URLSearchParams('?str=foo')
-    expect(searchBefore.get("str")).toBe("foo")
     const result = serialize(searchBefore, { str: 'bar' })
     expect(result).toBe('?str=bar')
-    expect(searchBefore.get("str")).toBe("foo")
+    expect(searchBefore.get('str')).toBe('foo')
   })
   test('with URL base', () => {
     const serialize = createSerializer(parsers)

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -72,6 +72,9 @@ function splitBase(base: Base) {
   } else if (base instanceof URLSearchParams) {
     return ['', new URLSearchParams(base)] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
   } else {
-    return [base.origin + base.pathname, new URLSearchParams(base.searchParams)] as const
+    return [
+      base.origin + base.pathname,
+      new URLSearchParams(base.searchParams)
+    ] as const
   }
 }

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -70,7 +70,7 @@ function splitBase(base: Base) {
     const [path = '', search] = base.split('?')
     return [path, new URLSearchParams(search)] as const
   } else if (base instanceof URLSearchParams) {
-    return ['', base] as const
+    return ['', new URLSearchParams(base)] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
   } else {
     return [base.origin + base.pathname, base.searchParams] as const
   }

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -72,6 +72,6 @@ function splitBase(base: Base) {
   } else if (base instanceof URLSearchParams) {
     return ['', new URLSearchParams(base)] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
   } else {
-    return [base.origin + base.pathname, base.searchParams] as const
+    return [base.origin + base.pathname, new URLSearchParams(base.searchParams)] as const
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/47ng/nuqs/discussions/646, that allows us to use the response from Next's `useSearchParams`, for example, as the `base` argument to a `serializer`. To do this we create a copy of `UrlSearchParams` in this code branch.