### PR TITLE
defaultValue on parseAsJson

### DIFF
--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -384,6 +384,7 @@ export function parseAsJson<T>(runtimeParser: (value: unknown) => T) {
         return null
       }
     },
+    defaultValue: runtimeParser(undefined),
     serialize: value => JSON.stringify(value),
     eq(a, b) {
       // Check for referential equality first


### PR DESCRIPTION
## Context

What's your version of `nuqs` 

current `"nuqs": "^2.4.1",`
 

What framework are you using?

- ✅ Next.js (pages router)


## Description

Desired effect:
- i want default values from zod to propogate to my nuqs state
- i.e.

```ts
  const defaultSchema = z.object({name: z.string()}).default({
      name: 'jordi'
  });


  const [json, setJson] = useQueryState(
    "json",
    parseAsJson(defaultSchema.parse),
  );
```

Currently this does not happen 😭


---

great repo btw <3 