### PR TITLE
doc: Fix date inputs on Chrome

### DIFF
--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -264,7 +264,7 @@ export function DateParserDemo({
               if (e.target.value === '') {
                 setValue(null)
               } else {
-                setValue(e.target.valueAsDate)
+                setValue(new Date(e.target.value))
               }
             }}
           />


### PR DESCRIPTION
I found the issue that on the docs Date inputs don't work well.
https://nuqs.47ng.com/docs/parsers/built-in#dates--timestamps

if we click `now` button, date successfully filled to the input and demo is working well, but if we it manually selecting the date and time, selected value is not filled.
This is because we can't `valueAsDate` for the input tag with `datetime-local`, so I fixed it.

I think this might be the same with the code below, but I don't know how I open the page of it so I can't debug it.
https://github.com/mehm8128/nuqs/blob/fix/docs-date-input/packages/docs/src/app/playground/_demos/parsers/page.tsx#L92-L109