### PR TITLE
chore: Install Next.js versions to both e2e & nuqs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,7 +55,7 @@ jobs:
         run: pnpm install
       - name: Install Next.js version ${{ matrix.next-version }}
         if: ${{ matrix.next-version != 'local' }}
-        run: pnpm add --filter e2e next@${{ matrix.next-version }}
+        run: pnpm add --filter e2e --filter nuqs next@${{ matrix.next-version }}
       - name: Run integration tests
         run: pnpm run test ${{ github.ref_name == 'ci' && '--force' || '' }}
         env:

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Install Next.js version ${{ inputs.version }}
-        run: pnpm add --filter e2e next@${{ inputs.version }}
+        run: pnpm add --filter e2e --filter nuqs next@${{ inputs.version }}
       - name: Run integration tests
         run: pnpm run test
         env:


### PR DESCRIPTION
This solves some incompatibilities when running tests related to the React version embedded by Next and exported by nuqs.

Symptom was that all pages in the pages router crashed on mount.

Supersedes #677, which attempted to use the catalogs feature of pnpm to keep things in sync, but isn't practical to inject custom versions in a CI context.