### PR TITLE
perf: Optimise render counts

### DIFF
--- a/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
@@ -50,7 +50,7 @@ for (const hook of hooks) {
             },
             expected: {
               mount: 1,
-              update: startTransition === true ? 4 : 2
+              update: 2
             },
             nextJsRouter: 'pages'
           })

--- a/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
@@ -32,22 +32,30 @@ for (const hook of hooks) {
   }
 }
 
-// for (const hook of hooks) {
-//   for (const shallow of shallows) {
-//     for (const history of histories) {
-//       testRenderCount({
-//         path: `/pages/render-count/${hook}/${shallow}/${history}`,
-//         hook,
-//         props: {
-//           shallow,
-//           history
-//         },
-//         expected: {
-//           mount: 1,
-//           update: 3
-//         },
-//         nextJsRouter: 'pages'
-//       })
-//     }
-//   }
-// }
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of shallow === false
+        ? [false, true]
+        : [false]) {
+        for (const delay of shallow === false ? [0, 50] : [0]) {
+          testRenderCount({
+            path: `/pages/render-count/${hook}/${shallow}/${history}/${startTransition}?delay=${delay}`,
+            hook,
+            props: {
+              shallow,
+              history,
+              startTransition,
+              delay
+            },
+            expected: {
+              mount: 1,
+              update: startTransition === true ? 4 : 2
+            },
+            nextJsRouter: 'pages'
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
@@ -7,9 +7,7 @@ const histories = ['replace', 'push'] as const
 for (const hook of hooks) {
   for (const shallow of shallows) {
     for (const history of histories) {
-      for (const startTransition of shallow === false
-        ? [false, true]
-        : [false]) {
+      for (const startTransition of [false, true]) {
         for (const delay of shallow === false ? [0, 50] : [0]) {
           testRenderCount({
             path: `/app/render-count/${hook}/${shallow}/${history}/${startTransition}?delay=${delay}`,
@@ -35,9 +33,7 @@ for (const hook of hooks) {
 for (const hook of hooks) {
   for (const shallow of shallows) {
     for (const history of histories) {
-      for (const startTransition of shallow === false
-        ? [false, true]
-        : [false]) {
+      for (const startTransition of [false, true]) {
         for (const delay of shallow === false ? [0, 50] : [0]) {
           testRenderCount({
             path: `/pages/render-count/${hook}/${shallow}/${history}/${startTransition}?delay=${delay}`,

--- a/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
@@ -1,0 +1,53 @@
+import { testRenderCount } from 'e2e-shared/specs/render-count.cy'
+
+const hooks = ['useQueryState', 'useQueryStates'] as const
+const shallows = [true, false] as const
+const histories = ['replace', 'push'] as const
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of shallow === false
+        ? [false, true]
+        : [false]) {
+        for (const delay of shallow === false ? [0, 50] : [0]) {
+          testRenderCount({
+            path: `/app/render-count/${hook}/${shallow}/${history}/${startTransition}?delay=${delay}`,
+            hook,
+            props: {
+              shallow,
+              history,
+              startTransition,
+              delay
+            },
+            expected: {
+              mount: 1,
+              update: shallow === true ? 2 : 3
+            },
+            nextJsRouter: 'app'
+          })
+        }
+      }
+    }
+  }
+}
+
+// for (const hook of hooks) {
+//   for (const shallow of shallows) {
+//     for (const history of histories) {
+//       testRenderCount({
+//         path: `/pages/render-count/${hook}/${shallow}/${history}`,
+//         hook,
+//         props: {
+//           shallow,
+//           history
+//         },
+//         expected: {
+//           mount: 1,
+//           update: 3
+//         },
+//         nextJsRouter: 'pages'
+//       })
+//     }
+//   }
+// }

--- a/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/render-count.cy.ts
@@ -22,7 +22,7 @@ for (const hook of hooks) {
             },
             expected: {
               mount: 1,
-              update: shallow === true ? 2 : 3
+              update: shallow === false ? 3 : 2
             },
             nextJsRouter: 'app'
           })

--- a/packages/e2e/next/package.json
+++ b/packages/e2e/next/package.json
@@ -16,7 +16,7 @@
     "start": "NODE_OPTIONS='--enable-source-maps=true' next start --port 3001",
     "pretest": "cypress install",
     "test": "start-server-and-test start http://localhost:3001${BASE_PATH} cypress:run",
-    "cypress:open": "cypress open",
+    "cypress:open": "cypress open --e2e --browser electron",
     "cypress:run": "cypress run --headless"
   },
   "dependencies": {

--- a/packages/e2e/next/src/app/app/(shared)/render-count/[hook]/[shallow]/[history]/[startTransition]/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/render-count/[hook]/[shallow]/[history]/[startTransition]/page.tsx
@@ -1,0 +1,47 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import {
+  loadParams,
+  loadSearchParams
+} from 'e2e-shared/specs/render-count.params'
+import { setTimeout } from 'node:timers/promises'
+import { type SearchParams } from 'nuqs/server'
+import { Suspense } from 'react'
+
+export const dynamic = 'force-dynamic'
+
+type PageProps = {
+  params: Promise<Record<keyof ReturnType<typeof loadParams>, string>>
+  searchParams: Promise<SearchParams>
+}
+
+export default async function Page({
+  params,
+  searchParams
+}: PageProps & { searchParams: Promise<SearchParams> }) {
+  const { hook, shallow, history, startTransition } = await loadParams(params)
+  const { delay } = await loadSearchParams(searchParams)
+  if (delay) {
+    await setTimeout(delay)
+  }
+  return (
+    <Suspense>
+      <RenderCount
+        hook={hook}
+        shallow={shallow}
+        history={history}
+        startTransition={startTransition}
+      />
+    </Suspense>
+  )
+}
+
+export async function generateStaticParams() {
+  const hooks = ['useQueryState', 'useQueryStates']
+  const shallow = [true, false]
+  const history = ['push', 'replace']
+  return hooks.flatMap(hook =>
+    shallow.flatMap(shallow =>
+      history.map(history => ({ hook, shallow: shallow.toString(), history }))
+    )
+  )
+}

--- a/packages/e2e/next/src/pages/pages/render-count/[hook]/[shallow]/[history]/[startTransition]/index.tsx
+++ b/packages/e2e/next/src/pages/pages/render-count/[hook]/[shallow]/[history]/[startTransition]/index.tsx
@@ -1,0 +1,25 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import {
+  loadParams,
+  loadSearchParams,
+  type Params
+} from 'e2e-shared/specs/render-count.params'
+import { GetServerSideProps } from 'next'
+import { setTimeout } from 'node:timers/promises'
+
+export default RenderCount
+
+// We need SSR to get the correct initial render counts
+// otherwise with SSG we get at least one extra render for hydration.
+export const getServerSideProps: GetServerSideProps<Params> = async ({
+  params,
+  query
+}) => {
+  const { delay } = loadSearchParams(query)
+  if (delay) {
+    await setTimeout(delay)
+  }
+  return {
+    props: loadParams(params!)
+  }
+}

--- a/packages/e2e/react-router/v6/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react-router/v6/cypress/e2e/shared/render-count.cy.ts
@@ -1,0 +1,80 @@
+import { testRenderCount } from 'e2e-shared/specs/render-count.cy'
+
+const hooks = ['useQueryState', 'useQueryStates'] as const
+const shallows = [false] as const
+const histories = ['replace', 'push'] as const
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/no-loader`,
+          description: 'no loader',
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2 + (shallow === false ? 1 : 0)
+          }
+        })
+      }
+    }
+  }
+}
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/sync-loader`,
+          description: 'sync loader',
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2 + (shallow === false ? 1 : 0) + (startTransition ? 1 : 0)
+          }
+        })
+      }
+    }
+  }
+}
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        for (const delay of shallow === false ? [0, 50] : [0]) {
+          testRenderCount({
+            path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/async-loader?delay=${delay}`,
+            description: 'async loader',
+            hook,
+            props: {
+              shallow,
+              history,
+              startTransition,
+              delay
+            },
+            expected: {
+              mount: 1,
+              update:
+                2 +
+                (shallow === false ? 1 : 0) +
+                (startTransition ? 1 : delay ? 1 : 0)
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/e2e/react-router/v6/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react-router/v6/cypress/e2e/shared/render-count.cy.ts
@@ -1,7 +1,7 @@
 import { testRenderCount } from 'e2e-shared/specs/render-count.cy'
 
 const hooks = ['useQueryState', 'useQueryStates'] as const
-const shallows = [false] as const
+const shallows = [true, false] as const
 const histories = ['replace', 'push'] as const
 
 for (const hook of hooks) {
@@ -19,7 +19,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 1 : 0)
+            update: 2 + (shallow === false ? (startTransition ? 0 : 1) : 0)
           }
         })
       }
@@ -42,7 +42,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 1 : 0) + (startTransition ? 1 : 0)
+            update: 2 + (shallow === false ? 1 : 0)
           }
         })
       }
@@ -70,7 +70,7 @@ for (const hook of hooks) {
               update:
                 2 +
                 (shallow === false ? 1 : 0) +
-                (startTransition ? 1 : delay ? 1 : 0)
+                (!startTransition && delay ? 1 : 0)
             }
           })
         }

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -41,6 +41,11 @@ const router = createBrowserRouter(
       <Route path="form/useQueryStates"                   lazy={load(import('./routes/form.useQueryStates'))} />
       <Route path="referential-stability/useQueryState"   lazy={load(import('./routes/referential-stability.useQueryState'))} />
       <Route path="referential-stability/useQueryStates"  lazy={load(import('./routes/referential-stability.useQueryStates'))} />
+
+      <Route path="render-count/:hook/:shallow/:history/:startTransition/no-loader"     lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.no-loader'))} />
+      <Route path="render-count/:hook/:shallow/:history/:startTransition/sync-loader"   lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader'))} />
+      <Route path="render-count/:hook/:shallow/:history/:startTransition/async-loader"  lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.async-loader'))} />
+
       {/* Reproductions */}
       <Route path='repro-839'   lazy={load(import('./routes/repro-839'))} />
     </Route>

--- a/packages/e2e/react-router/v6/src/routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx
+++ b/packages/e2e/react-router/v6/src/routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx
@@ -1,0 +1,22 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import {
+  loadParams,
+  loadSearchParams
+} from 'e2e-shared/specs/render-count.params'
+
+import { useParams, type LoaderFunctionArgs } from 'react-router-dom'
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { delay } = loadSearchParams(request)
+  if (delay) {
+    await wait(delay)
+  }
+  return null
+}
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/react-router/v6/src/routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx
+++ b/packages/e2e/react-router/v6/src/routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx
@@ -1,0 +1,8 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+import { useParams } from 'react-router-dom'
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/react-router/v6/src/routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx
+++ b/packages/e2e/react-router/v6/src/routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx
@@ -1,0 +1,12 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+import { useParams } from 'react-router-dom'
+
+export function loader() {
+  return null
+}
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -24,6 +24,9 @@ export default [
     route('/form/useQueryStates',                   './routes/form.useQueryStates.tsx'),
     route('/referential-stability/useQueryState',   './routes/referential-stability.useQueryState.tsx'),
     route('/referential-stability/useQueryStates',  './routes/referential-stability.useQueryStates.tsx'),
+    route('/render-count/:hook/:shallow/:history/:startTransition/no-loader',    './routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx'),
+    route('/render-count/:hook/:shallow/:history/:startTransition/sync-loader',  './routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx'),
+    route('/render-count/:hook/:shallow/:history/:startTransition/async-loader', './routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx'),
     // Reproductions
     route('/repro-839',   './routes/repro-839.tsx'),
   ])

--- a/packages/e2e/react-router/v7/app/routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx
+++ b/packages/e2e/react-router/v7/app/routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx
@@ -1,0 +1,20 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import {
+  loadParams,
+  loadSearchParams
+} from 'e2e-shared/specs/render-count.params'
+import { setTimeout } from 'node:timers/promises'
+import { useParams, type LoaderFunctionArgs } from 'react-router'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { delay } = loadSearchParams(request)
+  if (delay) {
+    await setTimeout(delay)
+  }
+  return null
+}
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/react-router/v7/app/routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx
+++ b/packages/e2e/react-router/v7/app/routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx
@@ -1,0 +1,8 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+import { useParams } from 'react-router'
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/react-router/v7/app/routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx
+++ b/packages/e2e/react-router/v7/app/routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx
@@ -1,0 +1,12 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+import { useParams } from 'react-router'
+
+export function loader() {
+  return null
+}
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/react-router/v7/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react-router/v7/cypress/e2e/shared/render-count.cy.ts
@@ -19,7 +19,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 2 : 0) + (startTransition ? 1 : 0)
+            update: 2 + (shallow === false ? 2 : 0)
           }
         })
       }
@@ -42,7 +42,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 3 : 0) + (startTransition ? 1 : 0)
+            update: 2 + (shallow === false ? 3 : 0)
           }
         })
       }
@@ -67,8 +67,7 @@ for (const hook of hooks) {
             },
             expected: {
               mount: 1,
-              update:
-                2 + (shallow === false ? 3 : 0) + (startTransition ? 1 : 0)
+              update: 2 + (shallow === false ? 3 : 0)
             }
           })
         }

--- a/packages/e2e/react-router/v7/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react-router/v7/cypress/e2e/shared/render-count.cy.ts
@@ -1,0 +1,78 @@
+import { testRenderCount } from 'e2e-shared/specs/render-count.cy'
+
+const hooks = ['useQueryState', 'useQueryStates'] as const
+const shallows = [true, false] as const
+const histories = ['replace', 'push'] as const
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/no-loader`,
+          description: 'no loader',
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2 + (shallow === false ? 2 : 0) + (startTransition ? 1 : 0)
+          }
+        })
+      }
+    }
+  }
+}
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/sync-loader`,
+          description: 'sync loader',
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2 + (shallow === false ? 3 : 0) + (startTransition ? 1 : 0)
+          }
+        })
+      }
+    }
+  }
+}
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        for (const delay of shallow === false ? [0, 50] : [0]) {
+          testRenderCount({
+            path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/async-loader?delay=${delay}`,
+            description: 'async loader',
+            hook,
+            props: {
+              shallow,
+              history,
+              startTransition,
+              delay
+            },
+            expected: {
+              mount: 1,
+              update:
+                2 + (shallow === false ? 3 : 0) + (startTransition ? 1 : 0)
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/e2e/react-router/v7/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react-router/v7/cypress/e2e/shared/render-count.cy.ts
@@ -42,7 +42,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 3 : 0)
+            update: 2 + (shallow === false ? 2 : 0)
           }
         })
       }
@@ -67,7 +67,7 @@ for (const hook of hooks) {
             },
             expected: {
               mount: 1,
-              update: 2 + (shallow === false ? 3 : 0)
+              update: 2 + (shallow === false ? 2 : 0)
             }
           })
         }

--- a/packages/e2e/react/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react/cypress/e2e/shared/render-count.cy.ts
@@ -1,0 +1,29 @@
+import { testRenderCount } from 'e2e-shared/specs/render-count.cy'
+
+const hooks = ['useQueryState', 'useQueryStates'] as const
+const shallows = [true, false] as const
+const histories = ['replace', 'push'] as const
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of shallow === false
+        ? [false, true]
+        : [false]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}`,
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2
+          }
+        })
+      }
+    }
+  }
+}

--- a/packages/e2e/react/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/react/cypress/e2e/shared/render-count.cy.ts
@@ -7,9 +7,7 @@ const histories = ['replace', 'push'] as const
 for (const hook of hooks) {
   for (const shallow of shallows) {
     for (const history of histories) {
-      for (const startTransition of shallow === false
-        ? [false, true]
-        : [false]) {
+      for (const startTransition of [false, true]) {
         testRenderCount({
           path: `/render-count/${hook}/${shallow}/${history}/${startTransition}`,
           hook,

--- a/packages/e2e/react/src/routes.tsx
+++ b/packages/e2e/react/src/routes.tsx
@@ -21,6 +21,23 @@ const routes: Record<string, React.LazyExoticComponent<() => JSX.Element>> = {
   '/form/useQueryStates':                   lazy(() => import('./routes/form.useQueryStates')),
   '/referential-stability/useQueryState':   lazy(() => import('./routes/referential-stability.useQueryState')),
   '/referential-stability/useQueryStates':  lazy(() => import('./routes/referential-stability.useQueryStates')),
+
+  '/render-count/useQueryState/true/replace/false':   lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/true/replace/true':    lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/true/push/false':      lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/true/push/true':       lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/false/replace/false':  lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/false/replace/true':   lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/false/push/false':     lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryState/false/push/true':      lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/true/replace/false':  lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/true/replace/true':   lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/true/push/false':     lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/true/push/true':      lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/false/replace/false': lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/false/replace/true':  lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/false/push/false':    lazy(() => import('./routes/render-count')),
+  '/render-count/useQueryStates/false/push/true':     lazy(() => import('./routes/render-count')),
 }
 
 export function Router() {

--- a/packages/e2e/react/src/routes/render-count.tsx
+++ b/packages/e2e/react/src/routes/render-count.tsx
@@ -1,0 +1,12 @@
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+import { useMemo } from 'react'
+
+export default function Page() {
+  const params = useMemo(() => {
+    const [_, hook, shallow, history, startTransition] =
+      location.pathname.split('/')
+    return loadParams({ hook, shallow, history, startTransition })
+  }, [])
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/remix/app/routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx
+++ b/packages/e2e/remix/app/routes/render-count.$hook.$shallow.$history.$startTransition.async-loader.tsx
@@ -1,0 +1,21 @@
+import { LoaderFunctionArgs } from '@remix-run/node'
+import { useParams } from '@remix-run/react'
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import {
+  loadParams,
+  loadSearchParams
+} from 'e2e-shared/specs/render-count.params'
+import { setTimeout } from 'node:timers/promises'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { delay } = loadSearchParams(request)
+  if (delay) {
+    await setTimeout(delay)
+  }
+  return null
+}
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/remix/app/routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx
+++ b/packages/e2e/remix/app/routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx
@@ -1,0 +1,8 @@
+import { useParams } from '@remix-run/react'
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/remix/app/routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx
+++ b/packages/e2e/remix/app/routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx
@@ -1,0 +1,12 @@
+import { useParams } from '@remix-run/react'
+import { RenderCount } from 'e2e-shared/specs/render-count'
+import { loadParams } from 'e2e-shared/specs/render-count.params'
+
+export function loader() {
+  return null
+}
+
+export default function Page() {
+  const params = loadParams(useParams())
+  return <RenderCount {...params} />
+}

--- a/packages/e2e/remix/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/remix/cypress/e2e/shared/render-count.cy.ts
@@ -19,7 +19,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 1 : 0)
+            update: 2
           }
         })
       }
@@ -42,7 +42,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 2 : 0)
+            update: 2 + (shallow === false ? 1 : 0)
           }
         })
       }
@@ -67,7 +67,7 @@ for (const hook of hooks) {
             },
             expected: {
               mount: 1,
-              update: 2 + (shallow === false ? 2 : 0)
+              update: 2 + (shallow === false ? 1 : 0)
             }
           })
         }

--- a/packages/e2e/remix/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/remix/cypress/e2e/shared/render-count.cy.ts
@@ -1,0 +1,78 @@
+import { testRenderCount } from 'e2e-shared/specs/render-count.cy'
+
+const hooks = ['useQueryState', 'useQueryStates'] as const
+const shallows = [true, false] as const
+const histories = ['replace', 'push'] as const
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/no-loader`,
+          description: 'no loader',
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2 + (shallow === false ? 1 : 0) + (startTransition ? 1 : 0)
+          }
+        })
+      }
+    }
+  }
+}
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        testRenderCount({
+          path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/sync-loader`,
+          description: 'sync loader',
+          hook,
+          props: {
+            shallow,
+            history,
+            startTransition
+          },
+          expected: {
+            mount: 1,
+            update: 2 + (shallow === false ? 2 : 0) + (startTransition ? 1 : 0)
+          }
+        })
+      }
+    }
+  }
+}
+
+for (const hook of hooks) {
+  for (const shallow of shallows) {
+    for (const history of histories) {
+      for (const startTransition of [false, true]) {
+        for (const delay of shallow === false ? [0, 50] : [0]) {
+          testRenderCount({
+            path: `/render-count/${hook}/${shallow}/${history}/${startTransition}/async-loader?delay=${delay}`,
+            description: 'async loader',
+            hook,
+            props: {
+              shallow,
+              history,
+              startTransition,
+              delay
+            },
+            expected: {
+              mount: 1,
+              update:
+                2 + (shallow === false ? 2 : 0) + (startTransition ? 1 : 0)
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/e2e/remix/cypress/e2e/shared/render-count.cy.ts
+++ b/packages/e2e/remix/cypress/e2e/shared/render-count.cy.ts
@@ -19,7 +19,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 1 : 0) + (startTransition ? 1 : 0)
+            update: 2 + (shallow === false ? 1 : 0)
           }
         })
       }
@@ -42,7 +42,7 @@ for (const hook of hooks) {
           },
           expected: {
             mount: 1,
-            update: 2 + (shallow === false ? 2 : 0) + (startTransition ? 1 : 0)
+            update: 2 + (shallow === false ? 2 : 0)
           }
         })
       }
@@ -67,8 +67,7 @@ for (const hook of hooks) {
             },
             expected: {
               mount: 1,
-              update:
-                2 + (shallow === false ? 2 : 0) + (startTransition ? 1 : 0)
+              update: 2 + (shallow === false ? 2 : 0)
             }
           })
         }

--- a/packages/e2e/shared/create-test.ts
+++ b/packages/e2e/shared/create-test.ts
@@ -6,12 +6,20 @@ export type TestConfig = {
 }
 
 export function createTest(
-  label: string,
+  firstArg: string | { label: string; variants: string },
   implementation: (config: TestConfig) => void
 ) {
   return (config: TestConfig) => {
+    const label = typeof firstArg === 'string' ? firstArg : firstArg.label
+    const variants = typeof firstArg === 'string' ? null : firstArg.variants
     const router = config.nextJsRouter ? `${config.nextJsRouter} router` : null
-    const describeLabel = [label, config.hook, router, config.description]
+    const describeLabel = [
+      label,
+      router,
+      config.hook,
+      variants,
+      config.description
+    ]
       .filter(Boolean)
       .join(' - ')
     describe(describeLabel, implementation.bind(null, config))

--- a/packages/e2e/shared/cypress.config.ts
+++ b/packages/e2e/shared/cypress.config.ts
@@ -20,7 +20,11 @@ export function defineConfig(config: Config) {
         openMode: 0,
         runMode: process.env.CI ? 1 : 0
       },
-      ...config
+      ...config,
+      env: {
+        ...config.env,
+        CI: Boolean(process.env.CI)
+      }
     }
   })
 }

--- a/packages/e2e/shared/specs/render-count.cy.ts
+++ b/packages/e2e/shared/specs/render-count.cy.ts
@@ -1,0 +1,67 @@
+import { createTest, TestConfig } from '../create-test'
+
+type TestRenderCountConfig = TestConfig & {
+  props: {
+    shallow: boolean
+    history: 'push' | 'replace'
+    startTransition: boolean
+    delay?: number
+  }
+  expected: {
+    mount: number
+    update: number
+  }
+}
+
+const stubConsoleLog = {
+  onBeforeLoad(window: any) {
+    cy.stub(window.console, 'log').as('consoleLog')
+  }
+}
+
+function assertLogCount(message: string, expectedCount: number) {
+  cy.get('@consoleLog').then(spy => {
+    // @ts-ignore
+    const matchingLogs = spy.args.filter(args => args[0] === message)
+    expect(matchingLogs.length).to.equal(expectedCount)
+  })
+}
+
+export function testRenderCount({
+  props,
+  expected,
+  ...config
+}: TestRenderCountConfig) {
+  const test = createTest(
+    {
+      label: 'Render count',
+      variants:
+        `shallow: ${props.shallow}, history: ${props.history}, startTransition: ${props.startTransition}` +
+        (props.delay ? `, delay: ${props.delay}ms` : '')
+    },
+    ({ path }) => {
+      it(`should render ${times(expected.mount)} on mount`, () => {
+        cy.visit(path, stubConsoleLog)
+        cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+        assertLogCount('render', expected.mount)
+      })
+      it(`should then render ${times(expected.update)} on updates`, () => {
+        cy.visit(path, stubConsoleLog)
+        cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+        cy.get('button').click()
+        if (props.delay) {
+          cy.wait(props.delay)
+        }
+        assertLogCount('render', expected.mount + expected.update)
+      })
+    }
+  )
+  return test(config)
+}
+
+function times(n: number) {
+  if (n === 1) {
+    return 'once'
+  }
+  return `${n} times`
+}

--- a/packages/e2e/shared/specs/render-count.cy.ts
+++ b/packages/e2e/shared/specs/render-count.cy.ts
@@ -40,22 +40,34 @@ export function testRenderCount({
         (props.delay ? `, delay: ${props.delay}ms` : '')
     },
     ({ path }) => {
-      it(`should render ${times(expected.mount)} on mount`, () => {
-        cy.visit(path, stubConsoleLog)
-        cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
-        assertLogCount('render', expected.mount)
-      })
-      it(`should then render ${times(expected.update)} on updates`, () => {
-        cy.visit(path, stubConsoleLog)
-        cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
-        cy.get('button').click()
-        if (props.delay) {
-          cy.wait(props.delay)
+      it(
+        `should render ${times(expected.mount)} on mount`,
+        {
+          ...(process.env.CI ? { retries: 4 } : undefined)
+        },
+        () => {
+          cy.visit(path, stubConsoleLog)
+          cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+          assertLogCount('render', expected.mount)
         }
-        assertLogCount('render', expected.mount + expected.update)
-        cy.get('#state').should('have.text', 'pass')
-        cy.location('search').should('contain', 'test=pass')
-      })
+      )
+      it(
+        `should then render ${times(expected.update)} on updates`,
+        {
+          ...(process.env.CI ? { retries: 4 } : undefined)
+        },
+        () => {
+          cy.visit(path, stubConsoleLog)
+          cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+          cy.get('button').click()
+          if (props.delay) {
+            cy.wait(props.delay)
+          }
+          assertLogCount('render', expected.mount + expected.update)
+          cy.get('#state').should('have.text', 'pass')
+          cy.location('search').should('contain', 'test=pass')
+        }
+      )
     }
   )
   return test(config)

--- a/packages/e2e/shared/specs/render-count.cy.ts
+++ b/packages/e2e/shared/specs/render-count.cy.ts
@@ -1,4 +1,4 @@
-import { createTest, TestConfig } from '../create-test'
+import { createTest, type TestConfig } from '../create-test'
 
 type TestRenderCountConfig = TestConfig & {
   props: {

--- a/packages/e2e/shared/specs/render-count.cy.ts
+++ b/packages/e2e/shared/specs/render-count.cy.ts
@@ -43,7 +43,7 @@ export function testRenderCount({
       it(
         `should render ${times(expected.mount)} on mount`,
         {
-          ...(process.env.CI ? { retries: 4 } : undefined)
+          ...(Cypress.env('CI') ? { retries: 4 } : undefined)
         },
         () => {
           cy.visit(path, stubConsoleLog)
@@ -54,7 +54,7 @@ export function testRenderCount({
       it(
         `should then render ${times(expected.update)} on updates`,
         {
-          ...(process.env.CI ? { retries: 4 } : undefined)
+          ...(Cypress.env('CI') ? { retries: 4 } : undefined)
         },
         () => {
           cy.visit(path, stubConsoleLog)

--- a/packages/e2e/shared/specs/render-count.cy.ts
+++ b/packages/e2e/shared/specs/render-count.cy.ts
@@ -53,6 +53,11 @@ export function testRenderCount({
           cy.wait(props.delay)
         }
         assertLogCount('render', expected.mount + expected.update)
+        cy.get('#state').should('have.text', 'pass')
+        cy.location('search').should(
+          'eq',
+          `?delay=${props.delay ?? 0}&test=pass`
+        )
       })
     }
   )

--- a/packages/e2e/shared/specs/render-count.cy.ts
+++ b/packages/e2e/shared/specs/render-count.cy.ts
@@ -54,10 +54,7 @@ export function testRenderCount({
         }
         assertLogCount('render', expected.mount + expected.update)
         cy.get('#state').should('have.text', 'pass')
-        cy.location('search').should(
-          'eq',
-          `?delay=${props.delay ?? 0}&test=pass`
-        )
+        cy.location('search').should('contain', 'test=pass')
       })
     }
   )

--- a/packages/e2e/shared/specs/render-count.params.ts
+++ b/packages/e2e/shared/specs/render-count.params.ts
@@ -1,0 +1,29 @@
+import {
+  createLoader,
+  type inferParserType,
+  parseAsBoolean,
+  parseAsInteger,
+  parseAsStringLiteral
+} from 'nuqs/server'
+
+const params = {
+  hook: parseAsStringLiteral([
+    'useQueryState',
+    'useQueryStates'
+  ] as const).withDefault('useQueryState'),
+  shallow: parseAsBoolean.withDefault(true),
+  history: parseAsStringLiteral(['push', 'replace'] as const).withDefault(
+    'replace'
+  ),
+  startTransition: parseAsBoolean.withDefault(false)
+}
+
+const searchParams = {
+  delay: parseAsInteger.withDefault(0)
+}
+
+export type Params = inferParserType<typeof params>
+export type SearchParams = inferParserType<typeof searchParams>
+
+export const loadParams = createLoader(params)
+export const loadSearchParams = createLoader(searchParams)

--- a/packages/e2e/shared/specs/render-count.tsx
+++ b/packages/e2e/shared/specs/render-count.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { parseAsString, useQueryState, useQueryStates } from 'nuqs'
+import { useTransition } from 'react'
+
+type RenderCountProps = {
+  hook: 'useQueryState' | 'useQueryStates'
+  shallow: boolean
+  history: 'push' | 'replace'
+  startTransition: boolean
+}
+
+export function RenderCount({
+  hook,
+  shallow,
+  history,
+  startTransition: enableStartTransition
+}: RenderCountProps) {
+  console.log('render')
+  const startTransition = enableStartTransition ? useTransition()[1] : undefined
+  if (hook === 'useQueryState') {
+    const [, setState] = useQueryState('test', {
+      shallow,
+      history,
+      startTransition
+    })
+    return <button onClick={() => setState('pass')}>Test</button>
+  }
+  if (hook === 'useQueryStates') {
+    const [, setState] = useQueryStates({
+      test: parseAsString.withOptions({ shallow, history, startTransition })
+    })
+    return <button onClick={() => setState({ test: 'pass' })}>Test</button>
+  }
+  return null
+}

--- a/packages/e2e/shared/specs/render-count.tsx
+++ b/packages/e2e/shared/specs/render-count.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { parseAsString, useQueryState, useQueryStates } from 'nuqs'
-import { useTransition } from 'react'
+import { startTransition as reactStartTransition } from 'react'
 
 type RenderCountProps = {
   hook: 'useQueryState' | 'useQueryStates'
@@ -17,7 +17,9 @@ export function RenderCount({
   startTransition: enableStartTransition
 }: RenderCountProps) {
   console.log('render')
-  const startTransition = enableStartTransition ? useTransition()[1] : undefined
+  const startTransition = enableStartTransition
+    ? reactStartTransition
+    : undefined
   let runTest = () => {}
   let state = null
   if (hook === 'useQueryState') {

--- a/packages/e2e/shared/specs/render-count.tsx
+++ b/packages/e2e/shared/specs/render-count.tsx
@@ -18,19 +18,28 @@ export function RenderCount({
 }: RenderCountProps) {
   console.log('render')
   const startTransition = enableStartTransition ? useTransition()[1] : undefined
+  let runTest = () => {}
+  let state = null
   if (hook === 'useQueryState') {
-    const [, setState] = useQueryState('test', {
+    const [testState, setState] = useQueryState('test', {
       shallow,
       history,
       startTransition
     })
-    return <button onClick={() => setState('pass')}>Test</button>
+    runTest = () => setState('pass')
+    state = testState
   }
   if (hook === 'useQueryStates') {
-    const [, setState] = useQueryStates({
+    const [{ test }, setState] = useQueryStates({
       test: parseAsString.withOptions({ shallow, history, startTransition })
     })
-    return <button onClick={() => setState({ test: 'pass' })}>Test</button>
+    runTest = () => setState({ test: 'pass' })
+    state = test
   }
-  return null
+  return (
+    <>
+      <button onClick={runTest}>Test</button>
+      <pre id="state">{state}</pre>
+    </>
+  )
 }

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -54,7 +54,8 @@ export function patchHistory(
   let lastSearchSeen = typeof location === 'object' ? location.search : ''
 
   emitter.on('update', search => {
-    lastSearchSeen = search.toString()
+    const searchString = search.toString()
+    lastSearchSeen = searchString.length ? '?' + searchString : ''
   })
 
   debug(

--- a/packages/nuqs/src/adapters/next/impl.app.ts
+++ b/packages/nuqs/src/adapters/next/impl.app.ts
@@ -12,32 +12,34 @@ export function useNuqsNextAppRouterAdapter(): AdapterInterface {
   const updateUrl: UpdateUrlFunction = useCallback((search, options) => {
     // App router
     startTransition(() => {
-      setOptimisticSearchParams(search)
+      if (!options.shallow) {
+        setOptimisticSearchParams(search)
+      }
+      const url = renderURL(location.origin + location.pathname, search)
+      debug('[nuqs queue (app)] Updating url: %s', url)
+      // First, update the URL locally without triggering a network request,
+      // this allows keeping a reactive URL if the network is slow.
+      const updateMethod =
+        options.history === 'push' ? history.pushState : history.replaceState
+      updateMethod.call(
+        history,
+        // In next@14.1.0, useSearchParams becomes reactive to shallow updates,
+        // but only if passing `null` as the history state.
+        null,
+        '',
+        url
+      )
+      if (options.scroll) {
+        window.scrollTo(0, 0)
+      }
+      if (!options.shallow) {
+        // Call the Next.js router to perform a network request
+        // and re-render server components.
+        router.replace(url, {
+          scroll: false
+        })
+      }
     })
-    const url = renderURL(location.origin + location.pathname, search)
-    debug('[nuqs queue (app)] Updating url: %s', url)
-    // First, update the URL locally without triggering a network request,
-    // this allows keeping a reactive URL if the network is slow.
-    const updateMethod =
-      options.history === 'push' ? history.pushState : history.replaceState
-    updateMethod.call(
-      history,
-      // In next@14.1.0, useSearchParams becomes reactive to shallow updates,
-      // but only if passing `null` as the history state.
-      null,
-      '',
-      url
-    )
-    if (options.scroll) {
-      window.scrollTo(0, 0)
-    }
-    if (!options.shallow) {
-      // Call the Next.js router to perform a network request
-      // and re-render server components.
-      router.replace(url, {
-        scroll: false
-      })
-    }
   }, [])
   return {
     searchParams: optimisticSearchParams,

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
       "env": ["BASE_PATH", "REACT_COMPILER", "E2E_NO_CACHE_ON_RERUN"]
     },
     "e2e-remix#build": {
-      "outputs": ["dist/**", "cypress/**"],
+      "outputs": ["build/**", "cypress/**"],
       "dependsOn": ["^build"],
       "env": ["REACT_COMPILER", "E2E_NO_CACHE_ON_RERUN"]
     },
@@ -27,7 +27,7 @@
       "env": ["REACT_COMPILER", "E2E_NO_CACHE_ON_RERUN"]
     },
     "e2e-react-router-v7#build": {
-      "outputs": ["dist/**", "cypress/**"],
+      "outputs": [".react-router/**", "build/**", "cypress/**"],
       "dependsOn": ["^build"],
       "env": ["REACT_COMPILER", "E2E_NO_CACHE_ON_RERUN"]
     },


### PR DESCRIPTION
The optimal number of renders should be:
- On mount: 1 (with the correct search params)
- On update, with shallow: true (the default): 2 (one for the internal state, and one when the URL has updated)
- On update, with shallow: false: 2 to 3, depending of whether we do optimistic URL updates and the time it takes for the server to respond and "update" the URL again

## Progress

- `useQueryStates` now renders only once on mount (was 2 renders previously)
- `useQueryStates` now renders one less time (detecting query cache hits)
- Fixed a bug in the patch-history caching logic (for React Router & Remix), saving one extra render on `shallow: false`.

<details><summary>Baseline</summary>

```txt
app router - useQueryState - shallow: true, history: replace, startTransition: false should then render 2 times on updates: expected 5 to equal 3 
app router - useQueryState - shallow: true, history: push, startTransition: false should then render 2 times on updates: expected 5 to equal 3 
app router - useQueryStates - shallow: true, history: replace, startTransition: false should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: true, history: replace, startTransition: false should then render 2 times on updates: expected 6 to equal 3
app router - useQueryStates - shallow: true, history: push, startTransition: false should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: true, history: push, startTransition: false should then render 2 times on updates: expected 6 to equal 3
app router - useQueryStates - shallow: false, history: replace, startTransition: false should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: replace, startTransition: false should then render 3 times on updates: expected 5 to equal 4
app router - useQueryStates - shallow: false, history: replace, startTransition: false, delay: 50ms should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: replace, startTransition: false, delay: 50ms should then render 3 times on updates: expected 6 to equal 4
app router - useQueryStates - shallow: false, history: replace, startTransition: true should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: replace, startTransition: true should then render 3 times on updates: expected 5 to equal 4
app router - useQueryStates - shallow: false, history: replace, startTransition: true, delay: 50ms should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: replace, startTransition: true, delay: 50ms should then render 3 times on updates: expected 6 to equal 4
app router - useQueryStates - shallow: false, history: push, startTransition: false should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: push, startTransition: false should then render 3 times on updates: expected 5 to equal 4
app router - useQueryStates - shallow: false, history: push, startTransition: false, delay: 50ms should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: push, startTransition: false, delay: 50ms should then render 3 times on updates: expected 5 to equal 4
app router - useQueryStates - shallow: false, history: push, startTransition: true should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: push, startTransition: true should then render 3 times on updates: expected 5 to equal 4
app router - useQueryStates - shallow: false, history: push, startTransition: true, delay: 50ms should render once on mount: expected 2 to equal 1
app router - useQueryStates - shallow: false, history: push, startTransition: true, delay: 50ms should then render 3 times on updates: expected 6 to equal 4
```

</details>

## Tasks

- [x] Investigate why wrapping URL updates with `startTransition` causes 4 renders in the pages router -> maybe the isLoading flag?
- [x] Add test to React Router based frameworks (there were differences whether the loader function was defined or not, that will require two different pages)
- [x] Add test to React SPA
- [x] Investigate flakiness on [test run](https://github.com/47ng/nuqs/actions/runs/12641628541/job/35224433279?pr=849#step:7:1294) (looks to be caused by CPU load, getting a lot more flakes on older machines when running 5 Cypress instances in parallel)

<details><summary>Click to expand</summary>

```txt
  Render count - app router - useQueryState - shallow: false, history: push, startTransition: true
render
    ✓ should render once on mount (84ms)
render
    (Attempt 1 of 2) should then render 3 times on updates
      cy:command ✔  visit	/app/render-count/useQueryState/false/push/true?delay=0
      cy:command ✔  contains	#hydration-marker, hydrated
      cy:command ✔  assert	expected **<div#hydration-marker>** to be **hidden**
      cy:command ✔  stub-1	log("render")
      cy:command ✔  get	button
      cy:command ✔  click	
      cy:command ✔  stub-1	log("render")
      cy:command ✔  stub-1	log("render")
      cy:command ✔  new url	http://localhost:3001/base/app/render-count/useQueryState/false/push/true?delay=0&test=pass
        cy:fetch ➟  GET http://localhost:3001/base/app/render-count/useQueryState/false/push/true?delay=0&test=pass&_rsc=vqr5f
                    Status: 200
      cy:command ✔  stub-1	log("render")
      cy:command ✔  stub-1	log("render")
      cy:command ✔  get	@consoleLog
      cy:command ✘  assert	expected **5** to equal **4**
                    Actual: 	5
                    Expected: 	4


render
    1) should then render 3 times on updates
      cy:command ✔  visit	/app/render-count/useQueryState/false/push/true?delay=0
      cy:command ✔  contains	#hydration-marker, hydrated
      cy:command ✔  assert	expected **<div#hydration-marker>** to be **hidden**
      cy:command ✔  stub-1	log("render")
      cy:command ✔  get	button
      cy:command ✔  click	
      cy:command ✔  stub-1	log("render")
      cy:command ✔  stub-1	log("render")
      cy:command ✔  new url	http://localhost:3001/base/app/render-count/useQueryState/false/push/true?delay=0&test=pass
        cy:fetch ➟  GET http://localhost:3001/base/app/render-count/useQueryState/false/push/true?delay=0&test=pass&_rsc=vqr5f
                    Status: 200
      cy:command ✔  get	@consoleLog
      cy:command ✘  assert	expected **3** to equal **4**
                    Actual: 	3
                    Expected: 	4
      cy:command ✔  stub-1	log("render")
```

</details>

## Notes

- Render counts are wildly different on React Router versions (6 vs 7 vs Remix), since everything else is the same, it feels like we're testing the frameworks.. At least it gives us a baseline to go down from.
- Defining startTransition almost always causes one extra render. That could be the isLoading flag toggling. It does not cause one in RRv6 though.