### PR TITLE
chore(docs): Waku v0.22 community adapter useRouter update 

### DIFF
--- a/packages/docs/content/docs/community-adapters/waku.mdx
+++ b/packages/docs/content/docs/community-adapters/waku.mdx
@@ -20,7 +20,7 @@ import {
   unstable_createAdapterProvider as createAdapterProvider,
   renderQueryString,
 } from "nuqs/adapters/custom";
-import { useRouter_UNSTABLE as useRouter } from "waku";
+import { useRouter } from "waku";
 
 function useNuqsAdapter() {
   const { path, query, push, replace } = useRouter();

--- a/packages/docs/content/docs/community-adapters/waku.mdx
+++ b/packages/docs/content/docs/community-adapters/waku.mdx
@@ -20,6 +20,8 @@ import {
   unstable_createAdapterProvider as createAdapterProvider,
   renderQueryString,
 } from "nuqs/adapters/custom";
+// import { useRouter_UNSTABLE as useRouter } from "waku";
+// if waku v0.22 or later:
 import { useRouter } from "waku";
 
 function useNuqsAdapter() {


### PR DESCRIPTION
useRouter is no longer unstable in Waku since v0.22.