### PR TITLE
doc: Fix transition docs to not call parser as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ function ClientComponent({ data }) {
   const [query, setQuery] = useQueryState(
     'query',
     // 2. Pass the `startTransition` as an option:
-    parseAsString().withOptions({
+    parseAsString.withOptions({
       startTransition,
       shallow: false // opt-in to notify the server (Next.js only)
     })

--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -293,7 +293,7 @@ function ClientComponent({ data }) {
     'query',
     // 2. Pass the `startTransition` as an option:
     // [!code word:startTransition:1]
-    parseAsString().withOptions({ startTransition, shallow: false })
+    parseAsString.withOptions({ startTransition, shallow: false })
   )
   // 3. `isLoading` will be true while the server is re-rendering
   // and streaming RSC payloads, when the query is updated via `setQuery`.


### PR DESCRIPTION
Docs appear to be incorrect, parsers aren't functions that can be called like this