### PR TITLE
ref: Use a useEffect rather than useLayoutEffect

### DIFF
--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -1,11 +1,5 @@
 import mitt from 'mitt'
-import {
-  startTransition,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState
-} from 'react'
+import { startTransition, useCallback, useEffect, useState } from 'react'
 import { renderQueryString } from '../../url-encoding'
 import type { AdapterInterface, AdapterOptions } from './defs'
 import {
@@ -98,7 +92,7 @@ export function createReactRouterBasedAdapter(
         window.removeEventListener('popstate', onPopState)
       }
     }, [])
-    useLayoutEffect(() => {
+    useEffect(() => {
       emitter.emit('update', serverSearchParams)
     }, [serverSearchParams])
     return searchParams


### PR DESCRIPTION
To synchronise the server search params (from stock RR useSearchParams to the internal optimistic search params state).

Using a layout effect gives a warning:

```txt
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format.
This will lead to a mismatch between the initial, non-hydrated UI and the intended UI.
To avoid this, useLayoutEffect should only be used in components that render exclusively on the client.
See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
```

Looks like tests are passing fine with a good old useEffect (shallow would be the smoking gun here).