### PR TITLE
feat: Add support for more global default options at the adapter level

### DIFF
--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -37,7 +37,14 @@ Default values for some options can also be configured globally via the `default
 
 ```tsx
 // [!code word:defaultOptions]
-<NuqsAdapter defaultOptions={{ shallow: false }}>
+<NuqsAdapter
+  defaultOptions={{
+    shallow: false,
+    scroll: true,
+    clearOnDefault: false,
+    limitUrlUpdates: throttle(250),
+  }}
+>
   {children}
 </NuqsAdapter>
 ```

--- a/packages/nuqs/src/adapters/lib/context.ts
+++ b/packages/nuqs/src/adapters/lib/context.ts
@@ -7,14 +7,15 @@ import {
   type ReactElement,
   type ReactNode
 } from 'react'
+import type { Options } from '../../defs'
 import { debugEnabled } from '../../lib/debug'
 import { error } from '../../lib/errors'
 import type { AdapterInterface, UseAdapterHook } from './defs'
 
 export type AdapterProps = {
-  defaultOptions?: {
-    shallow?: boolean
-  }
+  defaultOptions?: Partial<
+    Pick<Options, 'shallow' | 'clearOnDefault' | 'scroll' | 'limitUrlUpdates'>
+  >
 }
 
 export type AdapterContext = AdapterProps & {

--- a/packages/nuqs/src/useQueryState.test.ts
+++ b/packages/nuqs/src/useQueryState.test.ts
@@ -331,18 +331,45 @@ describe('useQueryState: adapter defaults', () => {
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
     const { result } = renderHook(() => useQueryState('test'), {
       wrapper: withNuqsTestingAdapter({
-        searchParams: '?test=default',
         defaultOptions: {
           shallow: false
         },
         onUrlUpdate
       })
     })
-    expect(result.current[0]).toEqual('default')
-
     await act(() => result.current[1]('update'))
-
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].options.shallow).toBe(false)
+  })
+  it('should use adapter default value for `scroll` when provided', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result } = renderHook(() => useQueryState('test'), {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          scroll: true
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]('update'))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.scroll).toBe(true)
+  })
+  it('should use adapter default value for `clearOnDefault` when provided', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result } = renderHook(
+      () => useQueryState('test', { defaultValue: 'pass' }),
+      {
+        wrapper: withNuqsTestingAdapter({
+          defaultOptions: {
+            clearOnDefault: false
+          },
+          onUrlUpdate
+        })
+      }
+    )
+    await act(() => result.current[1]('pass'))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?test=pass')
   })
 })

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -210,14 +210,14 @@ export function useQueryState<T = string>(
   const {
     history = 'replace',
     shallow = defaultOptions?.shallow ?? true,
-    scroll = false,
+    scroll = defaultOptions?.scroll ?? false,
     throttleMs = defaultRateLimit.timeMs,
-    limitUrlUpdates,
+    limitUrlUpdates = defaultOptions?.limitUrlUpdates,
     parse = x => x as unknown as T,
     serialize = String,
     eq = (a, b) => a === b,
     defaultValue = undefined,
-    clearOnDefault = true,
+    clearOnDefault = defaultOptions?.clearOnDefault ?? true,
     startTransition
   } = options
   const hookId = useId()

--- a/packages/nuqs/src/useQueryStates.test.ts
+++ b/packages/nuqs/src/useQueryStates.test.ts
@@ -690,19 +690,45 @@ describe('useQueryStates: adapter defaults', () => {
     const useTestHook = () => useQueryStates({ test: parseAsString })
     const { result } = renderHook(useTestHook, {
       wrapper: withNuqsTestingAdapter({
-        searchParams: '?test=default',
         defaultOptions: {
           shallow: false
         },
         onUrlUpdate
       })
     })
-
-    expect(result.current[0]).toEqual({ test: 'default' })
-
     await act(() => result.current[1]({ test: 'update' }))
-
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].options.shallow).toBe(false)
+  })
+  it('should use adapter default value for `scroll` when provided', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () => useQueryStates({ test: parseAsString })
+    const { result } = renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          scroll: true
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]({ test: 'update' }))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.scroll).toBe(true)
+  })
+  it('should use adapter default value for `clearOnDefault` when provided', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () =>
+      useQueryStates({ test: parseAsString.withDefault('pass') })
+    const { result } = renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          clearOnDefault: false
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]({ test: 'pass' }))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?test=pass')
   })
 })

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -71,11 +71,11 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
   const {
     history = 'replace',
-    scroll = false,
+    scroll = defaultOptions?.scroll ?? false,
     shallow = defaultOptions?.shallow ?? true,
     throttleMs = defaultRateLimit.timeMs,
-    limitUrlUpdates,
-    clearOnDefault = true,
+    limitUrlUpdates = defaultOptions?.limitUrlUpdates,
+    clearOnDefault = defaultOptions?.clearOnDefault ?? true,
     startTransition,
     urlKeys = defaultUrlKeys as UrlKeys<KeyMap>
   } = options


### PR DESCRIPTION
Supported:
- `shallow` defaults to `true`, change to `false` to always send 
notifications to the server on updates
- `scroll` defaults to `false`, change to `true` to always scroll to
the top of the page after an update
- `clearOnDefault` defaults to `true`, change to `false` to always
write values to the URL, even when set to the default value (explicit defaults)
- `limitUrlUpdates` defaults to a custom throttle rate for your browser,
increase it here if need be (debouncing at the top level is not recommended).

cc @TkDodo