### PR TITLE
fix: Make the testing adapter clear the URL queue

### DIFF
--- a/packages/nuqs/src/adapters/testing.ts
+++ b/packages/nuqs/src/adapters/testing.ts
@@ -1,4 +1,5 @@
 import { createElement, type ReactNode } from 'react'
+import { resetQueue } from '../update-queue'
 import { renderQueryString } from '../url-encoding'
 import type { AdapterInterface, AdapterOptions } from './defs'
 import { context } from './internal.context'
@@ -15,10 +16,17 @@ type TestingAdapterProps = {
   searchParams?: string | Record<string, string> | URLSearchParams
   onUrlUpdate?: OnUrlUpdateFunction
   rateLimitFactor?: number
+  resetUrlUpdateQueueOnMount?: boolean
   children: ReactNode
 }
 
-export function NuqsTestingAdapter(props: TestingAdapterProps) {
+export function NuqsTestingAdapter({
+  resetUrlUpdateQueueOnMount = true,
+  ...props
+}: TestingAdapterProps) {
+  if (resetUrlUpdateQueueOnMount) {
+    resetQueue()
+  }
   const useAdapter = (): AdapterInterface => ({
     searchParams: new URLSearchParams(props.searchParams),
     updateUrl(search, options) {

--- a/packages/nuqs/src/update-queue.ts
+++ b/packages/nuqs/src/update-queue.ts
@@ -25,6 +25,15 @@ export function getQueuedValue(key: string) {
   return updateQueue.get(key)
 }
 
+export function resetQueue() {
+  updateQueue.clear()
+  transitionsQueue.clear()
+  queueOptions.history = 'replace'
+  queueOptions.scroll = false
+  queueOptions.shallow = true
+  queueOptions.throttleMs = FLUSH_RATE_LIMIT_MS
+}
+
 export function enqueueQueryStringUpdate<Value>(
   key: string,
   value: Value | null,
@@ -132,12 +141,7 @@ function flushUpdateQueue(
   const options = { ...queueOptions }
   const transitions = Array.from(transitionsQueue)
   // Restore defaults
-  updateQueue.clear()
-  transitionsQueue.clear()
-  queueOptions.history = 'replace'
-  queueOptions.scroll = false
-  queueOptions.shallow = true
-  queueOptions.throttleMs = FLUSH_RATE_LIMIT_MS
+  resetQueue()
   debug('[nuqs queue] Flushing queue %O with options %O', items, options)
   for (const [key, value] of items) {
     if (value === null) {


### PR DESCRIPTION
This caused issues in sequential tests where a test would update a query state, the URL update would be queued, but not flushed at the moment when the test finished, and the next test would then pick up the queued value in its initial state.