### PR TITLE
doc: Fix link to options docs

### DIFF
--- a/packages/docs/content/docs/parsers/built-in.mdx
+++ b/packages/docs/content/docs/parsers/built-in.mdx
@@ -47,7 +47,7 @@ If search params are strings by default, what's the point of this _"parser"_ ?
 
 It becomes useful if you're declaring a search params object, and/or you want
 to use the builder pattern to specify [default values](./basic-usage#default-values)
-and [options](./options):
+and [options](../options):
 
 ```ts
 export const searchParamsParsers = {


### PR DESCRIPTION
The options is located at https://nuqs.47ng.com/docs/options and not in https://nuqs.47ng.com/docs/parsers/options :)