### PR TITLE
feat: Abstract reading from location.search in adapters interface

### DIFF
--- a/packages/nuqs/src/adapters/defs.ts
+++ b/packages/nuqs/src/adapters/defs.ts
@@ -12,5 +12,6 @@ export type UseAdapterHook = () => AdapterInterface
 export type AdapterInterface = {
   searchParams: URLSearchParams
   updateUrl: UpdateUrlFunction
+  getSearchParamsSnapshot?: () => URLSearchParams
   rateLimitFactor?: number
 }

--- a/packages/nuqs/src/adapters/testing.ts
+++ b/packages/nuqs/src/adapters/testing.ts
@@ -36,6 +36,9 @@ export function NuqsTestingAdapter({
         options
       })
     },
+    getSearchParamsSnapshot() {
+      return new URLSearchParams(props.searchParams)
+    },
     rateLimitFactor: props.rateLimitFactor ?? 0
   })
   return createElement(

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -228,12 +228,8 @@ export function useQueryState<T = string>(
     defaultValue: undefined
   }
 ) {
-  // Not reactive, but available on the server and on page load
-  const {
-    searchParams: initialSearchParams,
-    updateUrl,
-    rateLimitFactor = 1
-  } = useAdapter()
+  const adapter = useAdapter()
+  const initialSearchParams = adapter.searchParams
   const queryRef = useRef<string | null>(initialSearchParams?.get(key) ?? null)
   const [internalState, setInternalState] = useState<T | null>(() => {
     const queuedQuery = getQueuedValue(key)
@@ -302,18 +298,9 @@ export function useQueryState<T = string>(
       })
       // Sync all hooks state (including this one)
       emitter.emit(key, { state: newValue, query: queryRef.current })
-      return scheduleFlushToURL(updateUrl, rateLimitFactor)
+      return scheduleFlushToURL(adapter)
     },
-    [
-      key,
-      history,
-      shallow,
-      scroll,
-      throttleMs,
-      startTransition,
-      updateUrl,
-      rateLimitFactor
-    ]
+    [key, history, shallow, scroll, throttleMs, startTransition, adapter]
   )
   return [internalState ?? defaultValue ?? null, update]
 }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -90,11 +90,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       ),
     [stateKeys, urlKeys]
   )
-  const {
-    searchParams: initialSearchParams,
-    updateUrl,
-    rateLimitFactor = 1
-  } = useAdapter()
+  const adapter = useAdapter()
+  const initialSearchParams = adapter.searchParams
   const queryRef = useRef<Record<string, string | null>>({})
   // Initialise the queryRef with the initial values
   if (Object.keys(queryRef.current).length !== Object.keys(keyMap).length) {
@@ -243,7 +240,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           query: queryRef.current[urlKey] ?? null
         })
       }
-      return scheduleFlushToURL(updateUrl, rateLimitFactor)
+      return scheduleFlushToURL(adapter)
     },
     [
       keyMap,
@@ -253,8 +250,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       throttleMs,
       startTransition,
       resolvedUrlKeys,
-      updateUrl,
-      rateLimitFactor,
+      adapter,
       defaultValues
     ]
   )


### PR DESCRIPTION
This is mainly for the testing adapter to only work on the provided set of initial search params without needing to stub/mock location.search.

But it also opens the door for adapters to define new storage locations, like hash/fragment or even localStorage.