### PR TITLE
fix: Import from next/navigation.js

### DIFF
--- a/packages/nuqs/src/adapters/next/impl.app.ts
+++ b/packages/nuqs/src/adapters/next/impl.app.ts
@@ -1,4 +1,4 @@
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation.js'
 import { startTransition, useCallback, useOptimistic } from 'react'
 import { debug } from '../../debug'
 import { renderQueryString } from '../../url-encoding'


### PR DESCRIPTION
So that the agonostic adapter is happy about the import when bundled under the pages router.

Closes #869.