### PR TITLE
chore: Rework bundling

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -55,8 +55,8 @@
       "require": "./esm-only.cjs"
     },
     "./server": {
-      "types": "./dist/server.d.ts",
-      "import": "./dist/server.js",
+      "types": "./dist/index.server.d.ts",
+      "import": "./dist/index.server.js",
       "require": "./esm-only.cjs"
     },
     "./adapters/react": {
@@ -113,7 +113,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "prebuild": "rm -rf dist",
-    "build": "tsup",
+    "build": "tsc --project tsconfig.build.json",
     "postbuild": "size-limit --json > size.json",
     "test": "pnpm run --stream '/^test:/'",
     "test:types": "tsd",
@@ -184,7 +184,7 @@
     },
     {
       "name": "Server",
-      "path": "dist/server.js",
+      "path": "dist/index.server.js",
       "limit": "2 kB",
       "ignore": [
         "react",

--- a/packages/nuqs/server.d.ts
+++ b/packages/nuqs/server.d.ts
@@ -4,4 +4,4 @@
 // but with `node`, TypeScript will look for a .d.ts file with that name at the
 // root of the package.
 
-export * from './dist/server'
+export * from './dist/index.server'

--- a/packages/nuqs/src/adapters/custom.ts
+++ b/packages/nuqs/src/adapters/custom.ts
@@ -1,3 +1,5 @@
+'use client'
+
 export { renderQueryString } from '../url-encoding'
 export {
   createAdapterProvider as unstable_createAdapterProvider,

--- a/packages/nuqs/src/adapters/next.ts
+++ b/packages/nuqs/src/adapters/next.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createAdapterProvider } from './lib/context'
 import type { AdapterInterface } from './lib/defs'
 import { useNuqsNextAppRouterAdapter } from './next/impl.app'

--- a/packages/nuqs/src/adapters/next/app.ts
+++ b/packages/nuqs/src/adapters/next/app.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createAdapterProvider } from '../lib/context'
 import { useNuqsNextAppRouterAdapter } from './impl.app'
 

--- a/packages/nuqs/src/adapters/next/pages.ts
+++ b/packages/nuqs/src/adapters/next/pages.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createAdapterProvider } from '../lib/context'
 import { useNuqsNextPagesRouterAdapter } from './impl.pages'
 

--- a/packages/nuqs/src/adapters/react-router.ts
+++ b/packages/nuqs/src/adapters/react-router.ts
@@ -1,3 +1,5 @@
+'use client'
+
 export {
   /**
    * @deprecated This import will be removed in nuqs@3.0.0.

--- a/packages/nuqs/src/adapters/react-router/v6.ts
+++ b/packages/nuqs/src/adapters/react-router/v6.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { createAdapterProvider } from '../lib/context'
 import { createReactRouterBasedAdapter } from '../lib/react-router'

--- a/packages/nuqs/src/adapters/react-router/v7.ts
+++ b/packages/nuqs/src/adapters/react-router/v7.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useNavigate, useSearchParams } from 'react-router'
 import { createAdapterProvider } from '../lib/context'
 import { createReactRouterBasedAdapter } from '../lib/react-router'

--- a/packages/nuqs/src/adapters/react.ts
+++ b/packages/nuqs/src/adapters/react.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import mitt from 'mitt'
 import { useEffect, useState } from 'react'
 import { renderQueryString } from '../url-encoding'

--- a/packages/nuqs/src/adapters/remix.ts
+++ b/packages/nuqs/src/adapters/remix.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useNavigate, useSearchParams } from '@remix-run/react'
 import { createAdapterProvider } from './lib/context'
 import { createReactRouterBasedAdapter } from './lib/react-router'

--- a/packages/nuqs/src/adapters/testing.ts
+++ b/packages/nuqs/src/adapters/testing.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createElement, type ReactNode } from 'react'
 import { resetQueue } from '../update-queue'
 import { renderQueryString } from '../url-encoding'

--- a/packages/nuqs/src/index.ts
+++ b/packages/nuqs/src/index.ts
@@ -1,3 +1,5 @@
+'use client'
+
 export type { HistoryOptions, Nullable, Options, SearchParams } from './defs'
 export * from './parsers'
 export { createSerializer } from './serializer'

--- a/packages/nuqs/src/tests/cache.test-d.ts
+++ b/packages/nuqs/src/tests/cache.test-d.ts
@@ -4,7 +4,7 @@ import {
   parseAsBoolean,
   parseAsInteger,
   parseAsString
-} from '../../dist/server'
+} from '../../dist/index.server'
 
 {
   const cache = createSearchParamsCache({

--- a/packages/nuqs/tsconfig.build.json
+++ b/packages/nuqs/tsconfig.build.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false,
+    "declaration": true
+  },
   "include": ["src/**/*.ts"],
   "exclude": ["src/tests", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/packages/nuqs/tsconfig.build.json
+++ b/packages/nuqs/tsconfig.build.json
@@ -3,8 +3,11 @@
   "compilerOptions": {
     "outDir": "dist",
     "noEmit": false,
-    "declaration": true
+    "declaration": true,
+    "declarationDir": "dist",
+    "declarationMap": false,
+    "incremental": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/tests", "src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": ["src/tests/**", "src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Trying new approaches to solve #708.

Complete unbundling is not the best outcome, as it would expose internals.

## Things to try
- [ ] Manually bundling a few files to see if it actually solves the intellisense issue (no need to go further if it doesn't)
- [ ] Find a minimal reproduction by hacking down start-ui and compare with a stock create next-app
- [ ] Rollup could work as a replacement for tsup, we might not want two bundlers (runtime / types)

Another thing to try and solve is how to keep the `/** @deprecated */` JSDoc annotations on re-exports.