### PR TITLE
fix: Add stub CJS exports for old ESLint plugins

### DIFF
--- a/packages/nuqs/esm-only.cjs
+++ b/packages/nuqs/esm-only.cjs
@@ -1,0 +1,9 @@
+// ESM only manifesto: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
+
+// This stub file was added to let some old ESLint plugins resolve
+// the import paths correctly, as setting exports.*.require: null in package.json didn't work.
+
+throw new Error(
+  `This package is ESM only.
+  See https://github.com/47ng/nuqs/issues/691 for more details.`
+)

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -40,7 +40,8 @@
     "adapters/remix.d.ts",
     "adapters/react-router.d.ts",
     "adapters/custom.d.ts",
-    "adapters/testing.d.ts"
+    "adapters/testing.d.ts",
+    "esm-only.cjs"
   ],
   "type": "module",
   "sideEffects": false,
@@ -49,43 +50,53 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./esm-only.cjs"
     },
     "./server": {
       "types": "./dist/server.d.ts",
-      "import": "./dist/server.js"
+      "import": "./dist/server.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/react": {
       "types": "./dist/adapters/react.d.ts",
-      "import": "./dist/adapters/react.js"
+      "import": "./dist/adapters/react.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/next": {
       "types": "./dist/adapters/next.d.ts",
-      "import": "./dist/adapters/next.js"
+      "import": "./dist/adapters/next.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/next/app": {
       "types": "./dist/adapters/next/app.d.ts",
-      "import": "./dist/adapters/next/app.js"
+      "import": "./dist/adapters/next/app.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/next/pages": {
       "types": "./dist/adapters/next/pages.d.ts",
-      "import": "./dist/adapters/next/pages.js"
+      "import": "./dist/adapters/next/pages.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/remix": {
       "types": "./dist/adapters/remix.d.ts",
-      "import": "./dist/adapters/remix.js"
+      "import": "./dist/adapters/remix.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/react-router": {
       "types": "./dist/adapters/react-router.d.ts",
-      "import": "./dist/adapters/react-router.js"
+      "import": "./dist/adapters/react-router.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/custom": {
       "types": "./dist/adapters/custom.d.ts",
-      "import": "./dist/adapters/custom.js"
+      "import": "./dist/adapters/custom.js",
+      "require": "./esm-only.cjs"
     },
     "./adapters/testing": {
       "types": "./dist/adapters/testing.d.ts",
-      "import": "./dist/adapters/testing.js"
+      "import": "./dist/adapters/testing.js",
+      "require": "./esm-only.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
The `eslint-import-resolver-alias` ESLint plugin chokes on nuqs adapters imports when running `next lint`:

```txt
 Error while loading rule 'import/no-cycle': Package subpath './adapters/next/app' is not defined by "exports" in /[...]/node_modules/nuqs/package.json
```

Adding a stub CJS file for all exports that throws with a link to the original issue seems to satisfy the module resolution graph (the contents of the file aren't actually interpreted, but there needs to be one, `exports.*.require: null` doesn't cut it).

Closes #691.