### PR TITLE
fix: Ship react-router v6/v7 .d.ts redirects on NPM

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -41,6 +41,8 @@
     "adapters/next/pages.d.ts",
     "adapters/remix.d.ts",
     "adapters/react-router.d.ts",
+    "adapters/react-router/v6.d.ts",
+    "adapters/react-router/v7.d.ts",
     "adapters/custom.d.ts",
     "adapters/testing.d.ts",
     "esm-only.cjs"


### PR DESCRIPTION
Somehow these slipped out of the `files` definition, doesn't seem to have caused issues but added back for consistency.