### PR TITLE
chore: Reduce the bundle size

### DIFF
--- a/packages/e2e/shared/specs/stitching.tsx
+++ b/packages/e2e/shared/specs/stitching.tsx
@@ -36,9 +36,9 @@ function StitchingUseQueryState() {
     setC(x => x + 1, { limitUrlUpdates: debounce(200) })
   }
   const testStaggered = () => {
-    setC(x => x + 1, { limitUrlUpdates: debounce(200) })
+    setC(x => x + 1, { limitUrlUpdates: debounce(500) })
     setTimeout(() => {
-      setB(x => x + 1, { limitUrlUpdates: debounce(100) })
+      setB(x => x + 1, { limitUrlUpdates: debounce(250) })
       setTimeout(() => {
         setA(x => x + 1)
       }, 0)

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -138,8 +138,7 @@
     "prepack": "./scripts/prepack.sh"
   },
   "dependencies": {
-    "@standard-schema/spec": "1.0.0",
-    "mitt": "^3.0.1"
+    "@standard-schema/spec": "1.0.0"
   },
   "peerDependencies": {
     "@remix-run/react": ">=2",
@@ -197,7 +196,7 @@
     {
       "name": "Client",
       "path": "dist/index.js",
-      "limit": "6 kB",
+      "limit": "5.6 kB",
       "ignore": [
         "react",
         "next"

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -196,7 +196,7 @@
     {
       "name": "Client",
       "path": "dist/index.js",
-      "limit": "5.6 kB",
+      "limit": "5.5 kB",
       "ignore": [
         "react",
         "next"

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -1,9 +1,9 @@
-import type { Emitter } from 'mitt'
 import { debug } from '../../lib/debug'
+import type { Emitter } from '../../lib/emitter'
 import { error } from '../../lib/errors'
 import { resetQueues, spinQueueResetMutex } from '../../lib/queues/reset'
 
-export type SearchParamsSyncEmitter = Emitter<{ update: URLSearchParams }>
+export type SearchParamsSyncEmitterEvents = { update: URLSearchParams }
 
 export const historyUpdateMarker = '__nuqs__'
 
@@ -62,7 +62,7 @@ export function markHistoryAsPatched(adapter: string): void {
 }
 
 export function patchHistory(
-  emitter: SearchParamsSyncEmitter,
+  emitter: Emitter<SearchParamsSyncEmitterEvents>,
   adapter: string
 ): void {
   if (!shouldPatchHistory(adapter)) {

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -1,4 +1,3 @@
-import mitt from 'mitt'
 import {
   startTransition,
   useCallback,
@@ -7,6 +6,7 @@ import {
   useState
 } from 'react'
 import { debug } from '../../lib/debug'
+import { createEmitter } from '../../lib/emitter'
 import { setQueueResetMutex } from '../../lib/queues/reset'
 import { globalThrottleQueue } from '../../lib/queues/throttle'
 import { renderQueryString } from '../../lib/url-encoding'
@@ -16,7 +16,7 @@ import { applyChange, filterSearchParams } from './key-isolation'
 import {
   patchHistory as applyHistoryPatch,
   historyUpdateMarker,
-  type SearchParamsSyncEmitter
+  type SearchParamsSyncEmitterEvents
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -49,7 +49,7 @@ export function createReactRouterBasedAdapter({
   NuqsAdapter: AdapterProvider
   useOptimisticSearchParams: () => URLSearchParams
 } {
-  const emitter: SearchParamsSyncEmitter = mitt()
+  const emitter = createEmitter<SearchParamsSyncEmitterEvents>()
   const enableQueueReset = adapter !== 'react-router-v6'
   function useNuqsReactRouterBasedAdapter(
     watchKeys: string[]

--- a/packages/nuqs/src/adapters/react.ts
+++ b/packages/nuqs/src/adapters/react.ts
@@ -1,4 +1,3 @@
-import mitt from 'mitt'
 import {
   createContext,
   createElement,
@@ -10,6 +9,7 @@ import {
   type ReactNode
 } from 'react'
 import { debug } from '../lib/debug'
+import { createEmitter } from '../lib/emitter'
 import { renderQueryString } from '../lib/url-encoding'
 import { createAdapterProvider, type AdapterProps } from './lib/context'
 import type { AdapterInterface, AdapterOptions } from './lib/defs'
@@ -17,10 +17,10 @@ import { applyChange, filterSearchParams } from './lib/key-isolation'
 import {
   historyUpdateMarker,
   patchHistory,
-  type SearchParamsSyncEmitter
+  type SearchParamsSyncEmitterEvents
 } from './lib/patch-history'
 
-const emitter: SearchParamsSyncEmitter = mitt()
+const emitter = createEmitter<SearchParamsSyncEmitterEvents>()
 
 function generateUpdateUrlFn(fullPageNavigationOnShallowFalseUpdates: boolean) {
   return function updateUrl(search: URLSearchParams, options: AdapterOptions) {

--- a/packages/nuqs/src/lib/compose.ts
+++ b/packages/nuqs/src/lib/compose.ts
@@ -2,15 +2,13 @@ export function compose(
   fns: React.TransitionStartFunction[],
   final: () => void
 ): void {
-  const recursiveCompose = (index: number) => {
-    if (index === fns.length) {
-      return final()
-    }
-    const fn = fns[index]
-    if (!fn) {
-      throw new Error('Invalid transition function')
-    }
-    fn(() => recursiveCompose(index + 1))
+  // Build a nested callback chain iteratively (avoids recursion helper)
+  let next = final
+  for (let i = fns.length - 1; i >= 0; i--) {
+    const fn = fns[i]
+    if (!fn) continue
+    const prev = next
+    next = () => fn(prev)
   }
-  recursiveCompose(0)
+  next()
 }

--- a/packages/nuqs/src/lib/debug.ts
+++ b/packages/nuqs/src/lib/debug.ts
@@ -9,7 +9,7 @@ export function debug(message: string, ...args: any[]): void {
   try {
     // Handle React Devtools not being able to console.log('%s', null)
     console.log(message, ...args)
-  } catch (error) {
+  } catch {
     console.log(msg)
   }
 }
@@ -24,37 +24,30 @@ export function warn(message: string, ...args: any[]): void {
 export function sprintf(base: string, ...args: any[]): string {
   return base.replace(/%[sfdO]/g, match => {
     const arg = args.shift()
-    if (match === '%O' && arg) {
-      return JSON.stringify(arg).replace(/"([^"]+)":/g, '$1:')
-    } else {
-      return String(arg)
-    }
+    return match === '%O' && arg
+      ? JSON.stringify(arg).replace(/"([^"]+)":/g, '$1:')
+      : String(arg)
   })
 }
 
-function isDebugEnabled() {
+function isDebugEnabled(): boolean {
   // Check if localStorage is available.
   // It may be unavailable in some environments,
   // like Safari in private browsing mode.
   // See https://github.com/47ng/nuqs/pull/588
   try {
+    const test = 'nuqs-localStorage-test'
     if (typeof localStorage === 'undefined') {
       return false
     }
-    const test = 'nuqs-localStorage-test'
     localStorage.setItem(test, test)
     const isStorageAvailable = localStorage.getItem(test) === test
     localStorage.removeItem(test)
-    if (!isStorageAvailable) {
-      return false
-    }
-  } catch (error) {
-    console.error(
-      '[nuqs]: debug mode is disabled (localStorage unavailable).',
-      error
+    return (
+      isStorageAvailable &&
+      (localStorage.getItem('debug') || '').includes('nuqs')
     )
+  } catch {
     return false
   }
-  const debug = localStorage.getItem('debug') ?? ''
-  return debug.includes('nuqs')
 }

--- a/packages/nuqs/src/lib/emitter.test.ts
+++ b/packages/nuqs/src/lib/emitter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createEmitter } from './emitter'
+
+type Events = {
+  test: string
+}
+
+describe('emitter', () => {
+  it('allows subscribing to events', () => {
+    const emitter = createEmitter<Events>()
+    const handler = vi.fn()
+    emitter.on('test', handler)
+    emitter.emit('test', 'pass')
+    expect(handler).toHaveBeenCalledExactlyOnceWith('pass')
+  })
+  it('allows unsubscribing from events from the returned callback', () => {
+    const emitter = createEmitter<Events>()
+    const handler = vi.fn()
+    const unsubscribe = emitter.on('test', handler)
+    unsubscribe()
+    emitter.emit('test', 'pass')
+    expect(handler).not.toHaveBeenCalled()
+  })
+  it('allows unsubscribing from events from an off method', () => {
+    const emitter = createEmitter<Events>()
+    const handler = vi.fn()
+    emitter.on('test', handler)
+    emitter.off('test', handler)
+    emitter.emit('test', 'pass')
+    expect(handler).not.toHaveBeenCalled()
+  })
+  it('allows listing all handlers for an event', () => {
+    const emitter = createEmitter<Events>()
+    const handler1 = vi.fn()
+    const handler2 = vi.fn()
+    emitter.on('test', handler1)
+    emitter.on('test', handler2)
+    expect(emitter.all.get('test')).toEqual([handler1, handler2])
+    emitter.off('test', handler1)
+    expect(emitter.all.get('test')).toEqual([handler2])
+  })
+  it('allows emitting events with no payload', () => {
+    const emitter = createEmitter<{ test: never }>()
+    const handler = vi.fn()
+    emitter.on('test', handler)
+    emitter.emit('test')
+    expect(handler).toHaveBeenCalledExactlyOnceWith(undefined)
+  })
+})

--- a/packages/nuqs/src/lib/emitter.ts
+++ b/packages/nuqs/src/lib/emitter.ts
@@ -28,8 +28,7 @@ export function createEmitter<
       handler: (event: Events[Key]) => any
     ): () => void {
       const handlers = all.get(type) || []
-      // @ts-expect-error
-      handlers.push(handler)
+      handlers.push(handler as (event: Events[keyof Events]) => any)
       all.set(type, handlers)
       return () => this.off(type, handler)
     },
@@ -50,8 +49,7 @@ export function createEmitter<
       event?: Events[Key] extends undefined ? never : Events[Key]
     ): void {
       const handlers = all.get(type)
-      // @ts-expect-error
-      handlers?.forEach(handler => handler(event))
+      handlers?.forEach(handler => handler(event as Events[keyof Events]))
     }
   }
 }

--- a/packages/nuqs/src/lib/emitter.ts
+++ b/packages/nuqs/src/lib/emitter.ts
@@ -1,0 +1,57 @@
+export type Emitter<Events extends Record<string, unknown>> = {
+  on<Key extends keyof Events>(
+    type: Key,
+    handler: (event: Events[Key]) => any
+  ): () => void
+  off<Key extends keyof Events>(
+    type: Key,
+    handler?: (event: Events[Key]) => any
+  ): void
+  emit<Key extends keyof Events>(
+    type: Key,
+    event?: Events[Key] extends undefined ? never : Events[Key]
+  ): void
+  all: Map<keyof Events, Array<(event: Events[keyof Events]) => any>>
+}
+
+export function createEmitter<
+  Events extends Record<string, unknown>
+>(): Emitter<Events> {
+  const all: Map<
+    keyof Events,
+    Array<(event: Events[keyof Events]) => any>
+  > = new Map()
+  return {
+    all,
+    on<Key extends keyof Events>(
+      type: Key,
+      handler: (event: Events[Key]) => any
+    ): () => void {
+      const handlers = all.get(type) || []
+      // @ts-expect-error
+      handlers.push(handler)
+      all.set(type, handlers)
+      return () => this.off(type, handler)
+    },
+    off<Key extends keyof Events>(
+      type: Key,
+      handler: (event: Events[Key]) => any
+    ): void {
+      const handlers = all.get(type)
+      if (handlers) {
+        all.set(
+          type,
+          handlers.filter(h => h !== handler)
+        )
+      }
+    },
+    emit<Key extends keyof Events>(
+      type: Key,
+      event?: Events[Key] extends undefined ? never : Events[Key]
+    ): void {
+      const handlers = all.get(type)
+      // @ts-expect-error
+      handlers?.forEach(handler => handler(event))
+    }
+  }
+}

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -1,6 +1,5 @@
-import type { Emitter } from 'mitt'
-import mitt from 'mitt'
 import { debug } from '../debug'
+import { createEmitter, type Emitter } from '../emitter'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
 import {
@@ -68,7 +67,7 @@ type DebouncedUpdateQueue = DebouncedPromiseQueue<
 export class DebounceController {
   throttleQueue: ThrottledQueue
   queues: Map<string, DebouncedUpdateQueue> = new Map()
-  queuedQuerySync: Emitter<Record<string, undefined>> = mitt()
+  queuedQuerySync: Emitter<Record<string, undefined>> = createEmitter()
 
   constructor(throttleQueue: ThrottledQueue = new ThrottledQueue()) {
     this.throttleQueue = throttleQueue
@@ -77,10 +76,7 @@ export class DebounceController {
   useQueuedQueries(keys: string[]): Record<string, string | null | undefined> {
     return useSyncExternalStores(
       keys,
-      (key, callback) => {
-        this.queuedQuerySync.on(key, callback)
-        return () => this.queuedQuerySync.off(key, callback)
-      },
+      (key, callback) => this.queuedQuerySync.on(key, callback),
       (key: string) => this.getQueuedQuery(key)
     )
   }

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -39,7 +39,7 @@ export class DebouncedPromiseQueue<ValueType, OutputType> {
         try {
           debug('[nuqs dq] Flushing debounce queue', value)
           const callbackPromise = this.callback(value)
-          debug('[nuqs dq] Reset debounced queue %O', this.queuedValue)
+          debug('[nuqs dq] Reset debounce queue %O', this.queuedValue)
           this.queuedValue = undefined
           this.resolvers = withResolvers<OutputType>()
           callbackPromise
@@ -92,7 +92,7 @@ export class DebounceController {
       return Promise.resolve(getSnapshot())
     }
     if (!this.queues.has(update.key)) {
-      debug('[nuqs dqc] Creating debounced queue for `%s`', update.key)
+      debug('[nuqs dqc] Creating debounce queue for `%s`', update.key)
       const queue = new DebouncedPromiseQueue<
         Omit<UpdateQueuePushArgs, 'timeMs'>,
         URLSearchParams
@@ -110,7 +110,7 @@ export class DebounceController {
       this.queues.set(update.key, queue)
     }
     debug(
-      '[nuqs dqc] Enqueueing debounced update %s=%s %O',
+      '[nuqs dqc] Enqueueing debounce update %s=%s %O',
       update.key,
       update.query,
       update.options
@@ -129,7 +129,7 @@ export class DebounceController {
       return passThrough => passThrough
     }
     debug(
-      '[nuqs dqc] Aborting debounced queue %s=%s',
+      '[nuqs dqc] Aborting debounce queue %s=%s',
       key,
       queue.queuedValue?.query
     )
@@ -151,7 +151,7 @@ export class DebounceController {
   abortAll(): void {
     for (const [key, queue] of this.queues.entries()) {
       debug(
-        '[nuqs dqc] Aborting debounced queue %s=%s',
+        '[nuqs dqc] Aborting debounce queue %s=%s',
         key,
         queue.queuedValue?.query
       )

--- a/packages/nuqs/src/lib/queues/useSyncExternalStores.test.ts
+++ b/packages/nuqs/src/lib/queues/useSyncExternalStores.test.ts
@@ -1,12 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
-import mitt, { type Emitter } from 'mitt'
 import { useRef } from 'react'
 import { describe, expect, it } from 'vitest'
+import { createEmitter } from '../emitter'
 import { useSyncExternalStores } from './useSyncExternalStores'
-
-function createEmitter(): Emitter<Record<string, undefined>> {
-  return mitt()
-}
 
 describe('useSyncExternalStores', () => {
   it('should handle an empty array of keys', () => {

--- a/packages/nuqs/src/lib/sync.ts
+++ b/packages/nuqs/src/lib/sync.ts
@@ -1,4 +1,4 @@
-import mitt, { type Emitter } from 'mitt'
+import { createEmitter, type Emitter } from './emitter'
 
 export type CrossHookSyncPayload = {
   state: any
@@ -9,4 +9,4 @@ type EventMap = {
   [key: string]: CrossHookSyncPayload
 }
 
-export const emitter: Emitter<EventMap> = mitt()
+export const emitter: Emitter<EventMap> = createEmitter()

--- a/packages/nuqs/src/lib/with-resolvers.ts
+++ b/packages/nuqs/src/lib/with-resolvers.ts
@@ -6,7 +6,7 @@ export type Resolvers<T> = {
 
 export function withResolvers<T>(): Resolvers<T> {
   const P = Promise<T>
-  if ('withResolvers' in Promise) {
+  if (Promise.hasOwnProperty('withResolvers')) {
     return Promise.withResolvers<T>()
   }
   // todo: Remove this once Promise.withResolvers is Baseline GA (September 2026)

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -149,7 +149,7 @@ function extractSearchParams(input: LoaderInput): URLSearchParams {
       return searchParams
     }
     if (typeof input === 'string') {
-      if ('canParse' in URL && URL.canParse(input)) {
+      if (URL.hasOwnProperty('canParse') && URL.canParse(input)) {
         return new URL(input).searchParams
       }
       return new URLSearchParams(input)

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -127,11 +127,7 @@ export function createLoader<Parsers extends ParserMap>(
 function extractSearchParams(input: LoaderInput): URLSearchParams {
   try {
     if (input instanceof Request) {
-      if (input.url) {
-        return new URL(input.url).searchParams
-      } else {
-        return new URLSearchParams()
-      }
+      return input.url ? new URL(input.url).searchParams : new URLSearchParams()
     }
     if (input instanceof URL) {
       return input.searchParams
@@ -140,9 +136,8 @@ function extractSearchParams(input: LoaderInput): URLSearchParams {
       return input
     }
     if (typeof input === 'object') {
-      const entries = Object.entries(input)
       const searchParams = new URLSearchParams()
-      for (const [key, value] of entries) {
+      for (const [key, value] of Object.entries(input)) {
         if (Array.isArray(value)) {
           for (const v of value) {
             searchParams.append(key, v)
@@ -159,8 +154,6 @@ function extractSearchParams(input: LoaderInput): URLSearchParams {
       }
       return new URLSearchParams(input)
     }
-  } catch (e) {
-    return new URLSearchParams()
-  }
+  } catch {}
   return new URLSearchParams()
 }

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -161,7 +161,7 @@ export const parseAsString: ParserBuilder<string> = createParser({
 export const parseAsInteger: ParserBuilder<number> = createParser({
   parse: v => {
     const int = parseInt(v)
-    return int == int ? int : null // NaN check
+    return int == int ? int : null // NaN check at low bundle size cost
   },
   serialize: v => '' + Math.round(v)
 })
@@ -169,7 +169,7 @@ export const parseAsInteger: ParserBuilder<number> = createParser({
 export const parseAsIndex: ParserBuilder<number> = createParser({
   parse: v => {
     const int = parseInt(v)
-    return int == int ? int - 1 : null // NaN check
+    return int == int ? int - 1 : null // NaN check at low bundle size cost
   },
   serialize: v => '' + Math.round(v + 1)
 })
@@ -177,7 +177,7 @@ export const parseAsIndex: ParserBuilder<number> = createParser({
 export const parseAsHex: ParserBuilder<number> = createParser({
   parse: v => {
     const int = parseInt(v, 16)
-    return int == int ? int : null // NaN check
+    return int == int ? int : null // NaN check at low bundle size cost
   },
   serialize: v => {
     const hex = Math.round(v).toString(16)
@@ -188,7 +188,7 @@ export const parseAsHex: ParserBuilder<number> = createParser({
 export const parseAsFloat: ParserBuilder<number> = createParser({
   parse: v => {
     const float = parseFloat(v)
-    return float == float ? float : null // NaN check
+    return float == float ? float : null // NaN check at low bundle size cost
   },
   serialize: String
 })
@@ -209,7 +209,7 @@ function compareDates(a: Date, b: Date) {
 export const parseAsTimestamp: ParserBuilder<Date> = createParser({
   parse: v => {
     const ms = parseInt(v)
-    return ms == ms ? new Date(ms) : null
+    return ms == ms ? new Date(ms) : null // NaN check at low bundle size cost
   },
   serialize: (v: Date) => '' + v.valueOf(),
   eq: compareDates
@@ -222,6 +222,7 @@ export const parseAsTimestamp: ParserBuilder<Date> = createParser({
 export const parseAsIsoDateTime: ParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
+    // NaN check at low bundle size cost
     return date.valueOf() == date.valueOf() ? date : null
   },
   serialize: (v: Date) => v.toISOString(),
@@ -239,6 +240,7 @@ export const parseAsIsoDateTime: ParserBuilder<Date> = createParser({
 export const parseAsIsoDate: ParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v.slice(0, 10))
+    // NaN check at low bundle size cost
     return date.valueOf() == date.valueOf() ? date : null
   },
   serialize: (v: Date) => v.toISOString().slice(0, 10),

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -155,59 +155,47 @@ export function createParser<T>(
 
 export const parseAsString: ParserBuilder<string> = createParser({
   parse: v => v,
-  serialize: v => `${v}`
+  serialize: String
 })
 
 export const parseAsInteger: ParserBuilder<number> = createParser({
   parse: v => {
     const int = parseInt(v)
-    if (Number.isNaN(int)) {
-      return null
-    }
-    return int
+    return int == int ? int : null // NaN check
   },
-  serialize: v => Math.round(v).toFixed()
+  serialize: v => '' + Math.round(v)
 })
 
 export const parseAsIndex: ParserBuilder<number> = createParser({
   parse: v => {
-    const int = parseAsInteger.parse(v)
-    if (int === null) {
-      return null
-    }
-    return int - 1
+    const int = parseInt(v)
+    return int == int ? int - 1 : null // NaN check
   },
-  serialize: v => parseAsInteger.serialize(v + 1)
+  serialize: v => '' + Math.round(v + 1)
 })
 
 export const parseAsHex: ParserBuilder<number> = createParser({
   parse: v => {
     const int = parseInt(v, 16)
-    if (Number.isNaN(int)) {
-      return null
-    }
-    return int
+    return int == int ? int : null // NaN check
   },
   serialize: v => {
     const hex = Math.round(v).toString(16)
-    return hex.padStart(hex.length + (hex.length % 2), '0')
+    return (hex.length & 1 ? '0' : '') + hex
   }
 })
 
 export const parseAsFloat: ParserBuilder<number> = createParser({
   parse: v => {
     const float = parseFloat(v)
-    if (Number.isNaN(float)) {
-      return null
-    }
-    return float
+    return float == float ? float : null // NaN check
   },
-  serialize: v => v.toString()
+  serialize: String
 })
 
 export const parseAsBoolean: ParserBuilder<boolean> = createParser({
   parse: v => v === 'true',
-  serialize: v => (v ? 'true' : 'false')
+  serialize: String
 })
 
 function compareDates(a: Date, b: Date) {
@@ -221,12 +209,9 @@ function compareDates(a: Date, b: Date) {
 export const parseAsTimestamp: ParserBuilder<Date> = createParser({
   parse: v => {
     const ms = parseInt(v)
-    if (Number.isNaN(ms)) {
-      return null
-    }
-    return new Date(ms)
+    return ms == ms ? new Date(ms) : null
   },
-  serialize: (v: Date) => v.valueOf().toString(),
+  serialize: (v: Date) => '' + v.valueOf(),
   eq: compareDates
 })
 
@@ -237,10 +222,7 @@ export const parseAsTimestamp: ParserBuilder<Date> = createParser({
 export const parseAsIsoDateTime: ParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
-    if (Number.isNaN(date.valueOf())) {
-      return null
-    }
-    return date
+    return date.valueOf() == date.valueOf() ? date : null
   },
   serialize: (v: Date) => v.toISOString(),
   eq: compareDates
@@ -257,10 +239,7 @@ export const parseAsIsoDateTime: ParserBuilder<Date> = createParser({
 export const parseAsIsoDate: ParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v.slice(0, 10))
-    if (Number.isNaN(date.valueOf())) {
-      return null
-    }
-    return date
+    return date.valueOf() == date.valueOf() ? date : null
   },
   serialize: (v: Date) => v.toISOString().slice(0, 10),
   eq: compareDates
@@ -296,16 +275,8 @@ export const parseAsIsoDate: ParserBuilder<Date> = createParser({
 export function parseAsStringEnum<Enum extends string>(
   validValues: Enum[]
 ): ParserBuilder<Enum> {
-  return createParser({
-    parse: (query: string) => {
-      const asEnum = query as unknown as Enum
-      if (validValues.includes(asEnum)) {
-        return asEnum
-      }
-      return null
-    },
-    serialize: (value: Enum) => value.toString()
-  })
+  // Delegate implementation to parseAsStringLiteral to avoid duplication.
+  return parseAsStringLiteral(validValues as readonly Enum[])
 }
 
 /**
@@ -333,12 +304,9 @@ export function parseAsStringLiteral<const Literal extends string>(
   return createParser({
     parse: (query: string) => {
       const asConst = query as unknown as Literal
-      if (validValues.includes(asConst)) {
-        return asConst
-      }
-      return null
+      return validValues.includes(asConst) ? asConst : null
     },
-    serialize: (value: Literal) => value.toString()
+    serialize: String
   })
 }
 
@@ -372,7 +340,7 @@ export function parseAsNumberLiteral<const Literal extends number>(
       }
       return null
     },
-    serialize: (value: Literal) => value.toString()
+    serialize: String
   })
 }
 

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -221,8 +221,9 @@ export function useQueryState<T = string>(
         old => ({
           [key]:
             typeof stateUpdater === 'function'
-              ? // @ts-expect-error
-                stateUpdater(old[key]!)
+              ? // @ts-expect-error somehow stateUpdater is not narrowed correctly
+                // and useQueryStates' key type is not inferred
+                stateUpdater(old[key])
               : stateUpdater
         }),
         callOptions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 15.6.9(@types/react@19.1.1)(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       fumadocs-mdx:
         specifier: ^11.7.4
-        version: 11.7.4(acorn@8.15.0)(fumadocs-core@15.6.9(@types/react@19.1.1)(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0))(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(vite@7.1.1(@types/node@24.2.1))
+        version: 11.7.4(acorn@8.15.0)(fumadocs-core@15.6.9(@types/react@19.1.1)(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0))(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(vite@7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
       fumadocs-ui:
         specifier: ^15.6.9
         version: 15.6.9(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)
@@ -673,9 +673,6 @@ importers:
       '@tanstack/react-router':
         specifier: ^1
         version: 1.121.41(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      mitt:
-        specifier: ^3.0.1
-        version: 3.0.1
       react-router:
         specifier: ^6 || ^7
         version: 7.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -724,7 +721,7 @@ importers:
         version: 26.1.0
       next:
         specifier: 15.4.6
-        version: 15.4.6(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.4.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: catalog:react19
         version: 19.1.0
@@ -14772,7 +14769,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@11.7.4(acorn@8.15.0)(fumadocs-core@15.6.9(@types/react@19.1.1)(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0))(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(vite@7.1.1(@types/node@24.2.1)):
+  fumadocs-mdx@11.7.4(acorn@8.15.0)(fumadocs-core@15.6.9(@types/react@19.1.1)(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react-router@7.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0))(next@15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(vite@7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)):
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       '@standard-schema/spec': 1.0.0
@@ -14790,7 +14787,7 @@ snapshots:
     optionalDependencies:
       next: 15.4.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
-      vite: 7.1.1(@types/node@24.2.1)
+      vite: 7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - acorn
       - supports-color
@@ -16569,30 +16566,6 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.4.6(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      '@next/env': 15.4.6
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001733
-      postcss: 8.4.31
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.1.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.4.6
-      '@next/swc-darwin-x64': 15.4.6
-      '@next/swc-linux-arm64-gnu': 15.4.6
-      '@next/swc-linux-arm64-musl': 15.4.6
-      '@next/swc-linux-x64-gnu': 15.4.6
-      '@next/swc-linux-x64-musl': 15.4.6
-      '@next/swc-win32-arm64-msvc': 15.4.6
-      '@next/swc-win32-x64-msvc': 15.4.6
-      '@opentelemetry/api': 1.9.0
-      sharp: 0.34.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   next@15.4.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.4.6
@@ -16601,7 +16574,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.1.0)
+      styled-jsx: 5.1.6(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.6
       '@next/swc-darwin-x64': 15.4.6
@@ -18182,12 +18155,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.1.0):
+  styled-jsx@5.1.6(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
-    optionalDependencies:
-      '@babel/core': 7.26.10
 
   styled-jsx@5.1.6(react@19.1.1):
     dependencies:
@@ -19037,7 +19008,7 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.1
 
-  vite@7.1.1(@types/node@24.2.1):
+  vite@7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -19048,6 +19019,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.2.1
       fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      terser: 5.43.1
+      tsx: 4.20.3
+      yaml: 2.8.1
     optional: true
 
   vitest-package-exports@0.1.1:


### PR DESCRIPTION
Various little refactorings here and there to reduce the minified + gzipped bundle size.

Notable changes:
- Replaced `mitt` with a smaller emitter bus (we didn't need the '*' event in mitt). nuqs is now a zero-runtime-dependency library! 🙌
- Removed the implementation of useQueryState to use useQueryStates internally

Ideally if we could land under 5kB that would be amazing, but short of removing all the debug log points, it would likely make the code hard to read and/or maintain.

Reduction: 5.943kB → 5.48kB (-463B, ~8%)