### PR TITLE
fix: Add back the .js extension to the pages router adapter

### DIFF
--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation.js'
 import type { NextRouter } from 'next/router'
 import { useCallback } from 'react'
 import { debug } from '../../debug'


### PR DESCRIPTION
Possible regression of #368.

Closes #693.