### PR TITLE
chore: Add bundle size comparison workflow

### DIFF
--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -21,7 +21,11 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: .node-version
+          cache: pnpm
       - name: Check for test file changes only
         id: check-files
         run: |
@@ -37,10 +41,13 @@ jobs:
           done
 
           echo "test_only=$test_only" >> $GITHUB_OUTPUT
-
+      - name: Install dependencies
+        if: steps.check-files.outputs.test_only != 'true'
+        run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs...
       - name: Check bundle size
         if: steps.check-files.outputs.test_only != 'true'
         uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          build_script: pnpm build --filter nuqs
           directory: packages/nuqs

--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -23,6 +23,18 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+      - name: Ensure cache paths exist
+        run: |
+          mkdir -p node_modules
+          mkdir -p .pnpm-store
+      - uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            .pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -32,8 +44,10 @@ jobs:
         id: check-files
         run: |
           set -e
-          # Fetch full history (if not already)
-          git fetch --unshallow || true
+          # Only unshallow if the repo is shallow
+          if git rev-parse --is-shallow-repository | grep -q true; then
+            git fetch --unshallow
+          fi
 
           # Get changed files between base and head
           changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" -- 'packages/nuqs/src/**/*.ts')

--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -1,0 +1,29 @@
+name: Bundle Size Comparison
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'packages/nuqs/**/*.ts'
+      - 'packages/nuqs/package.json'
+      - 'packages/nuqs/tsconfig.json'
+    paths-ignore:
+      - 'packages/nuqs/**/*.test.ts'
+      - 'packages/nuqs/**/*.spec.ts'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  size-comparision:
+    name: Compare bundle size
+    runs-on: ubuntu-24.04-arm
+    if: github.event.pull_request.draft == false
+    env:
+      CI_JOB_NUMBER: 1
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Check bundle size
+        uses: andresz1/size-limit-action@v1.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          directory: packages/nuqs

--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -3,12 +3,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'packages/nuqs/**/*.ts'
+      - 'packages/nuqs/src/**/*.ts'
       - 'packages/nuqs/package.json'
+      - 'packages/nuqs/tsdown.config.ts'
       - 'packages/nuqs/tsconfig.json'
-    paths-ignore:
-      - 'packages/nuqs/**/*.test.ts'
-      - 'packages/nuqs/**/*.spec.ts'
+      - 'packages/nuqs/tsconfig.build.json'
 
 permissions:
   pull-requests: write
@@ -22,7 +21,25 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Check for test file changes only
+        id: check-files
+        run: |
+          # Check if only test files were changed
+          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- 'packages/nuqs/src/**/*.ts')
+          test_only=true
+
+          for file in $changed_files; do
+            if [[ ! "$file" =~ \.(test)\.(ts)$ ]]; then
+              test_only=false
+              break
+            fi
+          done
+
+          echo "test_only=$test_only" >> $GITHUB_OUTPUT
+
       - name: Check bundle size
+        if: steps.check-files.outputs.test_only != 'true'
         uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -49,16 +49,20 @@ jobs:
             git fetch --unshallow
           fi
 
-          # Get changed files between base and head
-          changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" -- 'packages/nuqs/src/**/*.ts')
+          # Get all changed files first
+          all_changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
+
+          changed_files=$(echo "$all_changed_files" | grep '^packages/nuqs/src/.*\.ts$' || true)
           test_only=true
 
-          for file in $changed_files; do
-            if [[ ! "$file" =~ \.test\.ts$ ]]; then
-              test_only=false
-              break
-            fi
-          done
+          if [ -n "$changed_files" ]; then
+            for file in $changed_files; do
+              if [[ ! "$file" =~ \.test\.ts$ ]]; then
+                test_only=false
+                break
+              fi
+            done
+          fi
 
           echo "test_only=$test_only" >> $GITHUB_OUTPUT
       - name: Install dependencies
@@ -69,5 +73,5 @@ jobs:
         uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          build_script: pnpm build --filter nuqs
+          package_manager: pnpm
           directory: packages/nuqs

--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -21,20 +21,26 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: .node-version
           cache: pnpm
-      - name: Check for test file changes only
+      - name: Check for test file changed only
         id: check-files
         run: |
-          # Check if only test files were changed
-          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- 'packages/nuqs/src/**/*.ts')
+          set -e
+          # Fetch full history (if not already)
+          git fetch --unshallow || true
+
+          # Get changed files between base and head
+          changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" -- 'packages/nuqs/src/**/*.ts')
           test_only=true
 
           for file in $changed_files; do
-            if [[ ! "$file" =~ \.(test)\.(ts)$ ]]; then
+            if [[ ! "$file" =~ \.test\.ts$ ]]; then
               test_only=false
               break
             fi

--- a/.github/workflows/size-comparison.yml
+++ b/.github/workflows/size-comparison.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'packages/nuqs/src/**/*.ts'
+      - '!packages/nuqs/src/**/*.test.ts'
       - 'packages/nuqs/package.json'
       - 'packages/nuqs/tsdown.config.ts'
       - 'packages/nuqs/tsconfig.json'
@@ -21,8 +22,6 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          fetch-depth: 0
       - name: Ensure cache paths exist
         run: |
           mkdir -p node_modules
@@ -40,36 +39,9 @@ jobs:
         with:
           node-version-file: .node-version
           cache: pnpm
-      - name: Check for test file changed only
-        id: check-files
-        run: |
-          set -e
-          # Only unshallow if the repo is shallow
-          if git rev-parse --is-shallow-repository | grep -q true; then
-            git fetch --unshallow
-          fi
-
-          # Get all changed files first
-          all_changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
-
-          changed_files=$(echo "$all_changed_files" | grep '^packages/nuqs/src/.*\.ts$' || true)
-          test_only=true
-
-          if [ -n "$changed_files" ]; then
-            for file in $changed_files; do
-              if [[ ! "$file" =~ \.test\.ts$ ]]; then
-                test_only=false
-                break
-              fi
-            done
-          fi
-
-          echo "test_only=$test_only" >> $GITHUB_OUTPUT
       - name: Install dependencies
-        if: steps.check-files.outputs.test_only != 'true'
         run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs...
       - name: Check bundle size
-        if: steps.check-files.outputs.test_only != 'true'
         uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR introduces an automated bundle size comparison workflow that runs on pull requests affecting the nuqs package. The workflow compares bundle sizes between the base branch and PR head, providing insights into how code changes impact the final bundle size.

## What's Changed
- Added `.github/workflows/size-comparison.yml` workflow
- The workflow automatically runs when PRs modify TypeScript files in `packages/nuqs/src/` or related configuration files
- Uses the existing `size-limit` setup already configured in the `nuqs` package
- Leverages `andresz1/size-limit-action` to generate size comparison reports

## Features
- **Smart triggering**: Only runs when relevant files are changed (TypeScript source files, package.json, or build configs)
- **Test-only optimization**: Skips bundle size checks when only test files are modified to reduce unnecessary CI runs
- **Automated reporting**: Posts size comparison comments directly on PRs via the size-limit-action
- **Incremental updates**: Re-runs comparison when new commits are pushed to the PR
- **Draft PR handling**: Skips execution for draft PRs to conserve resources

<img width="916" height="295" alt="image" src="https://github.com/user-attachments/assets/5926d9d6-60d6-406f-9da1-3f910d580207" />


## Workflow Behavior
1. **Triggers on**: PR opened/synchronized/reopened with changes to nuqs package files
2. **Builds**: Installs dependencies and runs size-limit analysis
3. **Reports**: Automatically comments on PR with size changes (bytes and percentage)
4. **Updates**: Re-evaluates on subsequent commits

## Benefits
- Provides immediate visibility into bundle size impacts of code changes
- Helps prevent accidental bundle size regressions
- Enables informed decisions about performance trade-offs
- Reduces manual overhead of size monitoring

## Testing
- Tested on forked repository with various PR scenarios
- Confirmed proper triggering conditions and size reporting
- Verified test-only file detection works correctly

This workflow will help maintain awareness of bundle size changes and support performance-conscious development practices.