### PR TITLE
feat(debounce): add warning when shallow: true is used with debounce

### DIFF
--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -119,6 +119,11 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     internalState,
     initialSearchParams
   )
+  if (limitUrlUpdates?.method === 'debounce' && shallow === true) {
+    console.warn(
+      '[nuqs] `shallow: true` and `limitUrlUpdates: debounce` are not compatible, use `shallow: false` instead so debounce can work properly (https://nuqs.47ng.com/docs/options#debounce)'
+    )
+  }
   // Initialise the refs with the initial values
   if (
     Object.keys(queryRef.current).join('&') !==


### PR DESCRIPTION
show a warning in case `shallow: true` is used with debounce, even with [the clarification](https://nuqs.47ng.com/docs/options#debounce) in docs, users may still trip up and combine the two options.

I've started this PR as a draft because there're some points that can be debated:
- Is a `console.warn` enough or would it be better to have something more severe like `console.error` or even an actual runtime error?
- The options check is currently in `useQueryStates` hook, as this is the only place where `shallow: true` will work (?), but are there any possible places to also include the check in?