### PR TITLE
ci: add docs typecheck & build job (#1075)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,6 +14,42 @@ env:
   FORCE_COLOR: 3 # Diplay chalk colors
 
 jobs:
+  docs:
+    name: Docs Typecheck & Build
+    runs-on: ubuntu-24.04-arm
+    needs: [ci-core]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Install docs dependencies
+        run: pnpm install --frozen-lockfile --filter docs...
+      - name: Run fumadocs postinstall
+        run: pnpm --filter docs run postinstall
+      - name: Build dependencies (nuqs, res packages)
+        run: pnpm build --filter docs... --filter=!docs
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      - name: Type-check docs
+        run: pnpm --filter docs run typecheck
+      - name: Build docs
+        run: pnpm build --filter docs
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      - uses: 47ng/actions-slack-notify@main
+        name: Notify on Slack
+        if: failure()
+        with:
+          status: ${{ job.status }}
+          jobName: docs
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   lint:
     name: Linting
     runs-on: ubuntu-24.04-arm
@@ -313,6 +349,7 @@ jobs:
     name: Notify on Slack
     runs-on: ubuntu-24.04-arm
     needs:
+      - docs
       - lint
       - publint
       - ci-core
@@ -338,6 +375,7 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for NPM provenance
     needs:
+      - docs
       - lint
       - publint
       - ci-core

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -17,7 +17,8 @@
     "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
-    "postinstall": "fumadocs-mdx"
+    "postinstall": "fumadocs-mdx",
+    "typecheck": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@faker-js/faker": "^9.9.0",


### PR DESCRIPTION
- Add typecheck script to docs package.json
- Create CI job for docs typecheck and build with Turborepo cache
- Include fumadocs postinstall for MDX types