### PR TITLE
chore: Update pkg.pr.new comments

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -53,4 +53,4 @@ jobs:
           echo "::notice title=Version::0.0.0-preview.${{ github.event.pull_request.head.sha }}"
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
-        run: pnpx pkg-pr-new publish --compact './packages/nuqs'
+        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -53,4 +53,4 @@ jobs:
           echo "::notice title=Version::0.0.0-preview.${{ github.event.pull_request.head.sha }}"
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
-        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template
+        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template --packageManager=pnpm

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -53,4 +53,4 @@ jobs:
           echo "::notice title=Version::0.0.0-preview.${{ github.event.pull_request.head.sha }}"
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
-        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template --packageManager=pnpm
+        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template --packageManager=pnpm --pnpm

--- a/packages/nuqs/remove-me
+++ b/packages/nuqs/remove-me
@@ -1,0 +1,1 @@
+Just to have a change in nuqs to trigger deploy to pkg.pr.new


### PR DESCRIPTION
- ~Add intro ("Use this to install a preview build of this PR" or something)~

Any customisation of the comment requires a complete opt-out of the automated behaviour and maintaining the code that does this work ourselves, we might need to think about a better way and contribute that to pkg.pr.new.

See https://github.com/stackblitz-labs/pkg.pr.new/issues/263