### PR TITLE
fix(types): Export `Nullable` type for correctly inferring return type of `createSerializer()`

### DIFF
--- a/packages/nuqs/src/index.server.ts
+++ b/packages/nuqs/src/index.server.ts
@@ -1,4 +1,4 @@
 export { createSearchParamsCache } from './cache'
-export type { HistoryOptions, Options, SearchParams } from './defs'
+export type { HistoryOptions, Nullable, Options, SearchParams } from './defs'
 export * from './parsers'
 export { createSerializer } from './serializer'

--- a/packages/nuqs/src/index.ts
+++ b/packages/nuqs/src/index.ts
@@ -1,4 +1,4 @@
-export type { HistoryOptions, Options, SearchParams } from './defs'
+export type { HistoryOptions, Nullable, Options, SearchParams } from './defs'
 export * from './parsers'
 export { createSerializer } from './serializer'
 export * from './useQueryState'


### PR DESCRIPTION
Bonsoir!* This PR fixes a type issue _someone with my exact username_ 👀 introduced in #769, related to TypeScript.

It seems like TS has issues with inferring the type of the created serialized if it doesn't have access to the `Nullable` type, and I've been getting this very cryptic error:

```
The inferred type of 'serializeProductDetailParams' cannot be named without a reference to '@/node_modules/nuqs/dist/_tsup-dts-rollup'. This is likely not portable. A type annotation is necessary.
```

![image](https://github.com/user-attachments/assets/36c001a1-e9b7-46a4-b22a-93246388ae7d)

This PR solves this by simply exporting nuqs' `Nullable` type (for both client and server package entrypoints), if that's alright with you, and `Nullable` doesn't even have to be imported by app code to solve the TS issue.

I'm not sure why TS can't manage without this explicit export and from some issues i've skimmed it shouldn't be the correct behaviour maybe, but the solution presented here is quite simple.

*I came across your website and realized we're quite close right now, as i'm currently staying in Lyon. Small world! 🌍 