### PR TITLE
doc: Update wording for the "missing suspense boundary" guidelines

### DIFF
--- a/packages/docs/content/docs/troubleshooting.mdx
+++ b/packages/docs/content/docs/troubleshooting.mdx
@@ -51,8 +51,7 @@ from Next.js:
 Missing Suspense boundary with useSearchParams
 ```
 
-Components using hooks like useQueryState should be wrapped in `<Suspense>` when
-rendered within a page component:
+Components using hooks like `useQueryState` should be wrapped in `<Suspense>` when rendered within a page component. Adding the 'use client' directive to the page.tsx file is the immediate fix to get things working if you are defining components that use client-side features (like nuqs or React Hooks):
 
 ```tsx
 'use client'
@@ -70,6 +69,8 @@ function Client() {
   // ...
 }
 ```
+
+However, the steps below indicate the optimal approach to get better UX: separating server and client files (and moving client side code as low down the tree as possible to pre-render the outer shell).
 
 The recommended approach is:
 


### PR DESCRIPTION
Updating the wording of [Client components need to be wrapped in a <Suspense> boundary](https://nuqs.47ng.com/docs/troubleshooting#client-components-need-to-be-wrapped-in-a-suspense-boundary) section based on the discussion at https://github.com/47ng/nuqs/discussions/846