### PR TITLE
fix(serializer/types): Allow `null` value in serializer for parsers with default values

### DIFF
--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -464,12 +464,3 @@ export type inferParserType<Input> =
     : Input extends Record<string, ParserBuilder<any>>
       ? inferParserRecordType<Input>
       : never
-
-type inferSingleSerializerType<Parser> =
-  Parser extends ParserBuilder<infer Value> ? Value | null : never
-
-export type inferSerializerRecordType<
-  Map extends Record<string, ParserBuilder<any>>
-> = {
-  [Key in keyof Map]: inferSingleSerializerType<Map[Key]>
-}

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -421,13 +421,13 @@ export function parseAsArrayOf<ItemType>(
 }
 
 type inferSingleParserType<Parser> = Parser extends ParserBuilder<
-  infer Type
+  infer Value
 > & {
-  defaultValue: infer Type
+  defaultValue: infer Value
 }
-  ? Type
-  : Parser extends ParserBuilder<infer Type>
-    ? Type | null
+  ? Value
+  : Parser extends ParserBuilder<infer Value>
+    ? Value | null
     : never
 
 type inferParserRecordType<Map extends Record<string, ParserBuilder<any>>> = {
@@ -464,3 +464,12 @@ export type inferParserType<Input> =
     : Input extends Record<string, ParserBuilder<any>>
       ? inferParserRecordType<Input>
       : never
+
+type inferSingleSerializerType<Parser> =
+  Parser extends ParserBuilder<infer Value> ? Value | null : never
+
+export type inferSerializerRecordType<
+  Map extends Record<string, ParserBuilder<any>>
+> = {
+  [Key in keyof Map]: inferSingleSerializerType<Map[Key]>
+}

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -86,6 +86,20 @@ describe('serializer', () => {
     const result = serialize('?str=foo&external=kept', null)
     expect(result).toBe('?external=kept')
   })
+  test('clears value when setting null for search param that has a default value', () => {
+    const serialize = createSerializer({
+      int: parseAsInteger.withDefault(0)
+    })
+    const result = serialize('?int=1&str=foo', { int: null })
+    expect(result).toBe('?str=foo')
+  })
+  test('clears value when setting null for search param that is set to its default value', () => {
+    const serialize = createSerializer({
+      int: parseAsInteger.withDefault(0)
+    })
+    const result = serialize('?int=0&str=foo', { int: null })
+    expect(result).toBe('?str=foo')
+  })
   test('clears value when setting the default value (`clearOnDefault: true` is the default)', () => {
     const serialize = createSerializer({
       int: parseAsInteger.withDefault(0),

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,9 +1,18 @@
 import type { Options } from './defs'
-import type { inferSerializerRecordType, ParserBuilder } from './parsers'
+import type { ParserBuilder } from './parsers'
 import { renderQueryString } from './url-encoding'
 
 type Base = string | URLSearchParams | URL
 type ParserWithOptionalDefault<T> = ParserBuilder<T> & { defaultValue?: T }
+
+type inferSingleSerializerType<Parser> =
+  Parser extends ParserBuilder<infer Value> ? Value | null : never
+
+export type inferSerializerRecordType<
+  Map extends Record<string, ParserBuilder<any>>
+> = {
+  [Key in keyof Map]: inferSingleSerializerType<Map[Key]>
+}
 
 export function createSerializer<
   Parsers extends Record<string, ParserWithOptionalDefault<any>>

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,18 +1,9 @@
-import type { Options } from './defs'
-import type { ParserBuilder } from './parsers'
+import type { Nullable, Options } from './defs'
+import type { inferParserType, ParserBuilder } from './parsers'
 import { renderQueryString } from './url-encoding'
 
 type Base = string | URLSearchParams | URL
 type ParserWithOptionalDefault<T> = ParserBuilder<T> & { defaultValue?: T }
-
-type inferSingleSerializerType<Parser> =
-  Parser extends ParserBuilder<infer Value> ? Value | null : never
-
-export type inferSerializerRecordType<
-  Map extends Record<string, ParserBuilder<any>>
-> = {
-  [Key in keyof Map]: inferSingleSerializerType<Map[Key]>
-}
 
 export function createSerializer<
   Parsers extends Record<string, ParserWithOptionalDefault<any>>
@@ -25,7 +16,7 @@ export function createSerializer<
     urlKeys?: Partial<Record<keyof Parsers, string>>
   } = {}
 ) {
-  type Values = Partial<inferSerializerRecordType<Parsers>>
+  type Values = Partial<Nullable<inferParserType<Parsers>>>
 
   /**
    * Generate a query string for the given values.

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,5 +1,5 @@
 import type { Options } from './defs'
-import type { inferParserType, ParserBuilder } from './parsers'
+import type { inferSerializerRecordType, ParserBuilder } from './parsers'
 import { renderQueryString } from './url-encoding'
 
 type Base = string | URLSearchParams | URL
@@ -16,7 +16,7 @@ export function createSerializer<
     urlKeys?: Partial<Record<keyof Parsers, string>>
   } = {}
 ) {
-  type Values = Partial<inferParserType<Parsers>>
+  type Values = Partial<inferSerializerRecordType<Parsers>>
 
   /**
    * Generate a query string for the given values.

--- a/packages/nuqs/src/tests/serializer.test-d.ts
+++ b/packages/nuqs/src/tests/serializer.test-d.ts
@@ -48,3 +48,16 @@ import { createSerializer, parseAsInteger, parseAsString } from '../../dist'
     serialize({ nope: null })
   })
 }
+
+// It accepts null for values
+{
+  const serialize = createSerializer({
+    foo: parseAsInteger,
+    bar: parseAsInteger.withDefault(0)
+  })
+  // Should accept number | null | undefined
+  expectType<string>(serialize({ foo: null }))
+  expectType<string>(serialize({ foo: undefined }))
+  expectType<string>(serialize({ bar: null }))
+  expectType<string>(serialize({ bar: undefined }))
+}


### PR DESCRIPTION
See [related discussion](https://github.com/47ng/nuqs/discussions/767).

Passing `null` to the serialize of a search param whose parser has a default currently is a type error, even though the behaviour works as expected.

This is because for the values argument it infers the types using the same `inferParserType` which is fine for parsing but is not quite right for serializing. The way i'm fixing it is just declaring a different `inferSerializerRecordType` to be used here. If there's some TS-foo i don't know which allows reusing the same `inferParserRecordType`, that'd be even better!

`CONTRIBUTING.md` mentions "adding a minimal reproduction in the playground can be very helpful" but i couldn't immediately find how to create one [there](https://nuqs.47ng.com/playground).

Added some very basic tests, feel free to point out if any more would be nice.