### PR TITLE
test: Add multitenancy test for Next.js

### DIFF
--- a/packages/e2e/next/cypress/e2e/multitenant.cy.ts
+++ b/packages/e2e/next/cypress/e2e/multitenant.cy.ts
@@ -1,12 +1,16 @@
 import { createTest, type TestConfig } from 'e2e-shared/create-test'
-import { getShallowUrl } from 'e2e-shared/specs/shallow.defs'
+import { getOptionsUrl } from 'e2e-shared/lib/options'
 
-function testMultiTenant(options: TestConfig) {
+function testMultiTenant(
+  options: TestConfig & {
+    expectedPathname: string
+  }
+) {
   const factory = createTest('Multitenant', ({ path }) => {
     for (const shallow of [true, false]) {
       for (const history of ['replace', 'push'] as const) {
         it(`Updates with ({ shallow: ${shallow}, history: ${history} })`, () => {
-          cy.visit(getShallowUrl(path, { shallow, history }))
+          cy.visit(getOptionsUrl(path, { shallow, history }))
           cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
           cy.get('#client-state').should('be.empty')
           cy.get('#server-state').should('be.empty')
@@ -14,9 +18,7 @@ function testMultiTenant(options: TestConfig) {
           cy.get('#server-tenant').should('have.text', 'david')
           cy.get('#router-pathname').should(
             'have.text',
-            options.nextJsRouter === 'pages'
-              ? '/pages/multitenant/[tenant]'
-              : '/app/multitenant'
+            options.expectedPathname
           )
           cy.get('button').click()
           cy.get('#client-state').should('have.text', 'pass')
@@ -24,9 +26,7 @@ function testMultiTenant(options: TestConfig) {
           cy.get('#server-tenant').should('have.text', 'david')
           cy.get('#router-pathname').should(
             'have.text',
-            options.nextJsRouter === 'pages'
-              ? '/pages/multitenant/[tenant]'
-              : '/app/multitenant'
+            options.expectedPathname
           )
           if (shallow === false) {
             cy.get('#server-state').should('have.text', 'pass')
@@ -43,9 +43,7 @@ function testMultiTenant(options: TestConfig) {
           cy.get('#server-state').should('be.empty')
           cy.get('#router-pathname').should(
             'have.text',
-            options.nextJsRouter === 'pages'
-              ? '/pages/multitenant/[tenant]'
-              : '/app/multitenant'
+            options.expectedPathname
           )
         })
       }
@@ -57,10 +55,14 @@ function testMultiTenant(options: TestConfig) {
 
 testMultiTenant({
   path: '/app/multitenant',
-  nextJsRouter: 'app'
+  nextJsRouter: 'app',
+  description: 'Dynamic route',
+  expectedPathname: '/app/multitenant'
 })
 
 testMultiTenant({
   path: '/pages/multitenant',
-  nextJsRouter: 'pages'
+  nextJsRouter: 'pages',
+  description: 'Dynamic route',
+  expectedPathname: '/pages/multitenant/[tenant]'
 })

--- a/packages/e2e/next/cypress/e2e/multitenant.cy.ts
+++ b/packages/e2e/next/cypress/e2e/multitenant.cy.ts
@@ -1,0 +1,66 @@
+import { createTest, type TestConfig } from 'e2e-shared/create-test'
+import { getShallowUrl } from 'e2e-shared/specs/shallow.defs'
+
+function testMultiTenant(options: TestConfig) {
+  const factory = createTest('Multitenant', ({ path }) => {
+    for (const shallow of [true, false]) {
+      for (const history of ['replace', 'push'] as const) {
+        it(`Updates with ({ shallow: ${shallow}, history: ${history} })`, () => {
+          cy.visit(getShallowUrl(path, { shallow, history }))
+          cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+          cy.get('#client-state').should('be.empty')
+          cy.get('#server-state').should('be.empty')
+          cy.get('#client-tenant').should('have.text', 'david')
+          cy.get('#server-tenant').should('have.text', 'david')
+          cy.get('#router-pathname').should(
+            'have.text',
+            options.nextJsRouter === 'pages'
+              ? '/pages/multitenant/[tenant]'
+              : '/app/multitenant'
+          )
+          cy.get('button').click()
+          cy.get('#client-state').should('have.text', 'pass')
+          cy.get('#client-tenant').should('have.text', 'david')
+          cy.get('#server-tenant').should('have.text', 'david')
+          cy.get('#router-pathname').should(
+            'have.text',
+            options.nextJsRouter === 'pages'
+              ? '/pages/multitenant/[tenant]'
+              : '/app/multitenant'
+          )
+          if (shallow === false) {
+            cy.get('#server-state').should('have.text', 'pass')
+          } else {
+            cy.get('#server-state').should('be.empty')
+          }
+          if (history !== 'push') {
+            return
+          }
+          cy.go('back')
+          cy.get('#client-tenant').should('have.text', 'david')
+          cy.get('#server-tenant').should('have.text', 'david')
+          cy.get('#client-state').should('be.empty')
+          cy.get('#server-state').should('be.empty')
+          cy.get('#router-pathname').should(
+            'have.text',
+            options.nextJsRouter === 'pages'
+              ? '/pages/multitenant/[tenant]'
+              : '/app/multitenant'
+          )
+        })
+      }
+    }
+  })
+
+  return factory(options)
+}
+
+testMultiTenant({
+  path: '/app/multitenant',
+  nextJsRouter: 'app'
+})
+
+testMultiTenant({
+  path: '/pages/multitenant',
+  nextJsRouter: 'pages'
+})

--- a/packages/e2e/next/cypress/e2e/shared/dynamic-segments.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/dynamic-segments.cy.ts
@@ -1,0 +1,77 @@
+import { testDynamicSegments } from 'e2e-shared/specs/dynamic-segments.cy'
+
+testDynamicSegments({
+  path: '/app/dynamic-segments/dynamic/segment',
+  expectedSegments: ['segment'],
+  nextJsRouter: 'app'
+})
+
+testDynamicSegments({
+  path: '/pages/dynamic-segments/dynamic/segment',
+  expectedSegments: ['segment'],
+  nextJsRouter: 'pages'
+})
+
+// Catch-all --
+
+testDynamicSegments({
+  path: '/app/dynamic-segments/catch-all/foo',
+  expectedSegments: ['foo'],
+  nextJsRouter: 'app'
+})
+
+testDynamicSegments({
+  path: '/pages/dynamic-segments/catch-all/foo',
+  expectedSegments: ['foo'],
+  nextJsRouter: 'pages'
+})
+
+testDynamicSegments({
+  path: '/app/dynamic-segments/catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c'],
+  nextJsRouter: 'app'
+})
+
+testDynamicSegments({
+  path: '/pages/dynamic-segments/catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c'],
+  nextJsRouter: 'pages'
+})
+
+// Optional catch-all --
+
+testDynamicSegments({
+  path: '/app/dynamic-segments/optional-catch-all', // no segments
+  expectedSegments: [],
+  nextJsRouter: 'app'
+})
+
+testDynamicSegments({
+  path: '/pages/dynamic-segments/optional-catch-all', // no segments
+  expectedSegments: [],
+  nextJsRouter: 'pages'
+})
+
+testDynamicSegments({
+  path: '/app/dynamic-segments/optional-catch-all/foo',
+  expectedSegments: ['foo'],
+  nextJsRouter: 'app'
+})
+
+testDynamicSegments({
+  path: '/pages/dynamic-segments/optional-catch-all/foo',
+  expectedSegments: ['foo'],
+  nextJsRouter: 'pages'
+})
+
+testDynamicSegments({
+  path: '/app/dynamic-segments/optional-catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c'],
+  nextJsRouter: 'app'
+})
+
+testDynamicSegments({
+  path: '/pages/dynamic-segments/optional-catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c'],
+  nextJsRouter: 'pages'
+})

--- a/packages/e2e/next/cypress/e2e/shared/pretty-urls.cy.ts
+++ b/packages/e2e/next/cypress/e2e/shared/pretty-urls.cy.ts
@@ -1,0 +1,11 @@
+import { testPrettyUrls } from 'e2e-shared/specs/pretty-urls.cy'
+
+testPrettyUrls({
+  path: '/app/pretty-urls',
+  nextJsRouter: 'app'
+})
+
+testPrettyUrls({
+  path: '/pages/pretty-urls',
+  nextJsRouter: 'pages'
+})

--- a/packages/e2e/next/src/app/app/(shared)/dynamic-segments/catch-all/[...segments]/client.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/dynamic-segments/catch-all/[...segments]/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { DisplaySegments } from 'e2e-shared/specs/dynamic-segments'
+import { useParams } from 'next/navigation'
+import { ReactNode } from 'react'
+
+export function ClientSegment({ children }: { children?: ReactNode }) {
+  const params = useParams()
+  const segments = params?.segments as string[]
+  return (
+    <>
+      {children}
+      <DisplaySegments environment="client" segments={segments} />
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/dynamic-segments/catch-all/[...segments]/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/dynamic-segments/catch-all/[...segments]/page.tsx
@@ -1,0 +1,34 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString, type SearchParams } from 'nuqs/server'
+import { Suspense } from 'react'
+import { ClientSegment } from './client'
+
+type PageProps = {
+  params: Promise<{ segments: string[] }>
+  searchParams: Promise<SearchParams>
+}
+
+const loadTest = createLoader({
+  test: parseAsString
+})
+
+export default async function DynamicPage(props: PageProps) {
+  const searchParams = await props.searchParams
+  const { segments } = await props.params
+  const { test: serverState } = loadTest(searchParams)
+  return (
+    <>
+      <Suspense>
+        <UrlControls>
+          <Display environment="server" state={serverState} />
+        </UrlControls>
+      </Suspense>
+      <Suspense>
+        <ClientSegment>
+          <DisplaySegments environment="server" segments={segments} />
+        </ClientSegment>
+      </Suspense>
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/dynamic-segments/dynamic/[segment]/client.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/dynamic-segments/dynamic/[segment]/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { DisplaySegments } from 'e2e-shared/specs/dynamic-segments'
+import { useParams } from 'next/navigation'
+import { ReactNode } from 'react'
+
+export function ClientSegment({ children }: { children?: ReactNode }) {
+  const params = useParams()
+  const segment = params?.segment as string
+  return (
+    <>
+      {children}
+      <DisplaySegments environment="client" segments={[segment]} />
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/dynamic-segments/dynamic/[segment]/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/dynamic-segments/dynamic/[segment]/page.tsx
@@ -1,0 +1,34 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString, type SearchParams } from 'nuqs/server'
+import { Suspense } from 'react'
+import { ClientSegment } from './client'
+
+type PageProps = {
+  params: Promise<{ segment: string }>
+  searchParams: Promise<SearchParams>
+}
+
+const loadTest = createLoader({
+  test: parseAsString
+})
+
+export default async function DynamicPage(props: PageProps) {
+  const searchParams = await props.searchParams
+  const { segment } = await props.params
+  const { test: serverState } = loadTest(searchParams)
+  return (
+    <>
+      <Suspense>
+        <UrlControls>
+          <Display environment="server" state={serverState} />
+        </UrlControls>
+      </Suspense>
+      <Suspense>
+        <ClientSegment>
+          <DisplaySegments environment="server" segments={[segment]} />
+        </ClientSegment>
+      </Suspense>
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/dynamic-segments/optional-catch-all/[[...segments]]/client.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/dynamic-segments/optional-catch-all/[[...segments]]/client.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { DisplaySegments } from 'e2e-shared/specs/dynamic-segments'
+import { useParams } from 'next/navigation'
+import { ReactNode } from 'react'
+
+export function ClientSegment({ children }: { children?: ReactNode }) {
+  const params = useParams()
+  const segments = params?.segments as string[]
+  return (
+    <>
+      {children}
+      <DisplaySegments environment="client" segments={segments} />
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/dynamic-segments/optional-catch-all/[[...segments]]/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/dynamic-segments/optional-catch-all/[[...segments]]/page.tsx
@@ -1,0 +1,34 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString, type SearchParams } from 'nuqs/server'
+import { Suspense } from 'react'
+import { ClientSegment } from './client'
+
+type PageProps = {
+  params: Promise<{ segments: string[] }>
+  searchParams: Promise<SearchParams>
+}
+
+const loadTest = createLoader({
+  test: parseAsString
+})
+
+export default async function DynamicPage(props: PageProps) {
+  const searchParams = await props.searchParams
+  const { segments } = await props.params
+  const { test: serverState } = loadTest(searchParams)
+  return (
+    <>
+      <Suspense>
+        <UrlControls>
+          <Display environment="server" state={serverState} />
+        </UrlControls>
+      </Suspense>
+      <Suspense>
+        <ClientSegment>
+          <DisplaySegments environment="server" segments={segments} />
+        </ClientSegment>
+      </Suspense>
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/pretty-urls/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/pretty-urls/page.tsx
@@ -1,0 +1,10 @@
+import { PrettyUrls } from 'e2e-shared/specs/pretty-urls'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <PrettyUrls />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/app/app/(shared)/shallow/useQueryState/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/shallow/useQueryState/page.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import {
   createSearchParamsCache,
   parseAsString,
@@ -29,7 +29,7 @@ export default async function Page({ searchParams }: PageProps) {
       <Suspense>
         <ShallowUseQueryState />
       </Suspense>
-      <ShallowDisplay environment="server" state={cache.get('state')} />
+      <Display environment="server" state={cache.get('state')} />
     </>
   )
 }

--- a/packages/e2e/next/src/app/app/(shared)/shallow/useQueryStates/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/shallow/useQueryStates/page.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryStates } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import {
   createSearchParamsCache,
   parseAsString,
@@ -29,7 +29,7 @@ export default async function Page({ searchParams }: PageProps) {
       <Suspense>
         <ShallowUseQueryStates />
       </Suspense>
-      <ShallowDisplay environment="server" state={cache.get('state')} />
+      <Display environment="server" state={cache.get('state')} />
     </>
   )
 }

--- a/packages/e2e/next/src/app/app/multitenant/[tenant]/client-tenant.tsx
+++ b/packages/e2e/next/src/app/app/multitenant/[tenant]/client-tenant.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useParams, usePathname } from 'next/navigation'
+
+export function TenantClient() {
+  const params = useParams()
+  const pathname = usePathname()
+  return (
+    <>
+      <p id="client-tenant">{params?.tenant}</p>
+      <p id="router-pathname">{pathname}</p>
+    </>
+  )
+}

--- a/packages/e2e/next/src/app/app/multitenant/[tenant]/page.tsx
+++ b/packages/e2e/next/src/app/app/multitenant/[tenant]/page.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import {
   createSearchParamsCache,
   parseAsString,
@@ -36,7 +36,7 @@ export default async function TenantPage({ params, searchParams }: PageProps) {
       <Suspense>
         <ShallowUseQueryState />
       </Suspense>
-      <ShallowDisplay environment="server" state={cache.get('state')} />
+      <Display environment="server" state={cache.get('state')} />
       <p id="server-tenant">{tenant}</p>
       <Suspense>
         <TenantClient />

--- a/packages/e2e/next/src/app/app/multitenant/[tenant]/page.tsx
+++ b/packages/e2e/next/src/app/app/multitenant/[tenant]/page.tsx
@@ -1,0 +1,46 @@
+import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
+import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
+import {
+  createSearchParamsCache,
+  parseAsString,
+  type SearchParams
+} from 'nuqs/server'
+import { Suspense } from 'react'
+import { TenantClient } from './client-tenant'
+
+type PageProps = {
+  params: Promise<{ tenant: string }>
+  searchParams: Promise<SearchParams>
+}
+
+const cache = createSearchParamsCache(
+  {
+    state: parseAsString
+  },
+  {
+    urlKeys: {
+      state: 'test'
+    }
+  }
+)
+
+export default async function TenantPage({ params, searchParams }: PageProps) {
+  const { tenant } = await params
+  if (!tenant) {
+    return <div>Error: Tenant not found.</div>
+  }
+  await cache.parse(searchParams)
+
+  return (
+    <>
+      <Suspense>
+        <ShallowUseQueryState />
+      </Suspense>
+      <ShallowDisplay environment="server" state={cache.get('state')} />
+      <p id="server-tenant">{tenant}</p>
+      <Suspense>
+        <TenantClient />
+      </Suspense>
+    </>
+  )
+}

--- a/packages/e2e/next/src/middleware.ts
+++ b/packages/e2e/next/src/middleware.ts
@@ -9,12 +9,18 @@ export default async function middleware(req: NextRequest) {
   const tenant = 'david'
   const pathname = req.nextUrl.pathname
   if (pathname === '/app/multitenant') {
-    const url = new URL(`/app/multitenant/${tenant}`, req.url)
+    const url = new URL(
+      `${req.nextUrl.basePath}/app/multitenant/${tenant}`,
+      req.url
+    )
     url.search = req.nextUrl.search
     return NextResponse.rewrite(url)
   }
   if (pathname === '/pages/multitenant') {
-    const url = new URL(`/pages/multitenant/${tenant}`, req.url)
+    const url = new URL(
+      `${req.nextUrl.basePath}/pages/multitenant/${tenant}`,
+      req.url
+    )
     url.search = req.nextUrl.search
     return NextResponse.rewrite(url)
   }

--- a/packages/e2e/next/src/middleware.ts
+++ b/packages/e2e/next/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const config = {
+  matcher: ['/app/multitenant', '/pages/multitenant']
+}
+
+export default async function middleware(req: NextRequest) {
+  // https://media1.tenor.com/m/YrcMb6KRczsAAAAC/doctor-who-dr-who.gif
+  const tenant = 'david'
+  const pathname = req.nextUrl.pathname
+  if (pathname === '/app/multitenant') {
+    const url = new URL(`/app/multitenant/${tenant}`, req.url)
+    url.search = req.nextUrl.search
+    return NextResponse.rewrite(url)
+  }
+  if (pathname === '/pages/multitenant') {
+    const url = new URL(`/pages/multitenant/${tenant}`, req.url)
+    url.search = req.nextUrl.search
+    return NextResponse.rewrite(url)
+  }
+  return NextResponse.next()
+}

--- a/packages/e2e/next/src/pages/pages/dynamic-segments/catch-all/[...segments].tsx
+++ b/packages/e2e/next/src/pages/pages/dynamic-segments/catch-all/[...segments].tsx
@@ -1,0 +1,38 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+import { useRouter } from 'next/router'
+
+type Props = {
+  serverState: string | null
+  serverSegments: string[]
+}
+
+export default function Page({ serverState, serverSegments }: Props) {
+  const router = useRouter()
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments
+        environment="client"
+        segments={router.query.segments as string[]}
+      />
+    </>
+  )
+}
+
+export function getServerSideProps(
+  ctx: GetServerSidePropsContext
+): GetServerSidePropsResult<Props> {
+  const serverState = (ctx.query.test as string) ?? null
+  const serverSegments = ctx.params?.segments as string[]
+  return {
+    props: {
+      serverState,
+      serverSegments
+    }
+  }
+}

--- a/packages/e2e/next/src/pages/pages/dynamic-segments/dynamic/[segment].tsx
+++ b/packages/e2e/next/src/pages/pages/dynamic-segments/dynamic/[segment].tsx
@@ -1,0 +1,38 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+import { useRouter } from 'next/router'
+
+type Props = {
+  serverState: string | null
+  serverSegments: string[]
+}
+
+export default function Page({ serverState, serverSegments }: Props) {
+  const router = useRouter()
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments
+        environment="client"
+        segments={[router.query.segment as string]}
+      />
+    </>
+  )
+}
+
+export function getServerSideProps(
+  ctx: GetServerSidePropsContext
+): GetServerSidePropsResult<Props> {
+  const serverState = (ctx.query.test as string) ?? null
+  const serverSegments = [ctx.params?.segment as string]
+  return {
+    props: {
+      serverState,
+      serverSegments
+    }
+  }
+}

--- a/packages/e2e/next/src/pages/pages/dynamic-segments/optional-catch-all/[[...segments]].tsx
+++ b/packages/e2e/next/src/pages/pages/dynamic-segments/optional-catch-all/[[...segments]].tsx
@@ -1,0 +1,42 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+import { useRouter } from 'next/router'
+
+type Props = {
+  serverState: string | null
+  serverSegments: string[] | null
+}
+
+export default function Page({ serverState, serverSegments }: Props) {
+  const router = useRouter()
+  console.dir({ client: router.query.segments, server: serverSegments })
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments
+        environment="server"
+        segments={serverSegments ?? undefined}
+      />
+      <DisplaySegments
+        environment="client"
+        segments={router.query.segments as string[]}
+      />
+    </>
+  )
+}
+
+export function getServerSideProps(
+  ctx: GetServerSidePropsContext
+): GetServerSidePropsResult<Props> {
+  const serverState = (ctx.query.test as string) ?? null
+  const serverSegments = (ctx.params?.segments as string[]) ?? null // Can't serialize undefined
+  return {
+    props: {
+      serverState,
+      serverSegments
+    }
+  }
+}

--- a/packages/e2e/next/src/pages/pages/middleware.tsx
+++ b/packages/e2e/next/src/pages/pages/middleware.tsx
@@ -1,0 +1,8 @@
+export default function MiddlewarePage() {
+  return (
+    <div>
+      <h1>Client</h1>
+      <p>Pages router</p>
+    </div>
+  )
+}

--- a/packages/e2e/next/src/pages/pages/multitenant/[tenant].tsx
+++ b/packages/e2e/next/src/pages/pages/multitenant/[tenant].tsx
@@ -1,0 +1,45 @@
+import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
+import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
+import { useParams } from 'next/navigation'
+import { useRouter } from 'next/router'
+
+type Props = {
+  serverState: string | null
+  tenant: string | null
+}
+
+export default function Page({ serverState, tenant }: Props) {
+  const params = useParams()
+  const router = useRouter()
+  return (
+    <>
+      <ShallowUseQueryState />
+      <ShallowDisplay environment="server" state={serverState} />
+      <p id="server-tenant">{tenant}</p>
+      <p id="client-tenant">{params?.tenant}</p>
+      <p id="router-pathname">{router.pathname}</p>
+    </>
+  )
+}
+
+export function getServerSideProps(
+  ctx: GetServerSidePropsContext
+): GetServerSidePropsResult<Props> {
+  const tenant = ctx.params?.tenant as string | null
+
+  if (!tenant) {
+    return {
+      notFound: true
+    }
+  }
+
+  const serverState = (ctx.query.test as string) ?? null
+
+  return {
+    props: {
+      serverState,
+      tenant
+    }
+  }
+}

--- a/packages/e2e/next/src/pages/pages/multitenant/[tenant].tsx
+++ b/packages/e2e/next/src/pages/pages/multitenant/[tenant].tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 import { useParams } from 'next/navigation'
 import { useRouter } from 'next/router'
@@ -15,7 +15,7 @@ export default function Page({ serverState, tenant }: Props) {
   return (
     <>
       <ShallowUseQueryState />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
       <p id="server-tenant">{tenant}</p>
       <p id="client-tenant">{params?.tenant}</p>
       <p id="router-pathname">{router.pathname}</p>

--- a/packages/e2e/next/src/pages/pages/pretty-urls.tsx
+++ b/packages/e2e/next/src/pages/pages/pretty-urls.tsx
@@ -1,0 +1,3 @@
+import { PrettyUrls } from 'e2e-shared/specs/pretty-urls'
+
+export default PrettyUrls

--- a/packages/e2e/next/src/pages/pages/shallow/useQueryState.tsx
+++ b/packages/e2e/next/src/pages/pages/shallow/useQueryState.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 
 type Props = {
@@ -10,7 +10,7 @@ export default function Page({ serverState }: Props) {
   return (
     <>
       <ShallowUseQueryState />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/next/src/pages/pages/shallow/useQueryStates.tsx
+++ b/packages/e2e/next/src/pages/pages/shallow/useQueryStates.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryStates } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 
 type Props = {
@@ -10,7 +10,7 @@ export default function Page({ serverState }: Props) {
   return (
     <>
       <ShallowUseQueryStates />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/react-router/v6/cypress/e2e/shared/dynamic-segments.cy.ts
+++ b/packages/e2e/react-router/v6/cypress/e2e/shared/dynamic-segments.cy.ts
@@ -1,0 +1,16 @@
+import { testDynamicSegments } from 'e2e-shared/specs/dynamic-segments.cy'
+
+testDynamicSegments({
+  path: '/dynamic-segments/dynamic/foo',
+  expectedSegments: ['foo']
+})
+
+testDynamicSegments({
+  path: '/dynamic-segments/catch-all',
+  expectedSegments: ['']
+})
+
+testDynamicSegments({
+  path: '/dynamic-segments/catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c']
+})

--- a/packages/e2e/react-router/v6/cypress/e2e/shared/pretty-urls.cy.ts
+++ b/packages/e2e/react-router/v6/cypress/e2e/shared/pretty-urls.cy.ts
@@ -1,0 +1,5 @@
+import { testPrettyUrls } from 'e2e-shared/specs/pretty-urls.cy'
+
+testPrettyUrls({
+  path: '/pretty-urls'
+})

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -47,6 +47,8 @@ const router = createBrowserRouter(
       <Route path="conditional-rendering/useQueryStates"  lazy={load(import('./routes/conditional-rendering.useQueryStates'))} />
       <Route path="scroll"                                lazy={load(import('./routes/scroll'))} />
       <Route path="pretty-urls"                           lazy={load(import('./routes/pretty-urls'))} />
+      <Route path="dynamic-segments/dynamic/:segment"     lazy={load(import('./routes/dynamic-segments.dynamic.$segment'))} />
+      <Route path="dynamic-segments/catch-all?*"          lazy={load(import('./routes/dynamic-segments.catch-all.$'))} />
 
       <Route path="render-count/:hook/:shallow/:history/:startTransition/no-loader"     lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.no-loader'))} />
       <Route path="render-count/:hook/:shallow/:history/:startTransition/sync-loader"   lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader'))} />

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -46,6 +46,7 @@ const router = createBrowserRouter(
       <Route path="conditional-rendering/useQueryState"   lazy={load(import('./routes/conditional-rendering.useQueryState'))} />
       <Route path="conditional-rendering/useQueryStates"  lazy={load(import('./routes/conditional-rendering.useQueryStates'))} />
       <Route path="scroll"                                lazy={load(import('./routes/scroll'))} />
+      <Route path="pretty-urls"                           lazy={load(import('./routes/pretty-urls'))} />
 
       <Route path="render-count/:hook/:shallow/:history/:startTransition/no-loader"     lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.no-loader'))} />
       <Route path="render-count/:hook/:shallow/:history/:startTransition/sync-loader"   lazy={load(import('./routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader'))} />

--- a/packages/e2e/react-router/v6/src/routes/dynamic-segments.catch-all.$.tsx
+++ b/packages/e2e/react-router/v6/src/routes/dynamic-segments.catch-all.$.tsx
@@ -1,0 +1,36 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString } from 'nuqs'
+import {
+  useLoaderData,
+  useParams,
+  type LoaderFunctionArgs
+} from 'react-router-dom'
+
+const loadSearchParams = createLoader({
+  test: parseAsString
+})
+
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const { test: serverState } = loadSearchParams(request)
+  return {
+    serverState,
+    serverSegments: params['*']?.split('/') ?? []
+  }
+}
+
+export default function Page() {
+  const { serverState, serverSegments } = useLoaderData() as ReturnType<
+    typeof loader
+  >
+  const clientSegments = useParams()['*']?.split('/') ?? []
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments environment="client" segments={clientSegments} />
+    </>
+  )
+}

--- a/packages/e2e/react-router/v6/src/routes/dynamic-segments.dynamic.$segment.tsx
+++ b/packages/e2e/react-router/v6/src/routes/dynamic-segments.dynamic.$segment.tsx
@@ -1,0 +1,39 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString } from 'nuqs'
+import {
+  useLoaderData,
+  useParams,
+  type LoaderFunctionArgs
+} from 'react-router-dom'
+
+const loadSearchParams = createLoader({
+  test: parseAsString
+})
+
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const { test: serverState } = loadSearchParams(request)
+  return {
+    serverState,
+    serverSegments: [params.segment as string]
+  }
+}
+
+export default function Page() {
+  const { serverState, serverSegments } = useLoaderData() as ReturnType<
+    typeof loader
+  >
+  const params = useParams()
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments
+        environment="client"
+        segments={[params.segment as string]}
+      />
+    </>
+  )
+}

--- a/packages/e2e/react-router/v6/src/routes/pretty-urls.tsx
+++ b/packages/e2e/react-router/v6/src/routes/pretty-urls.tsx
@@ -1,0 +1,3 @@
+import { PrettyUrls } from 'e2e-shared/specs/pretty-urls'
+
+export default PrettyUrls

--- a/packages/e2e/react-router/v6/src/routes/shallow.useQueryState.tsx
+++ b/packages/e2e/react-router/v6/src/routes/shallow.useQueryState.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import { useLoaderData, type LoaderFunctionArgs } from 'react-router-dom'
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -14,7 +14,7 @@ export default function Page() {
   return (
     <>
       <ShallowUseQueryState />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/react-router/v6/src/routes/shallow.useQueryStates.tsx
+++ b/packages/e2e/react-router/v6/src/routes/shallow.useQueryStates.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryStates } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import { useLoaderData, type LoaderFunctionArgs } from 'react-router-dom'
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -14,7 +14,7 @@ export default function Page() {
   return (
     <>
       <ShallowUseQueryStates />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -30,6 +30,8 @@ export default [
     route('/conditional-rendering/useQueryStates',  './routes/conditional-rendering.useQueryStates.tsx'),
     route('/scroll',                                './routes/scroll.tsx'),
     route('/pretty-urls',                           './routes/pretty-urls.tsx'),
+    route('/dynamic-segments/dynamic/:segment',     './routes/dynamic-segments.dynamic.$segment.tsx'),
+    route('/dynamic-segments/catch-all?/*',         './routes/dynamic-segments.catch-all.$.tsx'),
 
     route('/render-count/:hook/:shallow/:history/:startTransition/no-loader',    './routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx'),
     route('/render-count/:hook/:shallow/:history/:startTransition/sync-loader',  './routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx'),

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -29,6 +29,7 @@ export default [
     route('/conditional-rendering/useQueryState',   './routes/conditional-rendering.useQueryState.tsx'),
     route('/conditional-rendering/useQueryStates',  './routes/conditional-rendering.useQueryStates.tsx'),
     route('/scroll',                                './routes/scroll.tsx'),
+    route('/pretty-urls',                           './routes/pretty-urls.tsx'),
 
     route('/render-count/:hook/:shallow/:history/:startTransition/no-loader',    './routes/render-count.$hook.$shallow.$history.$startTransition.no-loader.tsx'),
     route('/render-count/:hook/:shallow/:history/:startTransition/sync-loader',  './routes/render-count.$hook.$shallow.$history.$startTransition.sync-loader.tsx'),

--- a/packages/e2e/react-router/v7/app/routes/dynamic-segments.catch-all.$.tsx
+++ b/packages/e2e/react-router/v7/app/routes/dynamic-segments.catch-all.$.tsx
@@ -1,0 +1,30 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString } from 'nuqs'
+import { useLoaderData, useParams, type LoaderFunctionArgs } from 'react-router'
+
+const loadSearchParams = createLoader({
+  test: parseAsString
+})
+
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const { test: serverState } = loadSearchParams(request)
+  return {
+    serverState,
+    serverSegments: params['*']?.split('/') ?? []
+  }
+}
+
+export default function Page() {
+  const { serverState, serverSegments } = useLoaderData<typeof loader>()
+  const clientSegments = useParams()['*']?.split('/') ?? []
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments environment="client" segments={clientSegments} />
+    </>
+  )
+}

--- a/packages/e2e/react-router/v7/app/routes/dynamic-segments.dynamic.$segment.tsx
+++ b/packages/e2e/react-router/v7/app/routes/dynamic-segments.dynamic.$segment.tsx
@@ -1,0 +1,33 @@
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString } from 'nuqs'
+import { useLoaderData, useParams, type LoaderFunctionArgs } from 'react-router'
+
+const loadSearchParams = createLoader({
+  test: parseAsString
+})
+
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const { test: serverState } = loadSearchParams(request)
+  return {
+    serverState,
+    serverSegments: [params.segment as string]
+  }
+}
+
+export default function Page() {
+  const { serverState, serverSegments } = useLoaderData<typeof loader>()
+  const params = useParams()
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments
+        environment="client"
+        segments={[params.segment as string]}
+      />
+    </>
+  )
+}

--- a/packages/e2e/react-router/v7/app/routes/pretty-urls.tsx
+++ b/packages/e2e/react-router/v7/app/routes/pretty-urls.tsx
@@ -1,0 +1,3 @@
+import { PrettyUrls } from 'e2e-shared/specs/pretty-urls'
+
+export default PrettyUrls

--- a/packages/e2e/react-router/v7/app/routes/shallow.useQueryState.tsx
+++ b/packages/e2e/react-router/v7/app/routes/shallow.useQueryState.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import { useLoaderData, type LoaderFunctionArgs } from 'react-router'
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -14,7 +14,7 @@ export default function Page() {
   return (
     <>
       <ShallowUseQueryState />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/react-router/v7/app/routes/shallow.useQueryStates.tsx
+++ b/packages/e2e/react-router/v7/app/routes/shallow.useQueryStates.tsx
@@ -1,5 +1,5 @@
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryStates } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 import { useLoaderData, type LoaderFunctionArgs } from 'react-router'
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -14,7 +14,7 @@ export default function Page() {
   return (
     <>
       <ShallowUseQueryStates />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/react-router/v7/cypress/e2e/shared/dynamic-segments.cy.ts
+++ b/packages/e2e/react-router/v7/cypress/e2e/shared/dynamic-segments.cy.ts
@@ -1,0 +1,16 @@
+import { testDynamicSegments } from 'e2e-shared/specs/dynamic-segments.cy'
+
+testDynamicSegments({
+  path: '/dynamic-segments/dynamic/foo',
+  expectedSegments: ['foo']
+})
+
+testDynamicSegments({
+  path: '/dynamic-segments/catch-all',
+  expectedSegments: ['']
+})
+
+testDynamicSegments({
+  path: '/dynamic-segments/catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c']
+})

--- a/packages/e2e/react-router/v7/cypress/e2e/shared/pretty-urls.cy.ts
+++ b/packages/e2e/react-router/v7/cypress/e2e/shared/pretty-urls.cy.ts
@@ -1,0 +1,5 @@
+import { testPrettyUrls } from 'e2e-shared/specs/pretty-urls.cy'
+
+testPrettyUrls({
+  path: '/pretty-urls'
+})

--- a/packages/e2e/react/cypress/e2e/shared/pretty-urls.cy.ts
+++ b/packages/e2e/react/cypress/e2e/shared/pretty-urls.cy.ts
@@ -1,0 +1,5 @@
+import { testPrettyUrls } from 'e2e-shared/specs/pretty-urls.cy'
+
+testPrettyUrls({
+  path: '/pretty-urls'
+})

--- a/packages/e2e/react/src/routes.tsx
+++ b/packages/e2e/react/src/routes.tsx
@@ -24,6 +24,7 @@ const routes: Record<string, React.LazyExoticComponent<() => JSX.Element>> = {
   '/conditional-rendering/useQueryState':   lazy(() => import('./routes/conditional-rendering.useQueryState')),
   '/conditional-rendering/useQueryStates':  lazy(() => import('./routes/conditional-rendering.useQueryStates')),
   '/scroll':                                lazy(() => import('./routes/scroll')),
+  '/pretty-urls':                           lazy(() => import('./routes/pretty-urls')),
 
   '/render-count/useQueryState/true/replace/false':   lazy(() => import('./routes/render-count')),
   '/render-count/useQueryState/true/replace/true':    lazy(() => import('./routes/render-count')),

--- a/packages/e2e/react/src/routes/pretty-urls.tsx
+++ b/packages/e2e/react/src/routes/pretty-urls.tsx
@@ -1,0 +1,3 @@
+import { PrettyUrls } from 'e2e-shared/specs/pretty-urls'
+
+export default PrettyUrls

--- a/packages/e2e/remix/app/routes/dynamic-segments.catch-all.$.tsx
+++ b/packages/e2e/remix/app/routes/dynamic-segments.catch-all.$.tsx
@@ -1,0 +1,31 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useParams } from '@remix-run/react'
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString } from 'nuqs'
+
+const loadSearchParams = createLoader({
+  test: parseAsString
+})
+
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const { test: serverState } = loadSearchParams(request)
+  return {
+    serverState,
+    serverSegments: params['*']?.split('/') ?? []
+  }
+}
+
+export default function Page() {
+  const { serverState, serverSegments } = useLoaderData<typeof loader>()
+  const clientSegments = useParams()['*']?.split('/') ?? []
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments environment="client" segments={clientSegments} />
+    </>
+  )
+}

--- a/packages/e2e/remix/app/routes/dynamic-segments.dynamic.$segment.tsx
+++ b/packages/e2e/remix/app/routes/dynamic-segments.dynamic.$segment.tsx
@@ -1,0 +1,34 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useParams } from '@remix-run/react'
+import { Display } from 'e2e-shared/components/display'
+import { DisplaySegments, UrlControls } from 'e2e-shared/specs/dynamic-segments'
+import { createLoader, parseAsString } from 'nuqs'
+
+const loadSearchParams = createLoader({
+  test: parseAsString
+})
+
+export function loader({ request, params }: LoaderFunctionArgs) {
+  const { test: serverState } = loadSearchParams(request)
+  return {
+    serverState,
+    serverSegments: [params.segment]
+  }
+}
+
+export default function Page() {
+  const { serverState, serverSegments } = useLoaderData<typeof loader>()
+  const params = useParams()
+  return (
+    <>
+      <UrlControls>
+        <Display environment="server" state={serverState} />
+      </UrlControls>
+      <DisplaySegments environment="server" segments={serverSegments} />
+      <DisplaySegments
+        environment="client"
+        segments={[params.segment as string]}
+      />
+    </>
+  )
+}

--- a/packages/e2e/remix/app/routes/pretty-urls.tsx
+++ b/packages/e2e/remix/app/routes/pretty-urls.tsx
@@ -1,0 +1,3 @@
+import { PrettyUrls } from 'e2e-shared/specs/pretty-urls'
+
+export default PrettyUrls

--- a/packages/e2e/remix/app/routes/shallow.useQueryState.tsx
+++ b/packages/e2e/remix/app/routes/shallow.useQueryState.tsx
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryState } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url)
@@ -15,7 +15,7 @@ export default function Page() {
   return (
     <>
       <ShallowUseQueryState />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/remix/app/routes/shallow.useQueryStates.tsx
+++ b/packages/e2e/remix/app/routes/shallow.useQueryStates.tsx
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
+import { Display } from 'e2e-shared/components/display'
 import { ShallowUseQueryStates } from 'e2e-shared/specs/shallow'
-import { ShallowDisplay } from 'e2e-shared/specs/shallow-display'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url)
@@ -15,7 +15,7 @@ export default function Page() {
   return (
     <>
       <ShallowUseQueryStates />
-      <ShallowDisplay environment="server" state={serverState} />
+      <Display environment="server" state={serverState} />
     </>
   )
 }

--- a/packages/e2e/remix/cypress/e2e/shared/dynamic-segments.cy.ts
+++ b/packages/e2e/remix/cypress/e2e/shared/dynamic-segments.cy.ts
@@ -1,0 +1,16 @@
+import { testDynamicSegments } from 'e2e-shared/specs/dynamic-segments.cy'
+
+testDynamicSegments({
+  path: '/dynamic-segments/dynamic/foo',
+  expectedSegments: ['foo']
+})
+
+testDynamicSegments({
+  path: '/dynamic-segments/catch-all',
+  expectedSegments: ['']
+})
+
+testDynamicSegments({
+  path: '/dynamic-segments/catch-all/a/b/c',
+  expectedSegments: ['a', 'b', 'c']
+})

--- a/packages/e2e/remix/cypress/e2e/shared/pretty-urls.cy.ts
+++ b/packages/e2e/remix/cypress/e2e/shared/pretty-urls.cy.ts
@@ -1,0 +1,5 @@
+import { testPrettyUrls } from 'e2e-shared/specs/pretty-urls.cy'
+
+testPrettyUrls({
+  path: '/pretty-urls'
+})

--- a/packages/e2e/shared/components/display.tsx
+++ b/packages/e2e/shared/components/display.tsx
@@ -1,0 +1,13 @@
+export type DisplayProps = {
+  environment: 'client' | 'server'
+  target?: string
+  state: string | null
+}
+
+export function Display({
+  state,
+  environment,
+  target = 'state'
+}: DisplayProps) {
+  return <pre id={`${environment}-${target}`}>{state}</pre>
+}

--- a/packages/e2e/shared/lib/options.ts
+++ b/packages/e2e/shared/lib/options.ts
@@ -1,0 +1,14 @@
+import {
+  createLoader,
+  createSerializer,
+  parseAsBoolean,
+  parseAsStringLiteral
+} from 'nuqs'
+
+export const optionsSearchParams = {
+  shallow: parseAsBoolean.withDefault(true),
+  history: parseAsStringLiteral(['replace', 'push']).withDefault('replace')
+}
+
+export const getOptionsUrl = createSerializer(optionsSearchParams)
+export const loadOptions = createLoader(optionsSearchParams)

--- a/packages/e2e/shared/specs/dynamic-segments.cy.ts
+++ b/packages/e2e/shared/specs/dynamic-segments.cy.ts
@@ -1,0 +1,54 @@
+import { createTest, type TestConfig } from '../create-test'
+import { getOptionsUrl } from '../lib/options'
+
+type TestDynamicSegmentsOptions = TestConfig & {
+  expectedSegments: string[]
+}
+
+export function testDynamicSegments({
+  expectedSegments,
+  ...options
+}: TestDynamicSegmentsOptions) {
+  function expectSegments(environment: 'client' | 'server') {
+    if (expectedSegments.length === 0) {
+      cy.get(`#${environment}-segments`).should('be.empty')
+    } else {
+      cy.get(`#${environment}-segments`).should(
+        'have.text',
+        JSON.stringify(expectedSegments)
+      )
+    }
+  }
+  const factory = createTest('Dynamic segments', ({ path }) => {
+    for (const shallow of [true, false]) {
+      for (const history of ['replace', 'push'] as const) {
+        it(`${path}: Updates with ({ shallow: ${shallow}, history: ${history} })`, () => {
+          cy.visit(getOptionsUrl(path, { shallow, history }))
+          cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+          cy.get('#client-state').should('be.empty')
+          cy.get('#server-state').should('be.empty')
+          expectSegments('server')
+          expectSegments('client')
+          cy.get('button').click()
+          cy.get('#client-state').should('have.text', 'pass')
+          expectSegments('server')
+          expectSegments('client')
+          if (shallow === false) {
+            cy.get('#server-state').should('have.text', 'pass')
+          } else {
+            cy.get('#server-state').should('be.empty')
+          }
+          if (history !== 'push') {
+            return
+          }
+          cy.go('back')
+          cy.get('#client-state').should('be.empty')
+          cy.get('#server-state').should('be.empty')
+          expectSegments('server')
+          expectSegments('client')
+        })
+      }
+    }
+  })
+  return factory(options)
+}

--- a/packages/e2e/shared/specs/dynamic-segments.tsx
+++ b/packages/e2e/shared/specs/dynamic-segments.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useQueryState, useQueryStates } from 'nuqs'
+import type { ReactNode } from 'react'
+import { Display, type DisplayProps } from '../components/display'
+import { optionsSearchParams } from '../lib/options'
+
+type UrlControlsProps = {
+  children?: ReactNode
+}
+
+export function UrlControls({ children }: UrlControlsProps) {
+  const [{ shallow, history }] = useQueryStates(optionsSearchParams)
+  const [state, setState] = useQueryState('test', { shallow, history })
+  return (
+    <>
+      <button onClick={() => setState('pass')}>Test</button>
+      {children}
+      <Display environment="client" state={state} />
+    </>
+  )
+}
+
+// --
+
+type DisplaySegmentsProps = Pick<DisplayProps, 'environment'> & {
+  segments: string[] | undefined
+}
+
+export function DisplaySegments({
+  segments,
+  environment
+}: DisplaySegmentsProps) {
+  return (
+    <Display
+      environment={environment}
+      target="segments"
+      state={JSON.stringify(segments)}
+    />
+  )
+}

--- a/packages/e2e/shared/specs/pretty-urls.cy.ts
+++ b/packages/e2e/shared/specs/pretty-urls.cy.ts
@@ -1,0 +1,10 @@
+import { createTest } from '../create-test'
+
+export const testPrettyUrls = createTest('Pretty URLs', ({ path }) => {
+  it('should render unencoded characters', () => {
+    cy.visit(path)
+    cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+    cy.get('button').click()
+    cy.get('#state').should('have.text', '-._~!$()*,;=:@/?[]{}\\|^')
+  })
+})

--- a/packages/e2e/shared/specs/pretty-urls.tsx
+++ b/packages/e2e/shared/specs/pretty-urls.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useQueryState } from 'nuqs'
+
+export function PrettyUrls() {
+  const [state, setState] = useQueryState('test')
+  return (
+    <>
+      <button onClick={() => setState('-._~!$()*,;=:@/?[]{}\\|^')}>Test</button>
+      <pre id="state">{state}</pre>
+    </>
+  )
+}

--- a/packages/e2e/shared/specs/shallow-display.tsx
+++ b/packages/e2e/shared/specs/shallow-display.tsx
@@ -1,8 +1,0 @@
-type ShallowDisplayProps = {
-  environment: 'client' | 'server'
-  state: string | null
-}
-
-export function ShallowDisplay({ state, environment }: ShallowDisplayProps) {
-  return <pre id={environment + '-state'}>{state}</pre>
-}

--- a/packages/e2e/shared/specs/shallow.cy.ts
+++ b/packages/e2e/shared/specs/shallow.cy.ts
@@ -1,5 +1,5 @@
 import { createTest, type TestConfig } from '../create-test'
-import { getShallowUrl } from './shallow.defs'
+import { getOptionsUrl } from '../lib/options'
 
 type TestShallowOptions = TestConfig & {
   supportsSSR?: boolean
@@ -17,7 +17,7 @@ export function testShallow({
     for (const shallow of shallowOptions) {
       for (const history of historyOptions) {
         it(`Updates with ({ shallow: ${shallow}, history: ${history} })`, () => {
-          cy.visit(getShallowUrl(path, { shallow, history }))
+          cy.visit(getOptionsUrl(path, { shallow, history }))
           cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
           cy.get('#client-state').should('be.empty')
           if (supportsSSR) {

--- a/packages/e2e/shared/specs/shallow.defs.ts
+++ b/packages/e2e/shared/specs/shallow.defs.ts
@@ -1,8 +1,0 @@
-import { createSerializer, parseAsBoolean, parseAsStringLiteral } from 'nuqs'
-
-export const shallowSearchParams = {
-  shallow: parseAsBoolean.withDefault(true),
-  history: parseAsStringLiteral(['replace', 'push']).withDefault('replace')
-}
-
-export const getShallowUrl = createSerializer(shallowSearchParams)

--- a/packages/e2e/shared/specs/shallow.tsx
+++ b/packages/e2e/shared/specs/shallow.tsx
@@ -1,22 +1,22 @@
 'use client'
 
 import { parseAsString, useQueryState, useQueryStates } from 'nuqs'
-import { ShallowDisplay } from './shallow-display'
-import { shallowSearchParams } from './shallow.defs'
+import { Display } from '../components/display'
+import { optionsSearchParams } from '../lib/options'
 
 export function ShallowUseQueryState() {
-  const [{ shallow, history }] = useQueryStates(shallowSearchParams)
+  const [{ shallow, history }] = useQueryStates(optionsSearchParams)
   const [state, setState] = useQueryState('test', { shallow, history })
   return (
     <>
       <button onClick={() => setState('pass')}>Test</button>
-      <ShallowDisplay environment="client" state={state} />
+      <Display environment="client" state={state} />
     </>
   )
 }
 
 export function ShallowUseQueryStates() {
-  const [{ shallow, history }] = useQueryStates(shallowSearchParams)
+  const [{ shallow, history }] = useQueryStates(optionsSearchParams)
   const [{ state }, setSearchParams] = useQueryStates(
     {
       state: parseAsString.withOptions({ shallow, history })
@@ -30,7 +30,7 @@ export function ShallowUseQueryStates() {
   return (
     <>
       <button onClick={() => setSearchParams({ state: 'pass' })}>Test</button>
-      <ShallowDisplay environment="client" state={state} />
+      <Display environment="client" state={state} />
     </>
   )
 }

--- a/packages/nuqs/src/adapters/next/impl.app.ts
+++ b/packages/nuqs/src/adapters/next/impl.app.ts
@@ -1,8 +1,8 @@
 import { useRouter, useSearchParams } from 'next/navigation'
 import { startTransition, useCallback, useOptimistic } from 'react'
 import { debug } from '../../debug'
+import { renderQueryString } from '../../url-encoding'
 import type { AdapterInterface, UpdateUrlFunction } from '../lib/defs'
-import { renderURL } from './shared'
 
 export function useNuqsNextAppRouterAdapter(): AdapterInterface {
   const router = useRouter()
@@ -47,4 +47,11 @@ export function useNuqsNextAppRouterAdapter(): AdapterInterface {
     // See: https://github.com/47ng/nuqs/issues/603#issuecomment-2317057128
     rateLimitFactor: 2
   }
+}
+
+function renderURL(base: string, search: URLSearchParams) {
+  const hashlessBase = base.split('#')[0] ?? ''
+  const query = renderQueryString(search)
+  const hash = location.hash
+  return hashlessBase + query + hash
 }

--- a/packages/nuqs/src/adapters/next/impl.pages.test.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { extractDynamicUrlParams, getAsPathPathname } from './impl.pages'
+
+describe('Next Pages Adapter: getAsPathPathname', () => {
+  it('returns a pure pathname', () => {
+    expect(getAsPathPathname('')).toBe('')
+    expect(getAsPathPathname('/')).toBe('/')
+    expect(getAsPathPathname('/a/b/c')).toBe('/a/b/c')
+  })
+  it('strips search params', () => {
+    expect(getAsPathPathname('/a/b/c?foo=bar')).toBe('/a/b/c')
+    expect(getAsPathPathname('/a/b/c?foo=bar&baz=qux')).toBe('/a/b/c')
+  })
+  it('strips hash', () => {
+    expect(getAsPathPathname('/a/b/c#foo')).toBe('/a/b/c')
+    expect(getAsPathPathname('/a/b/c#foo/bar')).toBe('/a/b/c')
+  })
+  it('strips both search params and hash', () => {
+    expect(getAsPathPathname('/a/b/c?foo=bar#baz')).toBe('/a/b/c')
+    expect(getAsPathPathname('/a/b/c?foo=bar&baz=qux#quux')).toBe('/a/b/c')
+  })
+})
+
+describe('Next Pages Adapter: extractDynamicUrlParams', () => {
+  it('returns an empty object when no dynamic params are present', () => {
+    const result = extractDynamicUrlParams('/path/without/params', {
+      ignored: 'gone' // ignored
+    })
+    expect(result).toEqual({})
+  })
+
+  it('returns an object with dynamic params', () => {
+    const result = extractDynamicUrlParams('/path/[foo]/[bar]', {
+      foo: 'bar',
+      bar: 'baz',
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ foo: 'bar', bar: 'baz' })
+  })
+
+  it('maps missing dynamic params to undefined', () => {
+    const result = extractDynamicUrlParams('/path/[foo]/[bar]', {
+      bar: 'baz' // foo is missing
+    })
+    expect(result).toEqual({ foo: undefined, bar: 'baz' })
+  })
+
+  // --
+
+  it('returns an array for catch-all params', () => {
+    const result = extractDynamicUrlParams('/path/[...params]', {
+      params: ['foo', 'bar'],
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ params: ['foo', 'bar'] })
+  })
+
+  // --
+
+  it('returns an empty array for optional catch-all params without values', () => {
+    const result = extractDynamicUrlParams('/path/[[...params]]', {
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ params: [] })
+  })
+
+  it('returns an array with a single item for optional catch-all params with a single value', () => {
+    const result = extractDynamicUrlParams('/path/[[...params]]', {
+      params: ['foo'],
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ params: ['foo'] })
+  })
+
+  it('returns an array with multiple items for optional catch-all params with multiple values', () => {
+    const result = extractDynamicUrlParams('/path/[[...params]]', {
+      params: ['foo', 'bar'],
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ params: ['foo', 'bar'] })
+  })
+
+  // --
+
+  it('supports a combination of dynamic and catch-all params', () => {
+    const result = extractDynamicUrlParams('/path/[foo]/[bar]/[...params]', {
+      foo: 'a',
+      bar: 'b',
+      params: ['baz'],
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ foo: 'a', bar: 'b', params: ['baz'] })
+  })
+
+  it('supports a combination of dynamic and optional catch-all params', () => {
+    const result = extractDynamicUrlParams('/path/[foo]/[bar]/[[...params]]', {
+      foo: 'a',
+      bar: 'b',
+      params: ['baz'],
+      ignored: 'gone'
+    })
+    expect(result).toEqual({ foo: 'a', bar: 'b', params: ['baz'] })
+  })
+})

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -67,7 +67,6 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
         query: {
           // Note: we put search params first so that one that conflicts
           // with dynamic params will be overwritten.
-          // todo: Test this in practice.
           ...Object.fromEntries(search.entries()),
           ...urlParams
         }
@@ -76,7 +75,7 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
       },
       // This is what makes the URL pretty (resolved dynamic segments
       // and nuqs-formatted search params).
-      asPath, // todo: Test formatting
+      asPath,
       // And these are the options that are passed to the router.
       {
         scroll: options.scroll,
@@ -127,11 +126,11 @@ export function extractDynamicUrlParams(
     Object.entries(values).filter(([key]) => paramNames.has(key))
   )
   const matchCatchAll = catchAllRegex.exec(pathname)
-  const matchOptionalCatchAll = optionalCatchAllRegex.exec(pathname)
   if (matchCatchAll && matchCatchAll[1]) {
     const key = matchCatchAll[1]
     dynamicValues[key] = values[key] ?? []
   }
+  const matchOptionalCatchAll = optionalCatchAllRegex.exec(pathname)
   if (matchOptionalCatchAll && matchOptionalCatchAll[1]) {
     const key = matchOptionalCatchAll[1]
     // Note: while Next.js returns undefined if there are no values for the

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -1,6 +1,6 @@
-import { useSearchParams } from 'next/navigation.js'
+import { useRouter } from 'next/compat/router'
 import type { NextRouter } from 'next/router'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { debug } from '../../debug'
 import { createAdapterProvider } from '../lib/context'
 import type { AdapterInterface, UpdateUrlFunction } from '../lib/defs'
@@ -23,7 +23,24 @@ export function isPagesRouter(): boolean {
 }
 
 export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
-  const searchParams = useSearchParams()
+  const router = useRouter()
+  const searchParams = useMemo(() => {
+    const searchParams = new URLSearchParams()
+    if (router === null) {
+      return searchParams
+    }
+    for (const [key, value] of Object.entries(router.query)) {
+      if (typeof value === 'string') {
+        searchParams.set(key, value)
+      } else if (Array.isArray(value)) {
+        for (const v of value) {
+          searchParams.append(key, v)
+        }
+      }
+    }
+    return searchParams
+  }, [JSON.stringify(router?.query)])
+
   const updateUrl: UpdateUrlFunction = useCallback((search, options) => {
     // While the Next.js team doesn't recommend using internals like this,
     // we need access to the pages router here to let it know about non-shallow
@@ -32,21 +49,77 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
     // The router adapter imported from next/navigation also doesn't support
     // passing an asPath, causing issues in dynamic routes in the pages router.
     const nextRouter = window.next?.router!
-    const url = renderURL(nextRouter.state.asPath.split('?')[0] ?? '', search)
-    debug('[nuqs queue (pages)] Updating url: %s', url)
+    const urlParams = extractDynamicUrlParams(
+      nextRouter.pathname,
+      nextRouter.query
+    )
+    const query = Object.fromEntries(search.entries())
+    const asPath = renderURL(
+      nextRouter.state.asPath.split('?')[0] ?? '',
+      search
+    )
+    debug('[nuqs queue (pages)] Updating url: %s', asPath)
     const method =
       options.history === 'push' ? nextRouter.push : nextRouter.replace
-    method.call(nextRouter, url, url, {
-      scroll: options.scroll,
-      shallow: options.shallow
-    })
+
+    method.call(
+      nextRouter,
+      {
+        pathname: nextRouter.pathname,
+        query: {
+          ...urlParams,
+          ...query
+        },
+        hash: location.hash
+      },
+      {
+        pathname: nextRouter.state.asPath.split('?')[0] ?? '',
+        query,
+        hash: location.hash
+      },
+      {
+        scroll: options.scroll,
+        shallow: options.shallow
+      }
+    )
   }, [])
   return {
     searchParams,
     updateUrl,
     // See: https://github.com/47ng/nuqs/issues/603#issuecomment-2317057128
-    rateLimitFactor: 2
+    rateLimitFactor: 1
   }
 }
 
 export const NuqsAdapter = createAdapterProvider(useNuqsNextPagesRouterAdapter)
+
+function extractDynamicUrlParams(
+  pathname: string,
+  values: Record<string, string | string[] | undefined>
+): Record<string, string | string[] | undefined> {
+  const paramNames = new Set<string>()
+  const dynamicRegex = /\[([^\]]+)\]/g
+  const catchAllRegex = /\[\.{3}([^\]]+)\]$/
+  const optionalCatchAllRegex = /\[\[\.{3}([^\]]+)\]\]$/
+
+  let match
+  while ((match = dynamicRegex.exec(pathname)) !== null) {
+    const paramName = match[1]
+    if (paramName) {
+      paramNames.add(paramName)
+    }
+  }
+  const dynamicValues = Object.fromEntries(
+    Object.entries(values).filter(([key]) => paramNames.has(key))
+  )
+  const matchCatchAll = catchAllRegex.exec(pathname)
+  const matchOptionalCatchAll = optionalCatchAllRegex.exec(pathname)
+  if (matchCatchAll) {
+    dynamicValues[matchCatchAll[1]!] = values[matchCatchAll[1]!] ?? []
+  }
+  if (matchOptionalCatchAll) {
+    dynamicValues[matchOptionalCatchAll[1]!] =
+      values[matchOptionalCatchAll[1]!] ?? []
+  }
+  return dynamicValues
+}

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -1,4 +1,4 @@
-import { useRouter } from 'next/compat/router'
+import { useRouter } from 'next/compat/router.js'
 import type { NextRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import { debug } from '../../debug'

--- a/packages/nuqs/src/adapters/next/shared.ts
+++ b/packages/nuqs/src/adapters/next/shared.ts
@@ -1,8 +1,0 @@
-import { renderQueryString } from '../../url-encoding'
-
-export function renderURL(base: string, search: URLSearchParams) {
-  const hashlessBase = base.split('#')[0] ?? ''
-  const query = renderQueryString(search)
-  const hash = location.hash
-  return hashlessBase + query + hash
-}


### PR DESCRIPTION
It failed to preserve the router pathname in the pages router with shallow: true.

Also surfaced some issues with dynamic routes in the pages router.

## Tasks

- [x] Add test for pretty URL rendering (not encoding some characters)
- [x] Add dynamic keys test for other frameworks

Might close #869 and #693 (updated import in the pages router from `next/navigation` to `next/compat/router.js`).

Closes #914.