### PR TITLE
feat: Allow remapping keys in useQueryStates

### DIFF
--- a/packages/docs/content/docs/batching.mdx
+++ b/packages/docs/content/docs/batching.mdx
@@ -111,3 +111,36 @@ This will clear `lat` & `lng`, and leave other search params untouched.
 
 </Callout>
 
+### Shorter search params keys
+
+One issue with tying the parsers object keys to the search params keys was that
+you had to trade-off between variable names that make sense for your domain
+or business logic, and short, URL-friendly keys.
+
+In `nuqs@1.20.0` and later, you can use a `urlKeys` object in the hook options
+to remap the variable names to shorter keys:
+
+```ts
+const [{ latitude, longitude }, setCoordinates] = useQueryStates(
+  {
+    // Use variable names that make sense in your codebase
+    latitude: parseAsFloat.withDefault(45.18),
+    longitude: parseAsFloat.withDefault(5.72)
+  },
+  {
+    urlKeys: {
+      // And remap them to shorter keys in the URL
+      latitude: 'lat',
+      longitude: 'lng'
+    }
+  }
+)
+
+// No changes in the setter API, but the keys are remapped to:
+// ?lat=45.18&lng=5.72
+setCoordinates({
+  latitude: 45.18,
+  longitude: 5.72
+})
+```
+

--- a/packages/e2e/cypress/e2e/remapped-keys.cy.js
+++ b/packages/e2e/cypress/e2e/remapped-keys.cy.js
@@ -1,0 +1,11 @@
+/// <reference types="cypress" />
+
+it('Remapped keys', () => {
+  cy.visit('/app/remapped-keys')
+  cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+  cy.get('#search').type('a')
+  cy.get('#page').clear().type('42')
+  cy.get('#react').check()
+  cy.get('#nextjs').check()
+  cy.location('search').should('eq', '?q=a&page=42&tags=react,next.js')
+})

--- a/packages/e2e/src/app/app/remapped-keys/page.tsx
+++ b/packages/e2e/src/app/app/remapped-keys/page.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import {
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsString,
+  useQueryStates
+} from 'nuqs'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Client />
+    </Suspense>
+  )
+}
+
+function Client() {
+  const [{ searchQuery, pageNumber, activeTags }, setURLState] = useQueryStates(
+    {
+      searchQuery: parseAsString.withDefault(''),
+      pageNumber: parseAsInteger.withDefault(1),
+      activeTags: parseAsArrayOf(parseAsString).withDefault([])
+    },
+    {
+      clearOnDefault: true,
+      urlKeys: {
+        searchQuery: 'q',
+        pageNumber: 'page',
+        activeTags: 'tags'
+      }
+    }
+  )
+
+  return (
+    <>
+      <label style={{ display: 'block' }}>
+        <input
+          id="search"
+          value={searchQuery}
+          onChange={e => setURLState({ searchQuery: e.target.value })}
+        />
+        <span>Search</span>
+      </label>
+      <label style={{ display: 'block' }}>
+        <input
+          id="page"
+          type="number"
+          min={1}
+          max={5}
+          step={1}
+          value={pageNumber}
+          onChange={e => setURLState({ pageNumber: e.target.valueAsNumber })}
+        />
+        <span>Page</span>
+      </label>
+      <label style={{ display: 'block' }}>
+        <label>
+          <input
+            id="react"
+            type="checkbox"
+            checked={activeTags.includes('react')}
+            onChange={e =>
+              setURLState(old => ({
+                activeTags: e.target.checked
+                  ? [...old.activeTags, 'react']
+                  : old.activeTags.filter(tag => !tag.includes('react'))
+              }))
+            }
+          />
+          React SPA
+        </label>
+        <label>
+          <input
+            id="nextjs"
+            type="checkbox"
+            checked={activeTags.includes('next.js')}
+            onChange={e =>
+              setURLState(old => ({
+                activeTags: e.target.checked
+                  ? [...old.activeTags, 'next.js']
+                  : old.activeTags.filter(tag => !tag.includes('next.js'))
+              }))
+            }
+          />
+          Next.js
+        </label>
+      </label>
+    </>
+  )
+}

--- a/packages/nuqs/src/tests/useQueryStates.test-d.ts
+++ b/packages/nuqs/src/tests/useQueryStates.test-d.ts
@@ -1,4 +1,4 @@
-import { expectNotAssignable, expectType } from 'tsd'
+import { expectError, expectNotAssignable, expectType } from 'tsd'
 import {
   parseAsBoolean,
   parseAsFloat,
@@ -76,4 +76,45 @@ import {
     hex: number | null
     bin: Buffer
   }>(states)
+}
+
+// Remapped keys
+{
+  const [states, setStates] = useQueryStates(
+    {
+      foo: parseAsString,
+      bar: parseAsString
+    },
+    {
+      urlKeys: {
+        foo: 'f'
+        // bar: 'b' // allows partial remapping
+      }
+    }
+  )
+  expectType<{
+    foo: string | null
+    bar: string | null
+  }>(states)
+  setStates({
+    foo: 'baz',
+    bar: 'qux'
+  })
+}
+
+// Remapped keys
+{
+  expectError(() => {
+    useQueryStates(
+      {
+        foo: parseAsString,
+        bar: parseAsString
+      },
+      {
+        urlKeys: {
+          notInTheList: 'f'
+        }
+      }
+    )
+  })
 }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -49,6 +49,11 @@ export type UseQueryStatesReturn<T extends UseQueryStatesKeysMap> = [
   SetValues<T>
 ]
 
+// Ensure referential consistency for the default value of urlKeys
+// by hoisting it out of the function scope.
+// Otherwise useEffect loops go brrrr
+const defaultUrlKeys = {}
+
 /**
  * Synchronise multiple query string arguments to React state in Next.js
  *
@@ -66,7 +71,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     throttleMs = FLUSH_RATE_LIMIT_MS,
     clearOnDefault = false,
     startTransition,
-    urlKeys = {}
+    urlKeys = defaultUrlKeys
   }: Partial<
     UseQueryStatesOptions & {
       // todo: Move into UseQueryStatesOptions in v2 (requires a breaking change
@@ -110,7 +115,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     )
     setInternalState(state)
   }, [
-    Object.keys(keyMap)
+    Object.keys(urlKeys)
       .map(key => initialSearchParams?.get(key))
       .join('&'),
     stateKeys,


### PR DESCRIPTION
While it was possible to do it via speading & remapping variable names in userland, this makes it more declarative and should help decouple business/domain logic in variable names vs short URL search param keys.

## Tasks

- [x] Add docs