### PR TITLE
feat(serializer): allow `null` to clear all param values from base

### DIFF
--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -70,10 +70,15 @@ describe('serializer', () => {
     const result = serialize(url, { str: 'foo' })
     expect(result).toBe('https://example.com/path?bar=egg&str=foo')
   })
-  test('null deletes from base', () => {
+  test('null value deletes from base', () => {
     const serialize = createSerializer(parsers)
     const result = serialize('?str=bar&int=-1', { str: 'foo', int: null })
     expect(result).toBe('?str=foo')
+  })
+  test('null deletes all from base', () => {
+    const serialize = createSerializer(parsers)
+    const result = serialize('?str=bar&int=-1', null)
+    expect(result).toBe('')
   })
   test('clears value when setting the default value when `clearOnDefault` is used', () => {
     const serialize = createSerializer({

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -80,11 +80,11 @@ describe('serializer', () => {
     const result = serialize('?str=bar&int=-1', null)
     expect(result).toBe('')
   })
-  test('null keeps search params not managed by the serializer', () => {  
-    const serialize = createSerializer(parsers)  
-    const result = serialize('?str=foo&external=kept', null)  
-    expect(result).toBe('?external=kept')  
-  })  
+  test('null keeps search params not managed by the serializer', () => {
+    const serialize = createSerializer(parsers)
+    const result = serialize('?str=foo&external=kept', null)
+    expect(result).toBe('?external=kept')
+  })
   test('clears value when setting the default value when `clearOnDefault` is used', () => {
     const serialize = createSerializer({
       int: parseAsInteger.withOptions({ clearOnDefault: true }).withDefault(0),

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -80,6 +80,11 @@ describe('serializer', () => {
     const result = serialize('?str=bar&int=-1', null)
     expect(result).toBe('')
   })
+  test('null keeps search params not managed by the serializer', () => {  
+    const serialize = createSerializer(parsers)  
+    const result = serialize('?str=foo&external=kept', null)  
+    expect(result).toBe('?external=kept')  
+  })  
   test('clears value when setting the default value when `clearOnDefault` is used', () => {
     const serialize = createSerializer({
       int: parseAsInteger.withOptions({ clearOnDefault: true }).withDefault(0),

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -27,15 +27,21 @@ export function createSerializer<
    * - another value is given for an existing key, in which case the
    *  search param will be updated
    */
-  function serialize(base: Base, values: Values<Parsers>): string
+  function serialize(base: Base, values: Values<Parsers> | null): string
   function serialize(
-    baseOrValues: Base | Values<Parsers>,
-    values: Values<Parsers> = {}
+    baseOrValues: Base | Values<Parsers> | null,
+    values: Values<Parsers> | null = {}
   ) {
     const [base, search] = isBase(baseOrValues)
       ? splitBase(baseOrValues)
       : ['', new URLSearchParams()]
     const vals = isBase(baseOrValues) ? values : baseOrValues
+    if (vals === null) {
+      for (const key in parsers) {
+        search.delete(key)
+      }
+      return base + renderQueryString(search)
+    }
     for (const key in parsers) {
       const parser = parsers[key]
       const value = vals[key]


### PR DESCRIPTION
Follow-up to https://github.com/47ng/nuqs/discussions/653, this PR allows callers to pass `null` to a serializer instance to clear any search params from `base`.