### PR TITLE
Readme: Add Astro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,39 @@ export function ReactRouter() {
 
 </details>
 
+<details><summary><img style="width:1em;height:1em;" src="https://docs.astro.build/favicon.svg" /> Astro (React)</summary>
+
+Example: [Astro React]([https://astro.build/](https://docs.astro.build/de/guides/integrations-guide/react/)).
+
+```astro
+// page.astro
+<NuqsReactComponent client:load />
+```
+
+```tsx
+// NuqsReactComponent.tsx
+import { NuqsAdapter } from 'nuqs/adapters/react'
+import { useQueryState } from 'nuqs'
+
+export const NuqsReactComponentWithNuqs = () => {
+  const [name, setName] = useQueryState('name')
+
+  return (
+    <code>{name}</code>
+  )
+}
+
+export const NuqsReactComponent = () => {
+  return (
+    <NuqsAdapter>
+      <NuqsReactComponentWithNuqs />
+    </NuqsAdapter>
+  )
+}
+```
+
+</details>
+
 ## Usage
 
 ```tsx


### PR DESCRIPTION
I am testing out nuqs with an Astro app and it looks like all works great (*).

This example for the Readme shows a possible way to use it. 

The thing that is different for Astro is, that there is no "Root" to place the `NuqsAdapter` IMO, since each Astro island is independent. Which is why we need to do this semi-elegant wrapper component.

There might be better ways to do this, though.

(*) (!) However, I did not test (yet) how this behaves with multiple islands and `NuqsAdapter`s. This could very well break the setup. Until now I used the recommended nanostore in those cases. See https://docs.astro.build/en/recipes/sharing-state-islands/
However, nanostore remove the nuqs like helper methods at some point. More on this is in https://github.com/nanostores/router/issues/30. My previous workaround was to use a copy of the removed helper, eg. https://github.com/osmberlin/www.osm-verkehrswende.org/commit/3d2e27b4fa7f427e3f72af41561d025857ec57c5#diff-acaaec4d6340f096b1c5dab9c107023b24ec701667fa9c9bb362fdf9e92ce846R55

---

I will mark this as a draft for now until the `(!)` is cleared up.