### PR TITLE
fix: Handle Promises for the searchParams page prop

### DIFF
--- a/packages/e2e/src/app/app/cache/page.tsx
+++ b/packages/e2e/src/app/app/cache/page.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from 'nuqs/server'
 import { Suspense } from 'react'
 import { All } from './all'
 import { Get } from './get'
@@ -5,11 +6,11 @@ import { cache } from './searchParams'
 import { Set } from './set'
 
 type Props = {
-  searchParams: Record<string, string | string[] | undefined>
+  searchParams: Promise<SearchParams>
 }
 
-export default function Page({ searchParams }: Props) {
-  const { str, bool, num, def, nope } = cache.parse(searchParams)
+export default async function Page({ searchParams }: Props) {
+  const { str, bool, num, def, nope } = await cache.parse(searchParams)
   return (
     <>
       <h1>Root page</h1>
@@ -30,9 +31,9 @@ export default function Page({ searchParams }: Props) {
   )
 }
 
-export function generateMetadata({ searchParams }: Props) {
+export async function generateMetadata({ searchParams }: Props) {
   // parse here too to ensure we can idempotently parse the same search params as the page in the same request
-  const { str } = cache.parse(searchParams)
+  const { str } = await cache.parse(searchParams)
   return {
     title: `metadata-title-str:${str}`
   }

--- a/packages/e2e/src/app/app/push/page.tsx
+++ b/packages/e2e/src/app/app/push/page.tsx
@@ -1,12 +1,13 @@
+import type { SearchParams } from 'nuqs/server'
 import { Client } from './client'
-import { parser } from './searchParams'
+import { searchParamsCache } from './searchParams'
 
-export default function Page({
+export default async function Page({
   searchParams
 }: {
-  searchParams: Record<string, string | string[] | undefined>
+  searchParams: Promise<SearchParams>
 }) {
-  const server = parser.parseServerSide(searchParams.server)
+  const { server } = await searchParamsCache.parse(searchParams)
   return (
     <>
       <p>

--- a/packages/e2e/src/app/app/push/searchParams.ts
+++ b/packages/e2e/src/app/app/push/searchParams.ts
@@ -1,5 +1,8 @@
-import { parseAsInteger } from 'nuqs'
+import { createSearchParamsCache, parseAsInteger } from 'nuqs/server'
 
 export const parser = parseAsInteger.withDefault(0).withOptions({
   history: 'push'
+})
+export const searchParamsCache = createSearchParamsCache({
+  server: parser
 })

--- a/packages/e2e/src/app/app/rewrites/destination/page.tsx
+++ b/packages/e2e/src/app/app/rewrites/destination/page.tsx
@@ -3,12 +3,12 @@ import { Suspense } from 'react'
 import { RewriteDestinationClient } from './client'
 import { cache } from './searchParams'
 
-export default function RewriteDestinationPage({
+export default async function RewriteDestinationPage({
   searchParams
 }: {
-  searchParams: SearchParams
+  searchParams: Promise<SearchParams>
 }) {
-  const { injected, through } = cache.parse(searchParams)
+  const { injected, through } = await cache.parse(searchParams)
   return (
     <>
       <p>

--- a/packages/e2e/src/app/app/transitions/page.tsx
+++ b/packages/e2e/src/app/app/transitions/page.tsx
@@ -1,9 +1,10 @@
 import { setTimeout } from 'node:timers/promises'
+import type { SearchParams } from 'nuqs/server'
 import { Suspense } from 'react'
 import { Client } from './client'
 
 type PageProps = {
-  searchParams: Record<string, string | string[] | undefined>
+  searchParams: Promise<SearchParams>
 }
 
 export default async function Page({ searchParams }: PageProps) {
@@ -11,7 +12,7 @@ export default async function Page({ searchParams }: PageProps) {
   return (
     <>
       <h1>Transitions</h1>
-      <pre id="server-rendered">{JSON.stringify(searchParams)}</pre>
+      <pre id="server-rendered">{JSON.stringify(await searchParams)}</pre>
       <Suspense>
         <Client />
       </Suspense>

--- a/packages/nuqs/src/tests/cache.test-d.ts
+++ b/packages/nuqs/src/tests/cache.test-d.ts
@@ -29,4 +29,8 @@ import {
   type All = Readonly<{ foo: string | null; bar: number | null; egg: boolean }>
   expectType<All>(cache.parse({}))
   expectType<All>(cache.all())
+
+  // It supports async search params (Next.js 15+)
+  expectType<Promise<All>>(cache.parse(Promise.resolve({})))
+  expectType<All>(cache.all())
 }


### PR DESCRIPTION
Next.js 15.0.0-canary-171 introduced a breaking change in https://github.com/vercel/next.js/pull/68812 causing the searchParam page prop to be a Promise.

Using overloads, the cache.parse function can now handle either, but typing the searchParams page prop in userland is becoming painful if support for both Next.js 14 and 15 is desired.

Best approach is to always declare it as a Promise<SearchParams> (with `SearchParams` imported from 'nuqs/server'), as it highlights the need to await the result of the parser, and doesn't cause runtime issues if the underlyign type is a plain object (the await becomes a no-op).