### PR TITLE
fix: Type inference for defaultValue of object syntax

### DIFF
--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -4,10 +4,6 @@ import { safeParse } from './lib/safe-parse'
 
 type Require<T, Keys extends keyof T> = Pick<Required<T>, Keys> & Omit<T, Keys>
 
-export type NoParser = {
-  [K in keyof Parser<unknown>]?: never
-}
-
 export type Parser<T> = {
   /**
    * Convert a query string value into a state value.

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -10,7 +10,7 @@ import {
 } from './lib/queues/throttle'
 import { safeParse } from './lib/safe-parse'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
-import type { NoParser, Parser } from './parsers'
+import type { Parser } from './parsers'
 
 export interface UseQueryStateOptions<T> extends Parser<T>, Options {}
 
@@ -95,7 +95,12 @@ export function useQueryState(
   key: string,
   options: Options & {
     defaultValue: string
-  } & NoParser
+  } & {
+    // Note: Ensure this overload isn't picked when specifying a default
+    // value and spreading a parser for which the default would be invalid.
+    // See https://github.com/47ng/nuqs/pull/1057
+    [K in keyof Parser<unknown>]?: never
+  }
 ): UseQueryStateReturn<string, typeof options.defaultValue>
 
 /**


### PR DESCRIPTION
The problem was that when passing an arbitrary `string` to `defaultValue` when a `parser` was defined, the wrong overload was picked up because we basically “fall through” to the overload where we have `defaultValue: string`.

Now, that last, basic overload is intersected with:

```
parse?: never
serialize?: never
eq?: never
```

so that it’s not picked up when a parser is specified