### PR TITLE
feat: export ./package.json in exports field for Module Federation support

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -56,6 +56,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",


### PR DESCRIPTION
# Context

This change addresses an issue raised in [Issue #1060](https://github.com/47ng/nuqs/issues/1060): currently, `package.json` isn’t listed in the `"exports"` field of the package. Tools like Vite Module Federation rely on this entry to resolve the package correctly. 

# What’s Changed

- Added `"./package.json": "./package.json"` to the `"exports"` field in `package.json`.

# Why It Matters

- Module Federation compatibility: Without this entry, Vite Module Federation fails to locate and load package.json, resulting in resolution errors
- Consistency: Aligns with patterns used by other libraries that explicitly export their `package.json` when needed.

# Steps to Verify

1. Install the updated `nuqs` package in a Vite-based project with Module Federation enabled.
2. Attempt to import or load the package.
3. Build module federation project to confirm that there are no resolution errors related to `package.json`.