### PR TITLE
fix: Lazily create AbortController in throttle queue for CloudFlare Workers support

### DIFF
--- a/packages/nuqs/src/lib/queues/rate-limiting.ts
+++ b/packages/nuqs/src/lib/queues/rate-limiting.ts
@@ -1,5 +1,7 @@
 import type { LimitUrlUpdates } from '../../defs'
 
+// 50ms between calls to the history API seems to satisfy Chrome and Firefox.
+// Safari remains annoying with at most 100 calls in 30 seconds.
 // edit: Safari 17 now allows 100 calls per 10 seconds, a bit better.
 function getDefaultThrottle() {
   if (typeof window === 'undefined') return 50


### PR DESCRIPTION
Some operations are not allowed at the top level in CloudFlare Workers, which includes creating an AbortController.

Since the global throttle queue is a singleton, it gets bundled up in the server bundle and causes this issue.

We now lazily create that controller on the first call to `flush`, when it becomes needed.

Fixes #1091.