### PR TITLE
fix(adapters/next): wrap setOptimisticSearchParams in startTransition

### DIFF
--- a/packages/nuqs/src/adapters/next/impl.app.ts
+++ b/packages/nuqs/src/adapters/next/impl.app.ts
@@ -1,5 +1,5 @@
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useOptimistic } from 'react'
+import { useCallback, useOptimistic, startTransition } from 'react'
 import { debug } from '../../debug'
 import type { AdapterInterface, UpdateUrlFunction } from '../defs'
 import { renderURL } from './shared'
@@ -11,7 +11,9 @@ export function useNuqsNextAppRouterAdapter(): AdapterInterface {
     useOptimistic<URLSearchParams>(searchParams)
   const updateUrl: UpdateUrlFunction = useCallback((search, options) => {
     // App router
-    setOptimisticSearchParams(search)
+    startTransition(() => {
+      setOptimisticSearchParams(search)
+    })
     const url = renderURL(location.origin + location.pathname, search)
     debug('[nuqs queue (app)] Updating url: %s', url)
     // First, update the URL locally without triggering a network request,


### PR DESCRIPTION
on next 15 app router. I was getting an error when updating a search param in a form input event handler. wrapping setOptimisticSearchParams with startTransition fixed it

```ts
<Input
  placeholder="https://example.com/font.woff2"
  {...field}
  onChange={(e) => {
    setWebFontUrl(e.target.value);
    field.onChange(e);
  }}
/>
```

error
```
ConsoleError: An optimistic state update occurred outside a transition or action. To fix, move the update to an action, or wrap with startTransition.
    at handleClientError (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-20241021__react@19.0.0-rc-69d4b800-20241021/node_modules/next/dist/client/components/react-dev-overlay/internal/helpers/use-error-handler.js:41:17)
    at window.console.error (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-20241021__react@19.0.0-rc-69d4b800-20241021/node_modules/next/dist/client/components/globals/intercept-console-error.js:39:56)
    at dispatchOptimisticSetState (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-20241021__react@19.0.0-rc-69d4b800-20241021/node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.development.js:7206:17)
    at eval (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/chunk-2Q6GSII2.js:19:5)
    at eval (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/index.js:407:13)
    at recursiveCompose (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/index.js:431:20)
    at compose (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/index.js:439:5)
    at flushUpdateQueue (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/index.js:406:9)
    at flushNow (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/index.js:353:42)
    at runOnNextTick (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/nuqs@2.1.0_next@15.0.1_react-dom@19.0.0-rc-69d4b800-20241021_react@19.0.0-rc-69d4b800-2024102_fs2fclt7luqmp6njf5pcuqcefm/node_modules/nuqs/dist/index.js:368:21)
```

```
    "react": "19.0.0-rc-69d4b800-20241021",
    "next": "15.0.1",
```
