### PR TITLE
doc: prevent NaN appearing in pagination example

### DIFF
--- a/packages/docs/src/app/playground/(demos)/pagination/rendering-controls.tsx
+++ b/packages/docs/src/app/playground/(demos)/pagination/rendering-controls.tsx
@@ -46,7 +46,7 @@ export function RenderingControls() {
             value={delay.toFixed()}
             onValueChange={value =>
               setControls({
-                delay: value === '0' ? null : parseInt(value)
+                delay: value && value !== '0' ? parseInt(value) : null
               })
             }
           >


### PR DESCRIPTION
a small fix to prevent `NaN` from appearing in the URL query. When the toggled state is off, the `onValueChange` callback receives an empty string, which is parsed as `NaN`.