### PR TITLE
fix: Prettify inferred types

### DIFF
--- a/packages/nuqs/src/cache.ts
+++ b/packages/nuqs/src/cache.ts
@@ -12,9 +12,7 @@ export function createSearchParamsCache<Parsers extends ParserMap>(
 ) {
   const load = createLoader(parsers, { urlKeys })
   type Keys = keyof Parsers
-  type ParsedSearchParams = {
-    readonly [K in Keys]: inferParserType<Parsers[K]>
-  }
+  type ParsedSearchParams = inferParserType<Parsers>
 
   type Cache = {
     searchParams: Partial<ParsedSearchParams>

--- a/packages/nuqs/src/defs.ts
+++ b/packages/nuqs/src/defs.ts
@@ -65,7 +65,7 @@ export type Options = {
 
 export type Nullable<T> = {
   [K in keyof T]: T[K] | null
-}
+} & {}
 
 /**
  * Helper type to define and reuse urlKey options to rename search params keys

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -457,7 +457,7 @@ type inferSingleParserType<Parser> = Parser extends ParserBuilder<
 
 type inferParserRecordType<Map extends Record<string, ParserBuilder<any>>> = {
   [Key in keyof Map]: inferSingleParserType<Map[Key]>
-}
+} & {}
 
 /**
  * Type helper to extract the underlying returned data type of a parser

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -19,7 +19,7 @@ type KeyMapValue<Type> = Parser<Type> &
 
 export type UseQueryStatesKeysMap<Map = any> = {
   [Key in keyof Map]: KeyMapValue<Map[Key]>
-}
+} & {}
 
 export type UseQueryStatesOptions<KeyMap extends UseQueryStatesKeysMap> =
   Options & {


### PR DESCRIPTION
Using Matt Pocock's [Prettify helper](https://www.totaltypescript.com/concepts/the-prettify-helper), we can resolve the underlying parsed data types in derived features like the loaders, cache, serializers etc, rather than getting gnarly half-resolved types based on the parser types.

Demo: https://www.youtube.com/watch?v=nlAPCgMfPXY