### PR TITLE
fix: Import React.cache only when needed

### DIFF
--- a/packages/nuqs/src/cache.ts
+++ b/packages/nuqs/src/cache.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import { cache } from 'react'
+import * as React from 'react'
 import type { SearchParams, UrlKeys } from './defs'
 import { error } from './errors'
 import { createLoader } from './loader'
@@ -27,7 +26,7 @@ export function createSearchParamsCache<Parsers extends ParserMap>(
   // whereas a simple object would be bound to the lifecycle of the process,
   // which may be reused between requests in a serverless environment
   // (warm lambdas on Vercel or AWS).
-  const getCache = cache<() => Cache>(() => ({
+  const getCache = React.cache<() => Cache>(() => ({
     searchParams: {}
   }))
 


### PR DESCRIPTION
Having `import { cache } from 'react'` caused issues when using React 18 or 19 GA, because the `cache` function is only exported in canary builds (which the Next.js app router uses internally, regardless of what's in your app's package.json).

This meant importing from `'nuqs/server'` caused an import error when done from non app-router code, like the pages router, an API route definition, or a non-Next.js framework, which would fallback to the version of React defined in the package.json (likely a stable one).

Changing the import to `import * as React from 'react'` is what is being highlighted in the React docs themselves, and allows to only call the cache function when actually creating a cache object.

Closes #804, and supersedes #805.