### PR TITLE
doc: Updated docs Client Components to be Wrapped in a `<Suspense>` Boundry

### DIFF
--- a/packages/docs/content/docs/troubleshooting.mdx
+++ b/packages/docs/content/docs/troubleshooting.mdx
@@ -61,6 +61,8 @@ function Client() {
   // ...
 }
 ```
+For reference - https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
+
 The recommended approach is to keep page.tsx as a server component (no 'use client') and 
 move client-side features into a separate client.tsx file.
 

--- a/packages/docs/content/docs/troubleshooting.mdx
+++ b/packages/docs/content/docs/troubleshooting.mdx
@@ -43,7 +43,8 @@ function useIntFloat() {
 ```
 
 ## Client Components to be Wrapped in a `<Suspense>` Boundary
-### When using nuqs hooks, keep the following guidelines in mind:
+
+When using nuqs hooks, keep the following guidelines in mind:
 Components using hooks like useQueryState should be wrapped in `<Suspense>` when rendered within a page component. 
 For example:
 ```ts

--- a/packages/docs/content/docs/troubleshooting.mdx
+++ b/packages/docs/content/docs/troubleshooting.mdx
@@ -47,7 +47,7 @@ function useIntFloat() {
 When using nuqs hooks, keep the following guidelines in mind:
 Components using hooks like useQueryState should be wrapped in `<Suspense>` when rendered within a page component. 
 For example:
-```ts
+```tsx
 'use client'
 export default function Page() {
   return (

--- a/packages/docs/content/docs/troubleshooting.mdx
+++ b/packages/docs/content/docs/troubleshooting.mdx
@@ -42,3 +42,24 @@ function useIntFloat() {
 }
 ```
 
+## Client Components to be Wrapped in a `<Suspense>` Boundary
+### When using nuqs hooks, keep the following guidelines in mind:
+Components using hooks like useQueryState should be wrapped in `<Suspense>` when rendered within a page component. 
+For example:
+```ts
+'use client'
+export default function Page() {
+  return (
+    <Suspense>
+      <Client />
+    </Suspense>
+  ) 
+}
+function Client() {
+  const [foo, setFoo] = useQueryState('foo')
+  // ...
+}
+```
+The recommended approach is to keep page.tsx as a server component (no 'use client') and 
+move client-side features into a separate client.tsx file.
+


### PR DESCRIPTION
Components using hooks like useQueryState should be wrapped in `<Suspense>` when rendered within a page component. 

Fixes #496.