### PR TITLE
fix: Allow useQueryStates' state updater function to return null

### DIFF
--- a/packages/nuqs/src/tests/useQueryStates.test-d.ts
+++ b/packages/nuqs/src/tests/useQueryStates.test-d.ts
@@ -25,7 +25,7 @@ describe('types/useQueryStates', () => {
     setState({ a: null }) // Clear an individual key
     setState(null) // Clear all managed keys
     setState(() => ({ a: null }))
-    // setState(() => null) // todo: Enable this test in a separate PR
+    setState(() => null)
   })
   it('allows setting to undefined to leave keys as-is', () => {
     const [, setState] = useQueryStates(parsers)
@@ -53,7 +53,7 @@ describe('types/useQueryStates', () => {
       return {}
     })
     setState(() => ({ a: null, b: null })) // Still allowed to clear it with null (state retuns to default)
-    // setState(() => null)  // todo: Enable this test in a separate PR
+    setState(() => null)
   })
   it('supports inline custom parsers', () => {
     const [state] = useQueryStates({


### PR DESCRIPTION
This would allow conditionally clearing the URL based on the previous values.

![image](https://github.com/user-attachments/assets/fe9ffc05-f4b9-4b21-be5d-fdd0846bbf4e)

Can't think of an immediately practical use-case, but when updating the type testing suite in #867, it felt like a blind spot in the API.