### PR TITLE
Refactor: Split pkg.pr.new into distinct check and deploy jobs

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,7 +1,7 @@
 name: PR Preview
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
   pull_request_review:
     types: [submitted]
 
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event.review.state == 'APPROVED' ||
       contains(github.event.pull_request.author_association, 'MEMBER') ||
-      github.event.pull_request.labels.*.name == 'deploy:preview'
+      contains(github.event.pull_request.labels.*.name, 'deploy:preview')
     runs-on: ubuntu-latest
     outputs:
       enable: ${{ steps.check-for-changes.outputs.enable }}

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -6,33 +6,50 @@ on:
     types: [submitted]
 
 jobs:
-  deploy-preview:
-    name: Deploy to pkg.pr.new
-    if: github.event.review.state == 'APPROVED' || contains(github.event.pull_request.author_association, 'MEMBER')
+  check-changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           fetch-depth: 2
+
       - name: Check for changes to nuqs package
         id: check-for-changes
         run: |
           if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
-            echo "No changes to nuqs package, skipping preview deployment."
+            echo "No changes to nuqs package, skipping build."
             echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected."
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
+
+  deploy-preview:
+    needs: check-changes  # This job depends on the check-changes job
+    runs-on: ubuntu-latest
+    if: needs.check-changes.outputs.skip != 'true'  # Only run if changes were detected
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          fetch-depth: 2
+
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+      
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
           node-version-file: .node-version
           cache: pnpm
+
       - name: Install dependencies
         run: pnpm install
+        
       - name: Build package
         run: pnpm build --filter nuqs
+        
       - name: Set package version
         run: pnpm pkg set version=0.0.0-preview.${{ github.event.pull_request.head.sha }}
         working-directory: packages/nuqs
+
       - name: Publish to pkg.pr.new
-        if: steps.check-for-changes.outputs.skip != 'true'
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'
+        

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   check-changes:
     name: Check for relevant changes to deploy
-    if: github.event.review.state == 'APPROVED' || contains(github.event.pull_request.author_association, 'MEMBER')
+    if: |
+      github.event.review.state == 'APPROVED' ||
+      contains(github.event.pull_request.author_association, 'MEMBER') ||
+      contains(github.event.pull_request.labels, 'deploy:preview')
     runs-on: ubuntu-latest
     outputs:
       enable: ${{ steps.check-for-changes.outputs.enable }}

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -24,6 +24,7 @@ jobs:
             echo "enable=false" >> $GITHUB_OUTPUT
           else
             echo "enable=true" >> $GITHUB_OUTPUT
+          fi
 
   deploy-preview:
     name: Deploy to pkg.pr.new

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -23,11 +23,12 @@ jobs:
             echo "Changes detected."
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
+          echo "Current skip status: ${{ steps.check-for-changes.outputs.skip }}"  # Debug statement
 
   deploy-preview:
-    needs: check-changes  # This job depends on the check-changes job
+    needs: check-changes
     runs-on: ubuntu-latest
-    if: needs.check-changes.outputs.skip != 'true'  # Only run if changes were detected
+    if: needs.check-changes.outputs.skip != 'true'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -48,4 +49,3 @@ jobs:
 
       - name: Publish to pkg.pr.new
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'
-        

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -45,10 +45,6 @@ jobs:
         
       - name: Build package
         run: pnpm build --filter nuqs
-        
-      - name: Set package version
-        run: pnpm pkg set version=0.0.0-preview.${{ github.event.pull_request.head.sha }}
-        working-directory: packages/nuqs
 
       - name: Publish to pkg.pr.new
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -38,7 +38,7 @@ jobs:
       
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          node-version-file: .node-version
+          # node-version-file: .node-version
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -7,19 +7,20 @@ on:
 
 jobs:
   check-changes:
+    name: Check for relevant changes to deploy
+    if: github.event.review.state == 'APPROVED' || contains(github.event.pull_request.author_association, 'MEMBER')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           fetch-depth: 2
 
-      - name: Check for PR Approval
+      - name: Check for relevant changes
         run: |
-          if [[ "${{ github.event.review.state }}" != "APPROVED" && ! "$(echo "${{ github.event.pull_request.author_association }}" | grep 'MEMBER')" ]]; then
-            echo "Deployment not allowed."
+          if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
+            echo "No changes to nuqs package, skipping preview deployment."
             echo "enable=false" >> $GITHUB_OUTPUT
           else
-            echo "Deployment allowed."
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
 
@@ -29,21 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          fetch-depth: 2
-
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
-      
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
           node-version-file: .node-version
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install
-        
       - name: Build package
         run: pnpm build --filter nuqs
-
+      - name: Set package version
+        run: pnpm pkg set version=0.0.0-preview.${{ github.event.pull_request.head.sha }}
+        working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
         run: pnpx pkg-pr-new publish --compact './packages/nuqs'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -13,20 +13,18 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check for changes to nuqs package
-        id: check-for-changes
+      - name: Check for PR Approval
         run: |
-          if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
-            echo "No changes to nuqs package, skipping build."
+          if [[ "${{ github.event.review.state }}" != "APPROVED" && ! "$(echo "${{ github.event.pull_request.author_association }}" | grep 'MEMBER')" ]]; then
+            echo "Deployment not allowed."
             echo "enable=false" >> $GITHUB_OUTPUT
           else
-            echo "Changes detected."
+            echo "Deployment allowed."
             echo "enable=true" >> $GITHUB_OUTPUT
           fi
-          echo "Current enable status: ${{ steps.check-for-changes.outputs.enable }}"  # Debug statement
 
   deploy-preview:
-    needs: check-changes
+    name: Deploy to pkg.pr.new
     if: needs.check-changes.outputs.enable == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event.review.state == 'APPROVED' ||
       contains(github.event.pull_request.author_association, 'MEMBER') ||
-      contains(github.event.pull_request.labels, 'deploy:preview')
+      github.event.pull_request.labels.*.name == 'deploy:preview'
     runs-on: ubuntu-latest
     outputs:
       enable: ${{ steps.check-for-changes.outputs.enable }}

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -10,24 +10,25 @@ jobs:
     name: Check for relevant changes to deploy
     if: github.event.review.state == 'APPROVED' || contains(github.event.pull_request.author_association, 'MEMBER')
     runs-on: ubuntu-latest
+    outputs:
+      enable: ${{ steps.check-for-changes.outputs.enable }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           fetch-depth: 2
-
       - name: Check for relevant changes
+        id: check-for-changes
         run: |
           if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
             echo "No changes to nuqs package, skipping preview deployment."
             echo "enable=false" >> $GITHUB_OUTPUT
           else
             echo "enable=true" >> $GITHUB_OUTPUT
-          fi
 
   deploy-preview:
     name: Deploy to pkg.pr.new
-    if: needs.check-changes.outputs.enable == 'true'
     needs: check-changes
+    if: needs.check-changes.outputs.enable == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -27,6 +27,7 @@ jobs:
   deploy-preview:
     name: Deploy to pkg.pr.new
     if: needs.check-changes.outputs.enable == 'true'
+    needs: check-changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -18,17 +18,17 @@ jobs:
         run: |
           if git diff --quiet HEAD^ HEAD ./packages/nuqs; then
             echo "No changes to nuqs package, skipping build."
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "enable=false" >> $GITHUB_OUTPUT
           else
             echo "Changes detected."
-            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "enable=true" >> $GITHUB_OUTPUT
           fi
-          echo "Current skip status: ${{ steps.check-for-changes.outputs.skip }}"  # Debug statement
+          echo "Current enable status: ${{ steps.check-for-changes.outputs.enable }}"  # Debug statement
 
   deploy-preview:
     needs: check-changes
+    if: needs.check-changes.outputs.enable == 'true'
     runs-on: ubuntu-latest
-    if: needs.check-changes.outputs.skip != 'true'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -38,7 +38,7 @@ jobs:
       
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          # node-version-file: .node-version
+          node-version-file: .node-version
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
### Overview

This pull request refactors the CI workflow by splitting the process into two jobs: one for detecting changes in the nuqs package and another for deployment. The deployment now only runs when changes are detected, optimizing the CI pipeline and preventing unnecessary builds. Workflow logic was improved based on feedback to ensure proper communication between jobs.

### Changes Made

- Added an ID to the step responsible for detecting changes in the `check-changes` job, allowing us to map the step output (`enable` flag) to a job-level output.
- Declared and passed the `enable` output at the job level for the `check-changes` job, ensuring proper communication between jobs.
- Updated the `deploy-preview` job to depend on the output of the `check-changes` job using the needs keyword. The deployment job now only runs when changes are detected, based on the `enable` flag.
- Simplified the conditional `if` clause in the `deploy-preview` job to use the job-level output (`enable`).

### Benefits

- Reduces unnecessary builds when no changes are detected, improving CI efficiency.
- Ensures a clear, logical flow between the `check-changes` and `deploy-preview` jobs, improving maintainability.
- Optimizes performance by focusing deployment efforts only when relevant changes occur.