### PR TITLE
doc: Title is hidden behind headers on mobile

### DIFF
--- a/packages/docs/src/app/globals.css
+++ b/packages/docs/src/app/globals.css
@@ -140,7 +140,7 @@
   #nd-subnav {
     flex-shrink: 0;
     /* https://github.com/47ng/nuqs/pull/1027#issuecomment-3007455946 */
-    @apply fixed z-30 w-full;
+    @apply z-30 w-full;
   }
 }
 

--- a/packages/docs/src/app/globals.css
+++ b/packages/docs/src/app/globals.css
@@ -140,7 +140,11 @@
   #nd-subnav {
     flex-shrink: 0;
     /* https://github.com/47ng/nuqs/pull/1027#issuecomment-3007455946 */
-    @apply z-30 w-full;
+    @apply fixed z-30 w-full;
+  }
+
+  #nd-page {
+    @apply pt-14 md:pt-0;
   }
 }
 

--- a/packages/docs/src/app/globals.css
+++ b/packages/docs/src/app/globals.css
@@ -143,6 +143,9 @@
     @apply fixed z-30 w-full;
   }
 
+  /* Fix titles being hidden behind the headers:
+    https://github.com/47ng/nuqs/pull/1043
+  */
   #nd-page {
     @apply pt-14 md:pt-0;
   }


### PR DESCRIPTION
Fix title is hidden behind headers on mobile
from: 
<img width="468" height="884" alt="image" src="https://github.com/user-attachments/assets/b35cb099-2555-48f0-8474-784f7eaea6a8" />
to:
<img width="454" height="792" alt="image" src="https://github.com/user-attachments/assets/320fda77-0b40-4c28-97b8-51d6d57b9b8f" />

Closes #1042.
