### PR TITLE
fix: Update query state key from 'hello' to 'name' in BasicUsageDemo

### DIFF
--- a/packages/docs/content/docs/demos.tsx
+++ b/packages/docs/content/docs/demos.tsx
@@ -48,7 +48,7 @@ function DemoContainer({ children, className, ...props }: DemoContainerProps) {
 }
 
 export function BasicUsageDemo() {
-  const [value, setValue] = useQueryState('hello', { defaultValue: '' })
+  const [value, setValue] = useQueryState('name', { defaultValue: '' })
   return (
     <DemoContainer className="flex-col items-stretch">
       <input


### PR DESCRIPTION
This PR fixes a small issue in the BasicUsageDemo where the query state key was incorrectly set to 'hello'. The correct key should be 'name', as it more accurately represents the state being queried.

By making this adjustment, the code becomes clearer and aligns better with the expected functionality. I have tested the changes locally to ensure the demo behaves as intended with the updated key.