### PR TITLE
feat: Allow the `serialize` function in parsers to remove their key from the URL

### DIFF
--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -63,7 +63,12 @@ export function createSerializer<
       ) {
         search.delete(urlKey)
       } else {
-        search.set(urlKey, parser.serialize(value))
+        const serialized = parser.serialize(value)
+        if (serialized === null) {
+          search.delete(urlKey)
+        } else {
+          search.set(urlKey, serialized)
+        }
       }
     }
     return base + renderQueryString(search)

--- a/packages/nuqs/src/update-queue.ts
+++ b/packages/nuqs/src/update-queue.ts
@@ -37,7 +37,7 @@ export function resetQueue() {
 export function enqueueQueryStringUpdate<Value>(
   key: string,
   value: Value | null,
-  serialize: (value: Value) => string,
+  serialize: (value: Value) => string | null,
   options: Pick<
     Options,
     'history' | 'scroll' | 'shallow' | 'startTransition' | 'throttleMs'


### PR DESCRIPTION
Returning `null` from the `serialize` function signals that the associated search param should be removed from the URL.

This would allow clearing invalid states passed to the serialize function.

Edit: this would actually count as a breaking change (the docs did break), so it will be added to the v3 release line.

## Tasks

- [ ] Add docs
- [ ] Add tests

See [related discussion](https://github.com/47ng/nuqs/discussions/662).