### PR TITLE
feat: Full-page navigation option for `shallow: false` updates in React SPA

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,13 +121,13 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   e2e-react:
-    name: E2E (react-reload-${{ matrix.reload-on-shallow-false }})
+    name: E2E (react-fpn-${{ matrix.full-page-nav-on-shallow-false }})
     runs-on: ubuntu-22.04-arm
     needs: [ci-core]
     strategy:
       fail-fast: false
       matrix:
-        reload-on-shallow-false: [false, true]
+        full-page-nav-on-shallow-false: [false, true]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
@@ -143,19 +143,19 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           E2E_NO_CACHE_ON_RERUN: ${{ github.run_attempt }}
-          RELOAD_ON_SHALLOW_FALSE: ${{ matrix.reload-on-shallow-false }}
+          FULL_PAGE_NAV_ON_SHALLOW_FALSE: ${{ matrix.full-page-nav-on-shallow-false }}
       - name: Save Cypress artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         if: failure()
         with:
           path: packages/e2e/react/cypress/screenshots
-          name: ci-react-reload-${{ matrix.reload-on-shallow-false }}
+          name: ci-react-fpn-${{ matrix.full-page-nav-on-shallow-false }}
       - uses: 47ng/actions-slack-notify@main
         name: Notify on Slack
         if: failure()
         with:
           status: ${{ job.status }}
-          jobName: react-reload-${{ matrix.reload-on-shallow-false }}
+          jobName: react-fpn-${{ matrix.full-page-nav-on-shallow-false }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,9 +121,13 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   e2e-react:
-    name: E2E (react)
+    name: E2E (react-reload-${{ matrix.reload-on-shallow-false }})
     runs-on: ubuntu-22.04-arm
     needs: [ci-core]
+    strategy:
+      fail-fast: false
+      matrix:
+        reload-on-shallow-false: [false, true]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
@@ -139,18 +143,19 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           E2E_NO_CACHE_ON_RERUN: ${{ github.run_attempt }}
+          RELOAD_ON_SHALLOW_FALSE: ${{ matrix.reload-on-shallow-false }}
       - name: Save Cypress artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         if: failure()
         with:
           path: packages/e2e/react/cypress/screenshots
-          name: ci-react
+          name: ci-react-reload-${{ matrix.reload-on-shallow-false }}
       - uses: 47ng/actions-slack-notify@main
         name: Notify on Slack
         if: failure()
         with:
           status: ${{ job.status }}
-          jobName: react
+          jobName: react-reload-${{ matrix.reload-on-shallow-false }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -94,9 +94,9 @@ updating query state configured with `shallow: false{:ts}`, to notify the web se
 that the URL state has changed, if it needs it for server-side rendering other
 parts of the application than the static React bundle:
 
-```tsx title="src/main.tsx" /reloadPageOnShallowFalseUpdates/
+```tsx title="src/main.tsx" /fullPageNavigationOnShallowFalseUpdates/
 createRoot(document.getElementById('root')!).render(
-  <NuqsAdapter reloadPageOnShallowFalseUpdates>
+  <NuqsAdapter fullPageNavigationOnShallowFalseUpdates>
     <App />
   </NuqsAdapter>
 )

--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -86,8 +86,8 @@ createRoot(document.getElementById('root')!).render(
 )
 ```
 
-Note: because there is no known server in this configuration, options
-like [`shallow: false{:ts}`](./options#shallow) will have no effect.
+Note: because there is no known server in this configuration, the
+[`shallow: false{:ts}`](./options#shallow) option will have no effect.
 
 Since `nuqs@2.4.0`, you can specify a flag to perform a full-page navigation when
 updating query state configured with `shallow: false{:ts}`, to notify the web server

--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -86,6 +86,25 @@ createRoot(document.getElementById('root')!).render(
 )
 ```
 
+Note: because there is no known server in this configuration, options
+like [`shallow: false{:ts}`](./options#shallow) will have no effect.
+
+Since `nuqs@2.4.0`, you can specify a flag to perform a full-page navigation when
+updating query state configured with `shallow: false{:ts}`, to notify the web server
+that the URL state has changed, if it needs it for server-side rendering other
+parts of the application than the static React bundle:
+
+```tsx title="src/main.tsx" /reloadPageOnShallowFalseUpdates/
+createRoot(document.getElementById('root')!).render(
+  <NuqsAdapter reloadPageOnShallowFalseUpdates>
+    <App />
+  </NuqsAdapter>
+)
+```
+
+This may be useful for servers not written in JavaScript, like Django (Python),
+Rails (Ruby), Laravel (PHP), Phoenix (Elixir) etc...
+
 ## Remix
 
 ```tsx title="app/root.tsx"

--- a/packages/e2e/react/src/main.tsx
+++ b/packages/e2e/react/src/main.tsx
@@ -8,7 +8,11 @@ enableHistorySync()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <NuqsAdapter>
+    <NuqsAdapter
+      reloadPageOnShallowFalseUpdates={
+        process.env.RELOAD_ON_SHALLOW_FALSE === 'true'
+      }
+    >
       <RootLayout>
         <Router />
       </RootLayout>

--- a/packages/e2e/react/src/main.tsx
+++ b/packages/e2e/react/src/main.tsx
@@ -9,8 +9,8 @@ enableHistorySync()
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <NuqsAdapter
-      reloadPageOnShallowFalseUpdates={
-        process.env.RELOAD_ON_SHALLOW_FALSE === 'true'
+      fullPageNavigationOnShallowFalseUpdates={
+        process.env.FULL_PAGE_NAV_ON_SHALLOW_FALSE === 'true'
       }
     >
       <RootLayout>

--- a/packages/e2e/react/vite.config.ts
+++ b/packages/e2e/react/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig(({ mode }) => {
       sourcemap: true
     },
     define: {
-      'process.env.RELOAD_ON_SHALLOW_FALSE': JSON.stringify(
-        env.RELOAD_ON_SHALLOW_FALSE
+      'process.env.FULL_PAGE_NAV_ON_SHALLOW_FALSE': JSON.stringify(
+        env.FULL_PAGE_NAV_ON_SHALLOW_FALSE
       )
     }
   }

--- a/packages/e2e/react/vite.config.ts
+++ b/packages/e2e/react/vite.config.ts
@@ -1,11 +1,19 @@
 import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 
 // https://vitejs.dev/config/
-export default defineConfig(() => ({
-  plugins: [react()],
-  build: {
-    target: 'es2022',
-    sourcemap: true
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    build: {
+      target: 'es2022',
+      sourcemap: true
+    },
+    define: {
+      'process.env.RELOAD_ON_SHALLOW_FALSE': JSON.stringify(
+        env.RELOAD_ON_SHALLOW_FALSE
+      )
+    }
   }
-}))
+})

--- a/packages/nuqs/src/adapters/react.ts
+++ b/packages/nuqs/src/adapters/react.ts
@@ -15,11 +15,11 @@ import { patchHistory, type SearchParamsSyncEmitter } from './lib/patch-history'
 
 const emitter: SearchParamsSyncEmitter = mitt()
 
-function generateUpdateUrlFn(reloadPageOnShallowFalseUpdates: boolean) {
+function generateUpdateUrlFn(fullPageNavigationOnShallowFalseUpdates: boolean) {
   return function updateUrl(search: URLSearchParams, options: AdapterOptions) {
     const url = new URL(location.href)
     url.search = renderQueryString(search)
-    if (reloadPageOnShallowFalseUpdates && options.shallow === false) {
+    if (fullPageNavigationOnShallowFalseUpdates && options.shallow === false) {
       const method =
         options.history === 'push' ? location.assign : location.replace
       method.call(location, url)
@@ -36,11 +36,11 @@ function generateUpdateUrlFn(reloadPageOnShallowFalseUpdates: boolean) {
 }
 
 const NuqsReactAdapterContext = createContext({
-  reloadPageOnShallowFalseUpdates: false
+  fullPageNavigationOnShallowFalseUpdates: false
 })
 
 function useNuqsReactAdapter() {
-  const { reloadPageOnShallowFalseUpdates } = useContext(
+  const { fullPageNavigationOnShallowFalseUpdates } = useContext(
     NuqsReactAdapterContext
   )
   const [searchParams, setSearchParams] = useState(() => {
@@ -63,8 +63,8 @@ function useNuqsReactAdapter() {
     }
   }, [])
   const updateUrl = useMemo(
-    () => generateUpdateUrlFn(reloadPageOnShallowFalseUpdates),
-    [reloadPageOnShallowFalseUpdates]
+    () => generateUpdateUrlFn(fullPageNavigationOnShallowFalseUpdates),
+    [fullPageNavigationOnShallowFalseUpdates]
   )
   return {
     searchParams,
@@ -76,14 +76,14 @@ const NuqsReactAdapter = createAdapterProvider(useNuqsReactAdapter)
 
 export function NuqsAdapter({
   children,
-  reloadPageOnShallowFalseUpdates = false
+  fullPageNavigationOnShallowFalseUpdates = false
 }: {
   children: ReactNode
-  reloadPageOnShallowFalseUpdates?: boolean
+  fullPageNavigationOnShallowFalseUpdates?: boolean
 }) {
   return createElement(
     NuqsReactAdapterContext.Provider,
-    { value: { reloadPageOnShallowFalseUpdates } },
+    { value: { fullPageNavigationOnShallowFalseUpdates } },
     createElement(NuqsReactAdapter, null, children)
   )
 }

--- a/packages/nuqs/src/adapters/react.ts
+++ b/packages/nuqs/src/adapters/react.ts
@@ -1,5 +1,13 @@
 import mitt from 'mitt'
-import { useEffect, useState } from 'react'
+import {
+  createContext,
+  createElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react'
 import { renderQueryString } from '../url-encoding'
 import { createAdapterProvider } from './lib/context'
 import type { AdapterOptions } from './lib/defs'
@@ -7,19 +15,34 @@ import { patchHistory, type SearchParamsSyncEmitter } from './lib/patch-history'
 
 const emitter: SearchParamsSyncEmitter = mitt()
 
-function updateUrl(search: URLSearchParams, options: AdapterOptions) {
-  const url = new URL(location.href)
-  url.search = renderQueryString(search)
-  const method =
-    options.history === 'push' ? history.pushState : history.replaceState
-  method.call(history, history.state, '', url)
-  emitter.emit('update', search)
-  if (options.scroll === true) {
-    window.scrollTo({ top: 0 })
+function generateUpdateUrlFn(reloadPageOnShallowFalseUpdates: boolean) {
+  return function updateUrl(search: URLSearchParams, options: AdapterOptions) {
+    const url = new URL(location.href)
+    url.search = renderQueryString(search)
+    if (reloadPageOnShallowFalseUpdates && options.shallow === false) {
+      const method =
+        options.history === 'push' ? location.assign : location.replace
+      method.call(location, url)
+    } else {
+      const method =
+        options.history === 'push' ? history.pushState : history.replaceState
+      method.call(history, history.state, '', url)
+    }
+    emitter.emit('update', search)
+    if (options.scroll === true) {
+      window.scrollTo({ top: 0 })
+    }
   }
 }
 
+const NuqsReactAdapterContext = createContext({
+  reloadPageOnShallowFalseUpdates: false
+})
+
 function useNuqsReactAdapter() {
+  const { reloadPageOnShallowFalseUpdates } = useContext(
+    NuqsReactAdapterContext
+  )
   const [searchParams, setSearchParams] = useState(() => {
     if (typeof location === 'undefined') {
       return new URLSearchParams()
@@ -39,13 +62,31 @@ function useNuqsReactAdapter() {
       window.removeEventListener('popstate', onPopState)
     }
   }, [])
+  const updateUrl = useMemo(
+    () => generateUpdateUrlFn(reloadPageOnShallowFalseUpdates),
+    [reloadPageOnShallowFalseUpdates]
+  )
   return {
     searchParams,
     updateUrl
   }
 }
 
-export const NuqsAdapter = createAdapterProvider(useNuqsReactAdapter)
+const NuqsReactAdapter = createAdapterProvider(useNuqsReactAdapter)
+
+export function NuqsAdapter({
+  children,
+  reloadPageOnShallowFalseUpdates = false
+}: {
+  children: ReactNode
+  reloadPageOnShallowFalseUpdates?: boolean
+}) {
+  return createElement(
+    NuqsReactAdapterContext.Provider,
+    { value: { reloadPageOnShallowFalseUpdates } },
+    createElement(NuqsReactAdapter, null, children)
+  )
+}
 
 /**
  * Opt-in to syncing shallow updates of the URL with the useOptimisticSearchParams hook.

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,7 @@
       "outputs": ["dist/**", "cypress/**"],
       "dependsOn": ["^build"],
       "env": [
-        "RELOAD_ON_SHALLOW_FALSE",
+        "FULL_PAGE_NAV_ON_SHALLOW_FALSE",
         "REACT_COMPILER",
         "E2E_NO_CACHE_ON_RERUN"
       ]

--- a/turbo.json
+++ b/turbo.json
@@ -34,7 +34,11 @@
     "e2e-react#build": {
       "outputs": ["dist/**", "cypress/**"],
       "dependsOn": ["^build"],
-      "env": ["REACT_COMPILER", "E2E_NO_CACHE_ON_RERUN"]
+      "env": [
+        "RELOAD_ON_SHALLOW_FALSE",
+        "REACT_COMPILER",
+        "E2E_NO_CACHE_ON_RERUN"
+      ]
     },
     "docs#build": {
       "outputs": [".next/**", "!.next/cache/**"],


### PR DESCRIPTION
This allows using the React SPA adapter with a backend server catching the search param updates configured with `shallow: false`. For example, this can be useful when paired with a server written in other languages than JavaScript: Rails, Laravel, Django, Phoenix etc, that serves a statically built React SPA bundle.

It's disabled by default to keep compatibility with existing code (where `shallow: false` doesn't do anything), but it might be switched on by default in nuqs@3.0.0 (TBC).

## Usage

```tsx
import { NuqsAdapter } from 'nuqs/adapters/react'
import { createRoot } from 'react-dom/client'

createRoot(document.getElementById('root')!).render(
  <NuqsAdapter reloadPageOnShallowFalseUpdates>
    <App />
  </NuqsAdapter>
)
```

## Tasks

- [x] Add e2e test (might require matricing the e2e-react job)
- [x] Add docs
- [x] Update the branch protection before merging
- ~Do a test with Django or Phoenix~