### PR TITLE
fix: Remove esm-only on TanStack Router export

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -113,7 +113,7 @@
     "./adapters/tanstack-router": {
       "types": "./dist/adapters/tanstack-router.d.ts",
       "import": "./dist/adapters/tanstack-router.js",
-      "require": "./esm-only.cjs"
+      "default": "./dist/adapters/tanstack-router.js"
     },
     "./adapters/custom": {
       "types": "./dist/adapters/custom.d.ts",


### PR DESCRIPTION
Left over from merging next into #996.