### PR TITLE
Fix: Run pkg.pr.new only if there are changes

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,10 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - name: Check for changes to nuqs package
+        id: check-for-changes
         run: |
           if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
             echo "No changes to nuqs package, skipping preview deployment."
-            exit 0
+            echo "skip=true" >> $GITHUB_OUTPUT
           fi
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check for changes to nuqs package
         id: check-for-changes
         run: |
-          if git diff --quiet ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ./packages/nuqs; then
+          if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
             echo "No changes to nuqs package, skipping preview deployment."
             echo "skip=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Check for changes to nuqs package
+        run: |
+          if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
+            echo "No changes to nuqs package, skipping preview deployment."
+            exit 0
+          fi
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check for changes to nuqs package
         id: check-for-changes
         run: |
-          if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
+          if git diff --quiet ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ./packages/nuqs; then
             echo "No changes to nuqs package, skipping preview deployment."
             echo "skip=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          fetch-depth: 2
       - name: Check for changes to nuqs package
         id: check-for-changes
         run: |

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -32,5 +32,5 @@ jobs:
         run: pnpm pkg set version=0.0.0-preview.${{ github.event.pull_request.head.sha }}
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
-      - if: steps.check-for-changes.outputs.skip != 'true'
+        if: steps.check-for-changes.outputs.skip != 'true'
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -33,5 +33,4 @@ jobs:
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
       - if: steps.check-for-changes.outputs.skip != 'true'
-        
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -32,4 +32,5 @@ jobs:
         run: pnpm pkg set version=0.0.0-preview.${{ github.event.pull_request.head.sha }}
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
+      - if: steps.check-for-changes.outputs.skip != 'true'
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -33,4 +33,5 @@ jobs:
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
       - if: steps.check-for-changes.outputs.skip != 'true'
+        
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'


### PR DESCRIPTION
Added a conditional check in pkg.pr.new.yml to prevent unnecessary runs when no changes are detected in the nuqs package.

Closes #655.