### PR TITLE
chore: Move type tests away from src

### DIFF
--- a/packages/nuqs/tests/cache.test-d.ts
+++ b/packages/nuqs/tests/cache.test-d.ts
@@ -4,7 +4,7 @@ import {
   parseAsBoolean,
   parseAsInteger,
   parseAsString
-} from '../../dist/server'
+} from '../dist/server'
 
 describe('types/cache', () => {
   const cache = createSearchParamsCache({

--- a/packages/nuqs/tests/parsers.test-d.ts
+++ b/packages/nuqs/tests/parsers.test-d.ts
@@ -14,7 +14,7 @@ import {
   parseAsStringLiteral,
   parseAsTimestamp,
   type inferParserType
-} from '../../dist'
+} from '../dist'
 
 describe('types/parsers', () => {
   test('parseAsString', () => {

--- a/packages/nuqs/tests/serializer.test-d.ts
+++ b/packages/nuqs/tests/serializer.test-d.ts
@@ -1,5 +1,5 @@
 import { assertType, describe, it } from 'vitest'
-import { createSerializer, parseAsInteger, parseAsString } from '../../dist'
+import { createSerializer, parseAsInteger, parseAsString } from '../dist'
 
 describe('types/serializer', () => {
   const serialize = createSerializer({

--- a/packages/nuqs/tests/useQueryState.test-d.ts
+++ b/packages/nuqs/tests/useQueryState.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { parseAsString, useQueryState } from '../../dist'
+import { parseAsString, useQueryState } from '../dist'
 
 describe('types/useQueryState', () => {
   it('has a nullable string state by default', () => {

--- a/packages/nuqs/tests/useQueryStates.test-d.ts
+++ b/packages/nuqs/tests/useQueryStates.test-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import { parseAsInteger, parseAsString, useQueryStates } from '../../dist'
+import { parseAsInteger, parseAsString, useQueryStates } from '../dist'
 
 describe('types/useQueryStates', () => {
   const parsers = {

--- a/packages/nuqs/tsconfig.build.json
+++ b/packages/nuqs/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
-  "exclude": ["src/tests", "src/**/*.test.ts", "src/**/*.test.tsx"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
There is no need for them to be in src since they test against the built types in dist.

Moving them out cleans it all up and allows for shorter relative import paths.