### PR TITLE
fix: React Router stale values after remount

### DIFF
--- a/packages/e2e/shared/specs/conditional-rendering.cy.ts
+++ b/packages/e2e/shared/specs/conditional-rendering.cy.ts
@@ -18,5 +18,14 @@ export const testConditionalRendering = createTest(
       cy.get('button#mount').click()
       cy.get('#state').should('have.text', 'pass')
     })
+    it('should keep the correct state after unmounting and remounting with a different state', () => {
+      cy.visit(path + '?test=init')
+      cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+      cy.get('button#mount').click()
+      cy.get('button#set').click()
+      cy.get('button#unmount').click()
+      cy.get('button#mount').click()
+      cy.get('#state').should('have.text', 'pass')
+    })
   }
 )

--- a/packages/nuqs/src/adapters/react-router/v6.ts
+++ b/packages/nuqs/src/adapters/react-router/v6.ts
@@ -1,19 +1,9 @@
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { createAdapterProvider } from '../lib/context'
 import { createReactRouterBasedAdapter } from '../lib/react-router'
 
-const {
-  enableHistorySync,
-  useNuqsReactRouterBasedAdapter: useNuqsReactRouterV6Adapter,
-  useOptimisticSearchParams
-} = createReactRouterBasedAdapter(
-  'react-router-v6',
-  useNavigate,
-  useSearchParams
-)
-
-export { useOptimisticSearchParams }
-
-export const NuqsAdapter = createAdapterProvider(useNuqsReactRouterV6Adapter)
-
-enableHistorySync()
+export const { NuqsAdapter, useOptimisticSearchParams } =
+  createReactRouterBasedAdapter({
+    adapter: 'react-router-v6',
+    useNavigate,
+    useSearchParams
+  })

--- a/packages/nuqs/src/adapters/react-router/v7.ts
+++ b/packages/nuqs/src/adapters/react-router/v7.ts
@@ -1,19 +1,9 @@
 import { useNavigate, useSearchParams } from 'react-router'
-import { createAdapterProvider } from '../lib/context'
 import { createReactRouterBasedAdapter } from '../lib/react-router'
 
-const {
-  enableHistorySync,
-  useNuqsReactRouterBasedAdapter: useNuqsReactRouterV7Adapter,
-  useOptimisticSearchParams
-} = createReactRouterBasedAdapter(
-  'react-router-v7',
-  useNavigate,
-  useSearchParams
-)
-
-export { useOptimisticSearchParams }
-
-export const NuqsAdapter = createAdapterProvider(useNuqsReactRouterV7Adapter)
-
-enableHistorySync()
+export const { NuqsAdapter, useOptimisticSearchParams } =
+  createReactRouterBasedAdapter({
+    adapter: 'react-router-v7',
+    useNavigate,
+    useSearchParams
+  })

--- a/packages/nuqs/src/adapters/remix.ts
+++ b/packages/nuqs/src/adapters/remix.ts
@@ -1,15 +1,9 @@
 import { useNavigate, useSearchParams } from '@remix-run/react'
-import { createAdapterProvider } from './lib/context'
 import { createReactRouterBasedAdapter } from './lib/react-router'
 
-const {
-  enableHistorySync,
-  useNuqsReactRouterBasedAdapter: useNuqsRemixAdapter,
-  useOptimisticSearchParams
-} = createReactRouterBasedAdapter('remix', useNavigate, useSearchParams)
-
-export { useOptimisticSearchParams }
-
-export const NuqsAdapter = createAdapterProvider(useNuqsRemixAdapter)
-
-enableHistorySync()
+export const { NuqsAdapter, useOptimisticSearchParams } =
+  createReactRouterBasedAdapter({
+    adapter: 'remix',
+    useNavigate,
+    useSearchParams
+  })


### PR DESCRIPTION
It looks like `useSearchParams`' `defaultInit` argument is cached on the first call and not re-evaluated when mounting subsequent components, causing those re-mounted components to have a stale optimistic search params state.

Closes #881.