### PR TITLE
fix: Mark framework packages as optional peer dependencies

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -99,16 +99,25 @@
     "test:size": "size-limit",
     "prepack": "./scripts/prepack.sh"
   },
-  "peerDependencies": {
-    "react": ">= 18.2.0"
-  },
   "dependencies": {
     "mitt": "^3.0.1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
+    "react": ">= 18.2.0",
     "@remix-run/react": ">= 2",
     "next": ">= 14.2.0",
     "react-router-dom": ">= 6"
+  },
+  "peerDependenciesMeta": {
+    "@remix-run/react": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    },
+    "react-router-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.47.9",

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -103,9 +103,9 @@
     "mitt": "^3.0.1"
   },
   "peerDependencies": {
-    "react": ">= 18.2.0",
     "@remix-run/react": ">= 2",
     "next": ">= 14.2.0",
+    "react": ">= 18.2.0",
     "react-router-dom": ">= 6"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,20 +377,13 @@ importers:
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
-    optionalDependencies:
-      '@remix-run/react':
-        specifier: '>= 2'
-        version: 2.12.1(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)(typescript@5.6.3)
-      next:
-        specifier: '>= 14.2.0'
-        version: 14.2.15(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)
-      react-router-dom:
-        specifier: '>= 6'
-        version: 6.26.2(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.47.9
         version: 7.47.9(@types/node@22.7.5)
+      '@remix-run/react':
+        specifier: ^2.12.1
+        version: 2.12.1(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)(typescript@5.6.3)
       '@size-limit/preset-small-lib':
         specifier: ^11.1.6
         version: 11.1.6(size-limit@11.1.6)
@@ -415,12 +408,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.2(vite@5.4.8(@types/node@22.7.5)(lightningcss@1.27.0)(terser@5.34.1))
+      next:
+        specifier: 14.2.15
+        version: 14.2.15(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)
       react:
         specifier: catalog:react19rc
         version: 19.0.0-rc-65a56d0e-20241020
       react-dom:
         specifier: catalog:react19rc
         version: 19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020)
+      react-router-dom:
+        specifier: ^6.26.2
+        version: 6.26.2(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)
       size-limit:
         specifier: ^11.1.6
         version: 11.1.6
@@ -11236,7 +11235,6 @@ snapshots:
       turbo-stream: 2.4.0
     optionalDependencies:
       typescript: 5.6.3
-    optional: true
 
   '@remix-run/router@1.19.2': {}
 


### PR DESCRIPTION
TIL: all package managers download and install `optionalDependencies`. To mark them as optional peer, we need to leverage `peerDependenciesMeta.{packageName}.optional: true`.

Closes #696.