### PR TITLE
doc: Use SVG for Next.js logo in the adapters ToC

### DIFF
--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -24,9 +24,7 @@ wrapping it with a `NuqsAdapter{:ts}` context provider:
 - <ReactRouterV7 className='inline mr-1.5' role="presentation" /> [React Router v7](#react-router-v7)
 - <TanStackRouter className='inline mr-1.5 not-prose' role="presentation"/> [TanStack Router](#tanstack-router)
 
-{/* For some reason the SVG icon's gradient fails when the link is highlighted in the ToC, in Chrome & Firefox (for once, Safari works fine) */}
-
-## <img src="/nextjs.png" alt="Next.js logo" className='not-prose size-[1em] border-[0.5] rounded-full border-white inline mr-1.5 -mt-1' role="presentation" /> Next.js [#nextjs]
+## <NextJS className='inline mr-1.5 -mt-1' role="presentation" /> Next.js [#nextjs]
 
 ### App router [#nextjs-app-router]
 


### PR DESCRIPTION
This showcases a bug with Chrome & Firefox where the gradient on the N logo
disappears when the ToC item is active, but shows up again when it's inactive.

It behaves correctly in Safari.