### PR TITLE
feat: multi-parsers

### DIFF
--- a/packages/docs/content/docs/parsers/built-in.mdx
+++ b/packages/docs/content/docs/parsers/built-in.mdx
@@ -329,11 +329,11 @@ parseAsJson(userSchema.validateSync)
 
 If you want to use the native URL format for arrays, repeating the same key multiple times like:
 
-```
-/products?tag=books&tag=tech&tag=design
-```
+import { Querystring } from '@/src/components/querystring'
 
-you can now use `MultiParsers` like `parseAsNativeArrayOf` to read and write those values in a fully type-safe way.
+<Querystring path="/products" value='?tag=books&tag=tech&tag=design' />
+
+you can now use `MultiParsers{:ts}` like `parseAsNativeArrayOf{:ts}` to read and write those values in a fully type-safe way.
 
 ```tsx
 import { useQueryState, parseAsNativeArrayOf, parseAsInteger } from 'nuqs'
@@ -343,15 +343,17 @@ const [projectIds, setProjectIds] = useQueryState(
   parseAsNativeArrayOf(parseAsInteger)
 )
 
-// ?project=123&project=456 ==> [123, 456]
+// ?project=123&project=456 → [123, 456]
 ```
 
 <Suspense fallback={<DemoFallback />}>
   <NativeArrayParserDemo />
 </Suspense>
 
-<Callout title="Empty Array Default">
-  Note that `parseAsNativeArrayOf` has a built-in default value of empty array (`.withDefault([])`) so that you don't have to handle `null` cases.
+<Callout title="Note: empty array default">
+  `parseAsNativeArrayOf{:ts}` has a built-in default value of empty array (`.withDefault([]){:ts}`) so that you don't have to handle `null{:ts}` cases.
+
+  Calls to `.withDefault(){:ts}` can be chained, so you can use it to set a custom default.
 </Callout>
 
 ## Using parsers server-side

--- a/packages/docs/content/docs/parsers/built-in.mdx
+++ b/packages/docs/content/docs/parsers/built-in.mdx
@@ -338,13 +338,12 @@ you can now use `MultiParsers` like `parseAsNativeArrayOf` to read and write tho
 ```tsx
 import { useQueryState, parseAsNativeArrayOf, parseAsInteger } from 'nuqs'
 
-export function ProjectsFilter() {
-  // ?project=123&project=456 ==> [123, 456]
-  const [projectIds, setProjectIds] = useQueryState(
-    'project',
-    parseAsNativeArrayOf(parseAsInteger)
-  )
-}
+const [projectIds, setProjectIds] = useQueryState(
+  'project',
+  parseAsNativeArrayOf(parseAsInteger)
+)
+
+// ?project=123&project=456 ==> [123, 456]
 ```
 
 <Suspense fallback={<DemoFallback />}>

--- a/packages/docs/content/docs/parsers/built-in.mdx
+++ b/packages/docs/content/docs/parsers/built-in.mdx
@@ -325,7 +325,7 @@ parseAsJson(userSchema.validateSync)
 
 ## Native Arrays
 
-<FeatureSupportMatrix introducedInVersion='2.6.0' />
+<FeatureSupportMatrix introducedInVersion='2.7.0' />
 
 If you want to use the native URL format for arrays, repeating the same key multiple times like:
 

--- a/packages/docs/content/docs/parsers/built-in.mdx
+++ b/packages/docs/content/docs/parsers/built-in.mdx
@@ -15,7 +15,8 @@ import {
   DateISOParserDemo,
   DatetimeISOParserDemo,
   DateTimestampParserDemo,
-  JsonParserDemo
+  JsonParserDemo,
+  NativeArrayParserDemo
 } from '@/content/docs/parsers/demos'
 
 Search params are strings by default, but chances are your state is more complex than that.
@@ -320,6 +321,38 @@ parseAsJson(userSchema.validateSync)
 <Callout title="Note">
   Validation functions must either throw an error or
   return `null{:ts}` for invalid data. Only **synchronous** validation is supported.
+</Callout>
+
+## Native Arrays
+
+<FeatureSupportMatrix introducedInVersion='2.6.0' />
+
+If you want to use the native URL format for arrays, repeating the same key multiple times like:
+
+```
+/products?tag=books&tag=tech&tag=design
+```
+
+you can now use `MultiParsers` like `parseAsNativeArrayOf` to read and write those values in a fully type-safe way.
+
+```tsx
+import { useQueryState, parseAsNativeArrayOf, parseAsInteger } from 'nuqs'
+
+export function ProjectsFilter() {
+  // ?project=123&project=456 ==> [123, 456]
+  const [projectIds, setProjectIds] = useQueryState(
+    'project',
+    parseAsNativeArrayOf(parseAsInteger)
+  )
+}
+```
+
+<Suspense fallback={<DemoFallback />}>
+  <NativeArrayParserDemo />
+</Suspense>
+
+<Callout title="Empty Array Default">
+  Note that `parseAsNativeArrayOf` has a built-in default value of empty array (`.withDefault([])`) so that you don't have to handle `null` cases.
 </Callout>
 
 ## Using parsers server-side

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -604,7 +604,7 @@ export function CustomMultiParserDemo() {
       <Button
         variant="secondary"
         onClick={() => setFilters(null)}
-        className="ml-auto"
+        className="ml-auto mt-auto"
       >
         Clear
       </Button>

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -15,11 +15,17 @@ import {
 } from '@/src/components/ui/pagination'
 import { Slider } from '@/src/components/ui/slider'
 import { cn } from '@/src/lib/utils'
-import { ChevronDown, ChevronUp, Minus, Star } from 'lucide-react'
 import {
-  ParserBuilder,
-  createParser,
+  ChevronDown,
+  ChevronUp,
+  Dices,
+  Minus,
+  Star,
+  Trash2
+} from 'lucide-react'
+import {
   createMultiParser,
+  createParser,
   parseAsBoolean,
   parseAsFloat,
   parseAsHex,
@@ -28,11 +34,10 @@ import {
   parseAsIsoDate,
   parseAsIsoDateTime,
   parseAsJson,
-  parseAsArrayOf,
   parseAsNativeArrayOf,
-  parseAsString,
   parseAsStringLiteral,
   parseAsTimestamp,
+  ParserBuilder,
   SingleParser,
   useQueryState
 } from 'nuqs'
@@ -478,13 +483,18 @@ export function NativeArrayParserDemo() {
   return (
     <DemoContainer demoKey="nativeArray">
       <Button
-        onClick={() => setValue(prev => prev.concat(Math.floor(Math.random() * 500) + 1))}
+        onClick={() =>
+          setValue(prev => prev.concat(Math.floor(Math.random() * 500) + 1))
+        }
       >
+        <Dices size={18} className="mr-2 inline-block" role="presentation" />
         Add random number
       </Button>
       <Button
         onClick={() => setValue(prev => prev.slice(0, -1))}
+        disabled={value.length === 0}
       >
+        <Trash2 size={16} className="mr-2 inline-block" role="presentation" />
         Remove last number
       </Button>
       <Button
@@ -494,24 +504,30 @@ export function NativeArrayParserDemo() {
       >
         Clear
       </Button>
-      <div className="w-full text-sm text-zinc-500">
-        Current value: [{value.join(', ') || ''}]
-      </div>
+      <CodeBlock
+        lang="json"
+        code={JSON.stringify(value)}
+        allowCopy={false}
+        className="my-0 w-full"
+      />
     </DemoContainer>
   )
 }
 
 export function CustomMultiParserDemo() {
-
   const parseAsFromTo = createParser({
     parse: value => {
-      const [min = null, max = null] = value.split('~').map(parseAsInteger.parse)
+      const [min = null, max = null] = value
+        .split('~')
+        .map(parseAsInteger.parse)
       if (min === null) return null
-      if (max === null) return { eq: min}
+      if (max === null) return { eq: min }
       return { gte: min, lte: max }
     },
     serialize: value => {
-      return value.eq !== undefined ? String(value.eq) : `${value.gte}~${value.lte}`
+      return value.eq !== undefined
+        ? String(value.eq)
+        : `${value.gte}~${value.lte}`
     }
   })
 
@@ -519,17 +535,21 @@ export function CustomMultiParserDemo() {
     parse: value => {
       const [key, val] = value.split(':')
       if (!key || !val) return null
-      return { key, value: val}
+      return { key, value: val }
     },
     serialize: value => {
       return `${value.key}:${value.value}`
     }
   })
 
-  const parseAsFilters = <TItem extends {}>(itemParser: SingleParser<TItem>) => {
+  const parseAsFilters = <TItem extends {}>(
+    itemParser: SingleParser<TItem>
+  ) => {
     return createMultiParser({
       parse: values => {
-        const keyValue = values.map(parseAsKeyValue.parse).filter(v => v !== null)
+        const keyValue = values
+          .map(parseAsKeyValue.parse)
+          .filter(v => v !== null)
 
         const result = Object.fromEntries(
           keyValue.flatMap(({ key, value }) => {
@@ -541,10 +561,15 @@ export function CustomMultiParserDemo() {
         return Object.keys(result).length === 0 ? null : result
       },
       serialize: values => {
-        return Object.entries(values).map(([key, value]) => {
-          if (!itemParser.serialize) return null
-          return parseAsKeyValue.serialize({ key, value: itemParser.serialize(value) })
-        }).filter(v => v !== null)
+        return Object.entries(values)
+          .map(([key, value]) => {
+            if (!itemParser.serialize) return null
+            return parseAsKeyValue.serialize({
+              key,
+              value: itemParser.serialize(value)
+            })
+          })
+          .filter(v => v !== null)
       }
     })
   }
@@ -557,25 +582,24 @@ export function CustomMultiParserDemo() {
   return (
     <DemoContainer demoKey="filters">
       <div>
-        <label
-          className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-        Rating:
+        <label className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          Rating:
         </label>
         <input
           type="number"
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.rating?.eq ?? ''}
           onChange={e => {
-            setFilters(prev => ({...prev, rating: { eq: e.target.valueAsNumber }}))
+            setFilters(prev => ({
+              ...prev,
+              rating: { eq: e.target.valueAsNumber }
+            }))
           }}
           autoComplete="off"
         />
       </div>
       <div>
-        <label
-          className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
+        <label className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
           Price From:
         </label>
         <input
@@ -583,15 +607,19 @@ export function CustomMultiParserDemo() {
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.price?.gte ?? 0}
           onChange={e => {
-            setFilters(prev => ({...prev, price: { lte: prev.price?.lte ?? 0, gte: e.target.value === '' ? 0 : e.target.valueAsNumber }}))
+            setFilters(prev => ({
+              ...prev,
+              price: {
+                lte: prev.price?.lte ?? 0,
+                gte: e.target.value === '' ? 0 : e.target.valueAsNumber
+              }
+            }))
           }}
           autoComplete="off"
         />
       </div>
       <div>
-        <label
-          className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
+        <label className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
           Price To:
         </label>
         <input
@@ -599,7 +627,13 @@ export function CustomMultiParserDemo() {
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.price?.lte ?? 0}
           onChange={e => {
-            setFilters(prev => ({...prev, price: { gte: prev.price?.gte ?? 0, lte: e.target.value === '' ? 0 : e.target.valueAsNumber }}))
+            setFilters(prev => ({
+              ...prev,
+              price: {
+                gte: prev.price?.gte ?? 0,
+                lte: e.target.value === '' ? 0 : e.target.valueAsNumber
+              }
+            }))
           }}
           autoComplete="off"
         />
@@ -607,7 +641,7 @@ export function CustomMultiParserDemo() {
       <Button
         variant="secondary"
         onClick={() => setFilters(null)}
-        className="ml-auto mt-auto"
+        className="mt-auto ml-auto"
       >
         Clear
       </Button>
@@ -616,35 +650,11 @@ export function CustomMultiParserDemo() {
 
   return (
     <DemoContainer demoKey="filters">
-      {
-        Object.entries(filters).map(([key, value]) => {
-          if (value.eq !== undefined) {
-            return (
-              <div key={key}>
-                <label
-                  className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  {key}:{' '}
-                </label>
-                <input
-                  key={key}
-                  type="number"
-                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                  value={value.eq}
-                  onChange={e => {
-                    setFilters(prev => ({...prev, [key]: { eq: e.target.valueAsNumber }}))
-                  }}
-                  placeholder="What's your favourite number?"
-                  autoComplete="off"
-                />
-              </div>
-            )
-          }
+      {Object.entries(filters).map(([key, value]) => {
+        if (value.eq !== undefined) {
           return (
             <div key={key}>
-              <label
-                className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
+              <label className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
                 {key}:{' '}
               </label>
               <input
@@ -653,15 +663,39 @@ export function CustomMultiParserDemo() {
                 className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 value={value.eq}
                 onChange={e => {
-                  setFilters(prev => ({...prev, [key]: { eq: e.target.valueAsNumber }}))
+                  setFilters(prev => ({
+                    ...prev,
+                    [key]: { eq: e.target.valueAsNumber }
+                  }))
                 }}
                 placeholder="What's your favourite number?"
                 autoComplete="off"
               />
             </div>
           )
-        })
-      }
+        }
+        return (
+          <div key={key}>
+            <label className="text-sm leading-none font-medium select-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+              {key}:{' '}
+            </label>
+            <input
+              key={key}
+              type="number"
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              value={value.eq}
+              onChange={e => {
+                setFilters(prev => ({
+                  ...prev,
+                  [key]: { eq: e.target.valueAsNumber }
+                }))
+              }}
+              placeholder="What's your favourite number?"
+              autoComplete="off"
+            />
+          </div>
+        )
+      })}
       <Button
         variant="secondary"
         onClick={() => setFilters(null)}
@@ -672,7 +706,6 @@ export function CustomMultiParserDemo() {
     </DemoContainer>
   )
 }
-
 
 type StarButtonProps = Omit<React.ComponentProps<typeof Button>, 'value'> & {
   index: Rating

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -27,6 +27,7 @@ import {
   parseAsIsoDate,
   parseAsIsoDateTime,
   parseAsJson,
+  parseAsNativeArrayOf,
   parseAsStringLiteral,
   parseAsTimestamp,
   useQueryState
@@ -458,6 +459,34 @@ export function CustomParserDemo() {
         variant="secondary"
         className="ml-auto"
         onClick={() => setValue(null)}
+      >
+        Clear
+      </Button>
+    </DemoContainer>
+  )
+}
+
+export function NativeArrayParserDemo() {
+  const [_, setValue] = useQueryState(
+    'nativeArray',
+    parseAsNativeArrayOf(parseAsInteger)
+  )
+  return (
+    <DemoContainer demoKey="nativeArray">
+      <Button
+        onClick={() => setValue(prev => prev.concat(Math.floor(Math.random() * 500) + 1))}
+      >
+        Add random number
+      </Button>
+      <Button
+        onClick={() => setValue(prev => prev.slice(0, -1))}
+      >
+        Remove last number
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => setValue([])}
+        className="ml-auto"
       >
         Clear
       </Button>

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -471,7 +471,7 @@ export function CustomParserDemo() {
 }
 
 export function NativeArrayParserDemo() {
-  const [_, setValue] = useQueryState(
+  const [value, setValue] = useQueryState(
     'nativeArray',
     parseAsNativeArrayOf(parseAsInteger)
   )
@@ -494,6 +494,9 @@ export function NativeArrayParserDemo() {
       >
         Clear
       </Button>
+      <div className="w-full text-sm text-zinc-500">
+        Current value: [{value.join(', ') || ''}]
+      </div>
     </DemoContainer>
   )
 }

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -580,7 +580,7 @@ export function CustomMultiParserDemo() {
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.price?.gte ?? 0}
           onChange={e => {
-            setFilters(prev => ({...prev, price: { lte: prev.price?.lte ?? 0, gte: e.target.valueAsNumber }}))
+            setFilters(prev => ({...prev, price: { lte: prev.price?.lte ?? 0, gte: e.target.value === '' ? 0 : e.target.valueAsNumber }}))
           }}
           autoComplete="off"
         />
@@ -596,7 +596,7 @@ export function CustomMultiParserDemo() {
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.price?.lte ?? 0}
           onChange={e => {
-            setFilters(prev => ({...prev, price: { gte: prev.price?.gte ?? 0, lte: e.target.valueAsNumber }}))
+            setFilters(prev => ({...prev, price: { gte: prev.price?.gte ?? 0, lte: e.target.value === '' ? 0 : e.target.valueAsNumber }}))
           }}
           autoComplete="off"
         />

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -589,10 +589,12 @@ export function CustomMultiParserDemo() {
           type="number"
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.rating?.eq ?? ''}
+          min={0}
+          max={5}
           onChange={e => {
             setFilters(prev => ({
               ...prev,
-              rating: { eq: e.target.valueAsNumber }
+              rating: { eq: e.target.value === '' ? 0 : e.target.valueAsNumber }
             }))
           }}
           autoComplete="off"
@@ -606,6 +608,8 @@ export function CustomMultiParserDemo() {
           type="number"
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.price?.gte ?? 0}
+          step={10}
+          max={1000}
           onChange={e => {
             setFilters(prev => ({
               ...prev,
@@ -626,6 +630,8 @@ export function CustomMultiParserDemo() {
           type="number"
           className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={filters.price?.lte ?? 0}
+          step={10}
+          max={1000}
           onChange={e => {
             setFilters(prev => ({
               ...prev,

--- a/packages/docs/content/docs/parsers/making-your-own.mdx
+++ b/packages/docs/content/docs/parsers/making-your-own.mdx
@@ -9,16 +9,17 @@ import {
 } from '@/content/docs/parsers/demos'
 
 You may wish to customise the rendered query string for your data type.
-For this, `nuqs` exposes the `createParser` function to make your own parsers.
+For this, `nuqs` exposes the `createParser{:ts}` function to make your own parsers.
 
 You pass it two functions:
-1. `parse`: a function that takes a string and returns the parsed value, or `null{:ts}` if invalid.
-2. `serialize`: a function that takes the parsed value and returns a string.
+1. `parse{:ts}`: a function that takes a string and returns the parsed value, or `null{:ts}` if invalid.
+2. `serialize{:ts}`: a function that takes the parsed value and returns a string.
 
 ```ts
 import { createParser } from 'nuqs'
 
 const parseAsStarRating = createParser({
+  // [!code word:parse]
   parse(queryValue) {
     const inBetween = queryValue.split('★')
     const isValid = inBetween.length > 1 && inBetween.every(s => s === '')
@@ -26,6 +27,7 @@ const parseAsStarRating = createParser({
     const numStars = inBetween.length - 1
     return Math.min(5, numStars)
   },
+  // [!code word:serialize]
   serialize(value) {
     return Array.from({length: value}, () => '★').join('')
   }
@@ -69,17 +71,36 @@ to check if the current value is equal to the default value.
 
 ## Custom Multi Parsers
 
-`MultiParsers` work similar to `SingleParsers`, except that they operate on Arrays. That means:
+The parsers we've seen until now are `SingleParsers{:ts}`: they operate on **the first occurence** of the
+key in the URL, and give you a string value to parse when it's available.
 
-1. `parse` takes an `Array<string>`. It receives all matching values of the key it operates on, and returns the parsed value, or `null{:ts}` if invalid.
-2. `serialize` takes the parsed value and returns an `Array<string>`, where each item will be separately added to the URL.
+`MultiParsers{:ts}` work similar to `SingleParsers{:ts}`, except that they operate on arrays, to support **key repetition**:
+
+import { Querystring } from '@/src/components/querystring'
+
+<Querystring path="/" value="?tag=type-safe&tag=url-state&tag=react" />
+
+This means:
+
+1. `parse{:ts}` takes an `Array<string>{:ts}`. It receives all matching values of the key it operates on, and returns the parsed value, or `null{:ts}` if invalid.
+2. `serialize{:ts}` takes the parsed value and returns an `Array<string>{:ts}`, where each item will be separately added to the URL.
+
+You can then compose & reduce this array to form **complex data types**:
+
+<Suspense>
+  <CustomMultiParserDemo />
+</Suspense>
 
 ```tsx
+/**
+ * 100~200 <=> { gte: 100, lte: 200 }
+ * 150     <=> { eq: 150 }
+ */
 const parseAsFromTo = createParser({
   parse: value => {
     const [min = null, max = null] = value.split('~').map(parseAsInteger.parse)
     if (min === null) return null
-    if (max === null) return { eq: min}
+    if (max === null) return { eq: min }
     return { gte: min, lte: max }
   },
   serialize: value => {
@@ -87,11 +108,14 @@ const parseAsFromTo = createParser({
   }
 })
 
+/**
+ * foo:bar <=> { key: 'foo', value: 'bar' }
+ */
 const parseAsKeyValue = createParser({
   parse: value => {
     const [key, val] = value.split(':')
     if (!key || !val) return null
-    return { key, value: val}
+    return { key, value: val }
   },
   serialize: value => {
     return `${value.key}:${value.value}`
@@ -126,10 +150,6 @@ const [filters, setFilters] = useQueryState(
   parseAsFilters(parseAsFromTo).withDefault({})
 )
 ```
-
-<Suspense>
-  <CustomMultiParserDemo/>
-</Suspense>
 
 ## Caveat: lossy serializers
 

--- a/packages/docs/content/docs/parsers/making-your-own.mdx
+++ b/packages/docs/content/docs/parsers/making-your-own.mdx
@@ -36,6 +36,37 @@ const parseAsStarRating = createParser({
   <CustomParserDemo/>
 </Suspense>
 
+## Equality function
+
+For state types that can't be compared by the `==={:ts}` operator, you'll need to
+provide an `eq{:ts}` function as well:
+
+```ts
+
+// Eg: TanStack Table sorting state
+// /?sort=foo:asc → { id: 'foo', desc: false }
+const parseAsSort = createParser({
+  parse(query) {
+    const [key = '', direction = ''] = query.split(':')
+    const desc = parseAsStringLiteral(['asc', 'desc']).parse(direction) ?? 'asc'
+    return {
+      id: key,
+      desc: desc === 'desc'
+    }
+  },
+  serialize(value) {
+    return `${value.id}:${value.desc ? 'desc' : 'asc'}`
+  },
+  // [!code highlight:3]
+  eq(a, b) {
+    return a.id === b.id && a.desc === b.desc
+  }
+})
+```
+
+This is used for the [`clearOnDefault{:ts}`](/docs/options#clear-on-default) option,
+to check if the current value is equal to the default value.
+
 ## Custom Multi Parsers
 
 `MultiParsers` work similar to `SingleParsers`, except that they operate on Arrays. That means:

--- a/packages/docs/content/docs/parsers/making-your-own.mdx
+++ b/packages/docs/content/docs/parsers/making-your-own.mdx
@@ -4,7 +4,8 @@ description: Making your own parsers for custom data types & pretty URLs
 ---
 
 import {
-  CustomParserDemo
+  CustomParserDemo,
+  CustomMultiParserDemo
 } from '@/content/docs/parsers/demos'
 
 You may wish to customise the rendered query string for your data type.
@@ -33,6 +34,70 @@ const parseAsStarRating = createParser({
 
 <Suspense>
   <CustomParserDemo/>
+</Suspense>
+
+## Custom Multi Parsers
+
+`MultiParsers` work similar to `SingleParsers`, except that they operate on Arrays. That means:
+
+1. `parse` takes an `Array<string>`. It receives all matching values of the key it operates on, and returns the parsed value, or `null{:ts}` if invalid.
+2. `serialize` takes the parsed value and returns an `Array<string>`, where each item will be separately added to the URL.
+
+```tsx
+const parseAsFromTo = createParser({
+  parse: value => {
+    const [min = null, max = null] = value.split('~').map(parseAsInteger.parse)
+    if (min === null) return null
+    if (max === null) return { eq: min}
+    return { gte: min, lte: max }
+  },
+  serialize: value => {
+    return value.eq !== undefined ? String(value.eq) : `${value.gte}~${value.lte}`
+  }
+})
+
+const parseAsKeyValue = createParser({
+  parse: value => {
+    const [key, val] = value.split(':')
+    if (!key || !val) return null
+    return { key, value: val}
+  },
+  serialize: value => {
+    return `${value.key}:${value.value}`
+  }
+})
+
+const parseAsFilters = <TItem extends {}>(itemParser: SingleParser<TItem>) => {
+  return createMultiParser({
+    parse: values => {
+      const keyValue = values.map(parseAsKeyValue.parse).filter(v => v !== null)
+
+      const result = Object.fromEntries(
+        keyValue.flatMap(({ key, value }) => {
+          const parsedValue: TItem | null = itemParser.parse(value)
+          return parsedValue === null ? [] : [[key, parsedValue]]
+        })
+      )
+
+      return Object.keys(result).length === 0 ? null : result
+    },
+    serialize: values => {
+      return Object.entries(values).map(([key, value]) => {
+        if (!itemParser.serialize) return null
+        return parseAsKeyValue.serialize({ key, value: itemParser.serialize(value) })
+      }).filter(v => v !== null)
+    }
+  })
+}
+
+const [filters, setFilters] = useQueryState(
+  'filters',
+  parseAsFilters(parseAsFromTo).withDefault({})
+)
+```
+
+<Suspense>
+  <CustomMultiParserDemo/>
 </Suspense>
 
 ## Caveat: lossy serializers

--- a/packages/docs/src/app/styles/tweaks.css
+++ b/packages/docs/src/app/styles/tweaks.css
@@ -35,6 +35,13 @@
 /* Fix x-spacing in inline code spans */
 .shiki:not(.not-fumadocs-codeblock *):has(> code .line) {
   --spacing: 0.5px;
+  & code {
+    /*
+      Reduce vertical padding to allow two inline code blocks
+      on adjacent lines to avoid overlapping.
+    */
+    padding-block: 1.5px;
+  }
 }
 
 /* Avoid a flash of black (in dark mode) in the navbar background when scrolling */

--- a/packages/docs/src/components/querystring.tsx
+++ b/packages/docs/src/components/querystring.tsx
@@ -2,17 +2,24 @@ import { cn } from '@/src/lib/utils'
 import { Fragment, useMemo } from 'react'
 
 export type QuerystringProps = React.ComponentProps<'pre'> & {
+  path?: string
   value: string | URLSearchParams
   keepKeys?: string[]
 }
 
-export function Querystring({ value, keepKeys, ...props }: QuerystringProps) {
+export function Querystring({
+  path,
+  value,
+  keepKeys,
+  ...props
+}: QuerystringProps) {
   const search = useMemo(
     () => filterQueryKeys(value, keepKeys),
     [value, keepKeys]
   )
   return (
     <QuerystringSkeleton {...props}>
+      {path && <span className="text-zinc-500">{path}</span>}
       {Array.from(search.entries()).map(([key, value], i) => (
         <Fragment key={key + i}>
           <span className="text-zinc-500">

--- a/packages/docs/src/components/querystring.tsx
+++ b/packages/docs/src/components/querystring.tsx
@@ -63,7 +63,7 @@ function filterQueryKeys(query: string | URLSearchParams, keys?: string[]) {
   const destination = new URLSearchParams()
   for (const [key, value] of source.entries()) {
     if (keys.includes(key)) {
-      destination.set(key, value)
+      destination.append(key, value)
     }
   }
   return destination

--- a/packages/e2e/next/src/app/app/(shared)/native-array/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/native-array/page.tsx
@@ -1,0 +1,10 @@
+import { NativeArray } from 'e2e-shared/specs/native-array'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <NativeArray />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/pages/pages/native-array.tsx
+++ b/packages/e2e/next/src/pages/pages/native-array.tsx
@@ -1,0 +1,3 @@
+import { NativeArray } from 'e2e-shared/specs/native-array'
+
+export default NativeArray

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -34,6 +34,7 @@ const router = createBrowserRouter(
       <Route path="linking/useQueryState/other"               lazy={load(import('./routes/linking.useQueryState.other'))} />
       <Route path="linking/useQueryStates"                    lazy={load(import('./routes/linking.useQueryStates'))} />
       <Route path="linking/useQueryStates/other"              lazy={load(import('./routes/linking.useQueryStates.other'))} />
+      <Route path="native-array"                              lazy={load(import('./routes/native-array'))} />
       <Route path="pretty-urls"                               lazy={load(import('./routes/pretty-urls'))} />
       <Route path="referential-stability/useQueryState"       lazy={load(import('./routes/referential-stability.useQueryState'))} />
       <Route path="referential-stability/useQueryStates"      lazy={load(import('./routes/referential-stability.useQueryStates'))} />

--- a/packages/e2e/react-router/v6/src/routes/native-array.tsx
+++ b/packages/e2e/react-router/v6/src/routes/native-array.tsx
@@ -1,0 +1,3 @@
+import { NativeArray } from 'e2e-shared/specs/native-array'
+
+export default NativeArray

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -17,6 +17,7 @@ export default [
     route('/linking/useQueryState/other',               './routes/linking.useQueryState.other.tsx'),
     route('/linking/useQueryStates',                    './routes/linking.useQueryStates.tsx'),
     route('/linking/useQueryStates/other',              './routes/linking.useQueryStates.other.tsx'),
+    route('/native-array',                              './routes/native-array.tsx'),
     route('/pretty-urls',                               './routes/pretty-urls.tsx'),
     route('/referential-stability/useQueryState',       './routes/referential-stability.useQueryState.tsx'),
     route('/referential-stability/useQueryStates',      './routes/referential-stability.useQueryStates.tsx'),

--- a/packages/e2e/react-router/v7/app/routes/native-array.tsx
+++ b/packages/e2e/react-router/v7/app/routes/native-array.tsx
@@ -1,0 +1,3 @@
+import { NativeArray } from 'e2e-shared/specs/native-array'
+
+export default NativeArray

--- a/packages/e2e/react/src/routes.tsx
+++ b/packages/e2e/react/src/routes.tsx
@@ -16,6 +16,7 @@ const routes: Record<string, React.LazyExoticComponent<() => JSX.Element>> = {
   '/linking/useQueryState/other':           lazy(() => import('./routes/linking.useQueryState.other')),
   '/linking/useQueryStates':                lazy(() => import('./routes/linking.useQueryStates')),
   '/linking/useQueryStates/other':          lazy(() => import('./routes/linking.useQueryStates.other')),
+  '/native-array':                          lazy(() => import('./routes/native-array')),
   '/pretty-urls':                           lazy(() => import('./routes/pretty-urls')),
   '/referential-stability/useQueryState':   lazy(() => import('./routes/referential-stability.useQueryState')),
   '/referential-stability/useQueryStates':  lazy(() => import('./routes/referential-stability.useQueryStates')),

--- a/packages/e2e/react/src/routes/native-array.tsx
+++ b/packages/e2e/react/src/routes/native-array.tsx
@@ -1,0 +1,3 @@
+import { NativeArray } from 'e2e-shared/specs/native-array'
+
+export default NativeArray

--- a/packages/e2e/remix/app/routes/native-array.tsx
+++ b/packages/e2e/remix/app/routes/native-array.tsx
@@ -1,0 +1,3 @@
+import { NativeArray } from 'e2e-shared/specs/native-array'
+
+export default NativeArray

--- a/packages/e2e/shared/shared.cy.ts
+++ b/packages/e2e/shared/shared.cy.ts
@@ -4,6 +4,7 @@ import { testConditionalRendering } from './specs/conditional-rendering.cy'
 import { testForm } from './specs/form.cy'
 import { testHashPreservation } from './specs/hash-preservation.cy'
 import { testJson } from './specs/json.cy'
+import { testNativeArray } from './specs/native-array.cy'
 import { testLifeAndDeath } from './specs/life-and-death.cy'
 import { testLinking } from './specs/linking.cy'
 import { testPrettyUrls } from './specs/pretty-urls.cy'
@@ -30,6 +31,13 @@ export function runSharedTests(
 
   testJson({
     path: `${pathPrefix}/json`,
+    ...config
+  })
+
+  // --
+
+  testNativeArray({
+    path: `${pathPrefix}/native-array`,
     ...config
   })
 

--- a/packages/e2e/shared/specs/native-array.cy.ts
+++ b/packages/e2e/shared/specs/native-array.cy.ts
@@ -1,0 +1,20 @@
+import { createTest } from '../create-test'
+
+export const testNativeArray = createTest('parseAsNativeArray', ({ path }) => {
+  it('reads native array from the URL', () => {
+    cy.visit(path + '?test=1&test=2&test=3')
+    cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+    cy.get('#client-name').should('have.text', '1 - 2 - 3')
+    cy.get('#add-button').click()
+    cy.get('#client-name').should('have.text', '1 - 2 - 3 - 4')
+  })
+  it('writes native array to the URL', () => {
+    cy.visit(path)
+    cy.contains('#hydration-marker', 'hydrated').should('be.hidden')
+    cy.get('#client-name').should('be.empty')
+    cy.get('#add-button').click()
+    cy.location('search').should('eq', '?test=1')
+    cy.get('#add-button').click()
+    cy.location('search').should('eq', '?test=1&test=2')
+  })
+})

--- a/packages/e2e/shared/specs/native-array.tsx
+++ b/packages/e2e/shared/specs/native-array.tsx
@@ -3,7 +3,7 @@
 import { parseAsInteger, parseAsNativeArrayOf, useQueryState } from 'nuqs'
 import { Display } from '../components/display'
 
-export const parser = parseAsNativeArrayOf(parseAsInteger).withDefault([])
+export const parser = parseAsNativeArrayOf(parseAsInteger)
 
 export function NativeArray() {
   const [state, setState] = useQueryState('test', parser)

--- a/packages/e2e/shared/specs/native-array.tsx
+++ b/packages/e2e/shared/specs/native-array.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { parseAsInteger, parseAsNativeArrayOf, useQueryState } from 'nuqs'
+import { Display } from '../components/display'
+
+export const parser = parseAsNativeArrayOf(parseAsInteger)
+
+export function NativeArray() {
+  const [state, setState] = useQueryState('test', parser)
+  return (
+    <>
+      <button onClick={() => setState([])}>Reset</button>
+      <button
+        id="add-button"
+        onClick={() =>
+          setState(prev => (prev ?? []).concat((prev ?? []).length + 1))
+        }
+      >
+        Add
+      </button>
+      <Display environment="client" target="name" state={state?.join(' - ')} />
+    </>
+  )
+}

--- a/packages/e2e/shared/specs/native-array.tsx
+++ b/packages/e2e/shared/specs/native-array.tsx
@@ -3,7 +3,7 @@
 import { parseAsInteger, parseAsNativeArrayOf, useQueryState } from 'nuqs'
 import { Display } from '../components/display'
 
-export const parser = parseAsNativeArrayOf(parseAsInteger)
+export const parser = parseAsNativeArrayOf(parseAsInteger).withDefault([])
 
 export function NativeArray() {
   const [state, setState] = useQueryState('test', parser)
@@ -12,9 +12,7 @@ export function NativeArray() {
       <button onClick={() => setState([])}>Reset</button>
       <button
         id="add-button"
-        onClick={() =>
-          setState(prev => (prev ?? []).concat((prev ?? []).length + 1))
-        }
+        onClick={() => setState(prev => prev.concat(prev.length + 1))}
       >
         Add
       </button>

--- a/packages/e2e/tanstack-router/cypress/e2e/shared/native-array.cy.ts
+++ b/packages/e2e/tanstack-router/cypress/e2e/shared/native-array.cy.ts
@@ -1,0 +1,3 @@
+import { testNativeArray } from 'e2e-shared/specs/native-array.cy'
+
+testNativeArray({ path: '/native-array' })

--- a/packages/e2e/tanstack-router/src/routes/native-array.tsx
+++ b/packages/e2e/tanstack-router/src/routes/native-array.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { NativeArray, parser } from 'e2e-shared/specs/native-array'
+import { createStandardSchemaV1 } from 'nuqs'
+
+const validateSearch = createStandardSchemaV1(
+  { test: parser },
+  { partialOutput: true }
+)
+
+export const Route = createFileRoute('/native-array')({
+  component: NativeArray,
+  validateSearch
+})

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -207,7 +207,7 @@
     {
       "name": "Server",
       "path": "dist/server.js",
-      "limit": "3.05 kB"
+      "limit": "3.1 kB"
     }
   ]
 }

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -207,7 +207,7 @@
     {
       "name": "Server",
       "path": "dist/server.js",
-      "limit": "3 kB"
+      "limit": "3.05 kB"
     }
   ]
 }

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -207,7 +207,7 @@
     {
       "name": "Server",
       "path": "dist/server.js",
-      "limit": "3.1 kB"
+      "limit": "3.5 kB"
     }
   ]
 }

--- a/packages/nuqs/src/adapters/lib/key-isolation.ts
+++ b/packages/nuqs/src/adapters/lib/key-isolation.ts
@@ -1,4 +1,5 @@
 import { debug } from '../../lib/debug'
+import { compareQuery } from '../../lib/compare'
 
 export function applyChange(
   newValue: URLSearchParams,
@@ -9,7 +10,9 @@ export function applyChange(
     const hasChanged =
       keys.length === 0
         ? true
-        : keys.some(key => oldValue.get(key) !== newValue.get(key))
+        : keys.some(
+            key => !compareQuery(oldValue.getAll(key), newValue.getAll(key))
+          )
     if (!hasChanged) {
       debug(
         '[nuqs `%s`] no change, returning previous',

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -8,6 +8,7 @@ const exports = `
 {
   ".": {
     "createLoader": "function",
+    "createMultiParser": "function",
     "createParser": "function",
     "createSerializer": "function",
     "createStandardSchemaV1": "function",
@@ -22,6 +23,7 @@ const exports = `
     "parseAsIsoDate": "object",
     "parseAsIsoDateTime": "object",
     "parseAsJson": "function",
+    "parseAsNativeArrayOf": "function",
     "parseAsNumberLiteral": "function",
     "parseAsString": "object",
     "parseAsStringEnum": "function",
@@ -73,6 +75,7 @@ const exports = `
   },
   "./server": {
     "createLoader": "function",
+    "createMultiParser": "function",
     "createParser": "function",
     "createSearchParamsCache": "function",
     "createSerializer": "function",
@@ -88,6 +91,7 @@ const exports = `
     "parseAsIsoDate": "object",
     "parseAsIsoDateTime": "object",
     "parseAsJson": "function",
+    "parseAsNativeArrayOf": "function",
     "parseAsNumberLiteral": "function",
     "parseAsString": "object",
     "parseAsStringEnum": "function",

--- a/packages/nuqs/src/lib/compare.test.ts
+++ b/packages/nuqs/src/lib/compare.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { compareQuery } from './compare'
+
+describe('compare', () => {
+  describe('strings', () => {
+    it('should return true for equal values', () => {
+      expect(compareQuery('a', 'a')).toBe(true)
+    })
+    it('should return false for different strings', () => {
+      expect(compareQuery('a', 'b')).toBe(false)
+    })
+  })
+  describe('iterables', () => {
+    it('should return true for equal arrays', () => {
+      expect(compareQuery(['a', 'b'], ['a', 'b'])).toBe(true)
+    })
+    it('should return true for same array instance', () => {
+      const arr = ['a', 'b']
+      expect(compareQuery(arr, arr)).toBe(true)
+    })
+    it('should return false for different arrays', () => {
+      expect(compareQuery(['a', 'b'], ['a', 'c'])).toBe(false)
+    })
+    it('should return false for different length arrays', () => {
+      expect(compareQuery(['a', 'b'], ['a', 'b', 'c'])).toBe(false)
+    })
+    it('should return true for equal sets', () => {
+      expect(compareQuery(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(true)
+    })
+    it('relies on insertion order for sets', () => {
+      expect(compareQuery(new Set(['a', 'b']), new Set(['b', 'a']))).toBe(false)
+    })
+    it('should return true for same set instance', () => {
+      const set = new Set(['a', 'b'])
+      expect(compareQuery(set, set)).toBe(true)
+    })
+    it('should return false for different sets', () => {
+      expect(compareQuery(new Set(['a', 'b']), new Set(['a', 'c']))).toBe(false)
+    })
+    it('should return false for different length sets', () => {
+      expect(compareQuery(new Set(['a', 'b']), new Set(['a', 'b', 'c']))).toBe(
+        false
+      )
+    })
+  })
+})

--- a/packages/nuqs/src/lib/compare.test.ts
+++ b/packages/nuqs/src/lib/compare.test.ts
@@ -10,7 +10,7 @@ describe('compare', () => {
       expect(compareQuery('a', 'b')).toBe(false)
     })
   })
-  describe('iterables', () => {
+  describe('arrays', () => {
     it('should return true for equal arrays', () => {
       expect(compareQuery(['a', 'b'], ['a', 'b'])).toBe(true)
     })
@@ -23,24 +23,6 @@ describe('compare', () => {
     })
     it('should return false for different length arrays', () => {
       expect(compareQuery(['a', 'b'], ['a', 'b', 'c'])).toBe(false)
-    })
-    it('should return true for equal sets', () => {
-      expect(compareQuery(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(true)
-    })
-    it('relies on insertion order for sets', () => {
-      expect(compareQuery(new Set(['a', 'b']), new Set(['b', 'a']))).toBe(false)
-    })
-    it('should return true for same set instance', () => {
-      const set = new Set(['a', 'b'])
-      expect(compareQuery(set, set)).toBe(true)
-    })
-    it('should return false for different sets', () => {
-      expect(compareQuery(new Set(['a', 'b']), new Set(['a', 'c']))).toBe(false)
-    })
-    it('should return false for different length sets', () => {
-      expect(compareQuery(new Set(['a', 'b']), new Set(['a', 'b', 'c']))).toBe(
-        false
-      )
     })
   })
 })

--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -1,6 +1,6 @@
-import type { QueryParam } from './search-params'
+import type { Query } from './search-params'
 
-export function compareQuery<T extends QueryParam>(
+export function compareQuery<T extends Query>(
   a: T | null,
   b: T | null
 ): boolean {

--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -10,7 +10,7 @@ export function compareQuery<T extends string | Iterable<string>>(
   }
   // we expect either strings or iterables, not a mix of both
   if (typeof a === 'string' || typeof b === 'string') {
-    return a === b
+    return false
   }
 
   const iterA = a[Symbol.iterator]()

--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -1,0 +1,33 @@
+export function compareQuery<T extends string | Iterable<string>>(
+  a: T | null,
+  b: T | null
+): boolean {
+  if (a === b) {
+    return true // Referentially stable
+  }
+  if (a === null || b === null) {
+    return false
+  }
+  // we expect either strings or iterables, not a mix of both
+  if (typeof a === 'string' || typeof b === 'string') {
+    return a === b
+  }
+
+  const iterA = a[Symbol.iterator]()
+  const iterB = b[Symbol.iterator]()
+
+  while (true) {
+    const nextA = iterA.next()
+    const nextB = iterB.next()
+
+    if (nextA.done && nextB.done) {
+      return true // both ended at the same time
+    }
+    if (nextA.done !== nextB.done) {
+      return false // different lengths
+    }
+    if (nextA.value !== nextB.value) {
+      return false // mismatched value
+    }
+  }
+}

--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -1,4 +1,6 @@
-export function compareQuery<T extends string | Iterable<string>>(
+import type { QueryParam } from './search-params'
+
+export function compareQuery<T extends QueryParam>(
   a: T | null,
   b: T | null
 ): boolean {
@@ -8,26 +10,14 @@ export function compareQuery<T extends string | Iterable<string>>(
   if (a === null || b === null) {
     return false
   }
-  // we expect either strings or iterables, not a mix of both
+  // we expect either strings or arrays, not a mix of both
   if (typeof a === 'string' || typeof b === 'string') {
     return false
   }
 
-  const iterA = a[Symbol.iterator]()
-  const iterB = b[Symbol.iterator]()
-
-  while (true) {
-    const nextA = iterA.next()
-    const nextB = iterB.next()
-
-    if (nextA.done && nextB.done) {
-      return true // both ended at the same time
-    }
-    if (nextA.done !== nextB.done) {
-      return false // different lengths
-    }
-    if (nextA.value !== nextB.value) {
-      return false // mismatched value
-    }
+  if (a.length !== b.length) {
+    return false
   }
+
+  return a.every((value, index) => value === b[index]!)
 }

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -1,5 +1,6 @@
 import { debug } from '../debug'
 import { createEmitter, type Emitter } from '../emitter'
+import type { Query } from '../search-params'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
 import {
@@ -10,7 +11,6 @@ import {
   type UpdateQueuePushArgs
 } from './throttle'
 import { useSyncExternalStores } from './useSyncExternalStores'
-import type { QueryParam } from '../search-params'
 
 export class DebouncedPromiseQueue<ValueType, OutputType> {
   callback: (value: ValueType) => Promise<OutputType>
@@ -74,9 +74,7 @@ export class DebounceController {
     this.throttleQueue = throttleQueue
   }
 
-  useQueuedQueries(
-    keys: string[]
-  ): Record<string, QueryParam | null | undefined> {
+  useQueuedQueries(keys: string[]): Record<string, Query | null | undefined> {
     return useSyncExternalStores(
       keys,
       (key, callback) => this.queuedQuerySync.on(key, callback),
@@ -156,7 +154,7 @@ export class DebounceController {
     this.queues.clear()
   }
 
-  getQueuedQuery(key: string): QueryParam | null | undefined {
+  getQueuedQuery(key: string): Query | null | undefined {
     // The debounced queued values are more likely to be up-to-date
     // than any updates pending in the throttle queue, which comes last
     // in the update chain.

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -73,7 +73,9 @@ export class DebounceController {
     this.throttleQueue = throttleQueue
   }
 
-  useQueuedQueries(keys: string[]): Record<string, string | null | undefined> {
+  useQueuedQueries(
+    keys: string[]
+  ): Record<string, Iterable<string> | null | undefined> {
     return useSyncExternalStores(
       keys,
       (key, callback) => this.queuedQuerySync.on(key, callback),
@@ -153,7 +155,7 @@ export class DebounceController {
     this.queues.clear()
   }
 
-  getQueuedQuery(key: string): string | null | undefined {
+  getQueuedQuery(key: string): Iterable<string> | null | undefined {
     // The debounced queued values are more likely to be up-to-date
     // than any updates pending in the throttle queue, which comes last
     // in the update chain.

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -10,6 +10,7 @@ import {
   type UpdateQueuePushArgs
 } from './throttle'
 import { useSyncExternalStores } from './useSyncExternalStores'
+import type { QueryParam } from '../search-params'
 
 export class DebouncedPromiseQueue<ValueType, OutputType> {
   callback: (value: ValueType) => Promise<OutputType>
@@ -75,7 +76,7 @@ export class DebounceController {
 
   useQueuedQueries(
     keys: string[]
-  ): Record<string, Iterable<string> | null | undefined> {
+  ): Record<string, QueryParam | null | undefined> {
     return useSyncExternalStores(
       keys,
       (key, callback) => this.queuedQuerySync.on(key, callback),
@@ -155,7 +156,7 @@ export class DebounceController {
     this.queues.clear()
   }
 
-  getQueuedQuery(key: string): Iterable<string> | null | undefined {
+  getQueuedQuery(key: string): QueryParam | null | undefined {
     // The debounced queued values are more likely to be up-to-date
     // than any updates pending in the throttle queue, which comes last
     // in the update chain.

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -6,8 +6,9 @@ import { error } from '../errors'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
 import { defaultRateLimit } from './rate-limiting'
+import { write } from '../search-params'
 
-type UpdateMap = Map<string, string | null>
+type UpdateMap = Map<string, Iterable<string> | null>
 type TransitionSet = Set<React.TransitionStartFunction>
 export type UpdateQueueAdapterContext = Pick<
   AdapterInterface,
@@ -19,7 +20,7 @@ export type UpdateQueueAdapterContext = Pick<
 
 export type UpdateQueuePushArgs = {
   key: string
-  query: string | null
+  query: Iterable<string> | null
   options: AdapterOptions & Pick<Options, 'startTransition'>
 }
 
@@ -65,7 +66,7 @@ export class ThrottledQueue {
     }
   }
 
-  getQueuedQuery(key: string): string | null | undefined {
+  getQueuedQuery(key: string): Iterable<string> | null | undefined {
     return this.updateMap.get(key)
   }
 
@@ -185,7 +186,7 @@ export class ThrottledQueue {
       if (value === null) {
         search.delete(key)
       } else {
-        search.set(key, value)
+        search = write(value, key, search)
       }
     }
     if (processUrlSearchParams) {

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -3,12 +3,12 @@ import type { Options } from '../../defs'
 import { compose } from '../compose'
 import { debug } from '../debug'
 import { error } from '../errors'
+import { write, type Query } from '../search-params'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
 import { defaultRateLimit } from './rate-limiting'
-import { type QueryParam, write } from '../search-params'
 
-type UpdateMap = Map<string, QueryParam | null>
+type UpdateMap = Map<string, Query | null>
 type TransitionSet = Set<React.TransitionStartFunction>
 export type UpdateQueueAdapterContext = Pick<
   AdapterInterface,
@@ -20,7 +20,7 @@ export type UpdateQueueAdapterContext = Pick<
 
 export type UpdateQueuePushArgs = {
   key: string
-  query: QueryParam | null
+  query: Query | null
   options: AdapterOptions & Pick<Options, 'startTransition'>
 }
 
@@ -66,7 +66,7 @@ export class ThrottledQueue {
     }
   }
 
-  getQueuedQuery(key: string): QueryParam | null | undefined {
+  getQueuedQuery(key: string): Query | null | undefined {
     return this.updateMap.get(key)
   }
 

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -6,9 +6,9 @@ import { error } from '../errors'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
 import { defaultRateLimit } from './rate-limiting'
-import { write } from '../search-params'
+import { type QueryParam, write } from '../search-params'
 
-type UpdateMap = Map<string, Iterable<string> | null>
+type UpdateMap = Map<string, QueryParam | null>
 type TransitionSet = Set<React.TransitionStartFunction>
 export type UpdateQueueAdapterContext = Pick<
   AdapterInterface,
@@ -20,7 +20,7 @@ export type UpdateQueueAdapterContext = Pick<
 
 export type UpdateQueuePushArgs = {
   key: string
-  query: Iterable<string> | null
+  query: QueryParam | null
   options: AdapterOptions & Pick<Options, 'startTransition'>
 }
 
@@ -66,7 +66,7 @@ export class ThrottledQueue {
     }
   }
 
-  getQueuedQuery(key: string): Iterable<string> | null | undefined {
+  getQueuedQuery(key: string): QueryParam | null | undefined {
     return this.updateMap.get(key)
   }
 

--- a/packages/nuqs/src/lib/safe-parse.ts
+++ b/packages/nuqs/src/lib/safe-parse.ts
@@ -1,11 +1,10 @@
-import type { Parser } from '../parsers'
 import { warn } from './debug'
 
-export function safeParse<T>(
-  parser: Parser<T>['parse'],
-  value: string,
+export function safeParse<I, R>(
+  parser: (arg: I) => R,
+  value: I,
   key?: string
-): T | null {
+): R | null {
   try {
     return parser(value)
   } catch (error) {

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,4 +1,6 @@
-export function isEmpty(query: string | Iterable<string> | null): boolean {
+export function isEmpty(
+  query: string | Iterable<string> | null
+): query is null | [] {
   return query === null || (Array.isArray(query) && query.length === 0)
 }
 

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,4 +1,4 @@
-export function isEmpty(
+export function isAbsentFromUrl(
   query: string | Iterable<string> | null
 ): query is null | [] {
   return query === null || (Array.isArray(query) && query.length === 0)

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,0 +1,55 @@
+import type { Options } from '../defs'
+import type { Parser } from '../parsers'
+
+export function read<T>(
+  parser: Parser<T> &
+    Options & {
+      defaultValue?: T
+    },
+  key: string,
+  searchParams: URLSearchParams,
+  strict: boolean
+): T | null {
+  let result
+  const query =
+    parser.type === 'multi'
+      ? searchParams.getAll(key) // empty key to get all values
+      : searchParams.get(key)
+  if (query === null || (Array.isArray(query) && query.length === 0)) {
+    return parser.defaultValue ?? null
+  }
+  try {
+    // we have properly narrowed `query` here, but TS doesn't keep track of that
+    // there are probably better ways to do this than a type assertion ¯\_(ツ)_/¯
+    result = parser.parse(query as string & readonly string[])
+  } catch (error) {
+    if (strict) {
+      throw new Error(
+        `[nuqs] Error while parsing query \`${query}\` for key \`${key}\`: ${error}`
+      )
+    }
+    result = null
+  }
+  if (strict && query && result === null) {
+    throw new Error(
+      `[nuqs] Failed to parse query \`${query}\` for key \`${key}\` (got null)`
+    )
+  }
+  return result
+}
+
+export function write(
+  serialized: Iterable<string>,
+  key: string,
+  searchParams: URLSearchParams
+): URLSearchParams {
+  if (typeof serialized === 'string') {
+    searchParams.set(key, serialized)
+  } else {
+    searchParams.delete(key)
+    for (const v of serialized) {
+      searchParams.append(key, v)
+    }
+  }
+  return searchParams
+}

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,11 +1,11 @@
-export function isAbsentFromUrl(
-  query: string | Iterable<string> | null
-): query is null | [] {
+export type QueryParam = string | Array<string>
+
+export function isAbsentFromUrl(query: QueryParam | null): query is null | [] {
   return query === null || (Array.isArray(query) && query.length === 0)
 }
 
 export function write(
-  serialized: Iterable<string>,
+  serialized: QueryParam,
   key: string,
   searchParams: URLSearchParams
 ): URLSearchParams {

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -16,6 +16,9 @@ export function write(
     for (const v of serialized) {
       searchParams.append(key, v)
     }
+    if (searchParams.size === 0) {
+      searchParams.set(key, '')
+    }
   }
   return searchParams
 }

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -16,7 +16,7 @@ export function write(
     for (const v of serialized) {
       searchParams.append(key, v)
     }
-    if (searchParams.size === 0) {
+    if (!searchParams.has(key)) {
       searchParams.set(key, '')
     }
   }

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -16,6 +16,9 @@ export function write(
     for (const v of serialized) {
       searchParams.append(key, v)
     }
+    // if we get here with an empty iterable, no values were appended
+    // however, an empty iterable here means we explicitly want to set the key
+    // because for default values, we don't call write at all
     if (!searchParams.has(key)) {
       searchParams.set(key, '')
     }

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,6 +1,10 @@
 import type { Options } from '../defs'
 import type { Parser } from '../parsers'
 
+export function isEmpty(query: string | Iterable<string> | null): boolean {
+  return query === null || (Array.isArray(query) && query.length === 0)
+}
+
 export function read<T>(
   parser: Parser<T> &
     Options & {
@@ -15,7 +19,7 @@ export function read<T>(
     parser.type === 'multi'
       ? searchParams.getAll(key) // empty key to get all values
       : searchParams.get(key)
-  if (query === null || (Array.isArray(query) && query.length === 0)) {
+  if (isEmpty(query)) {
     return parser.defaultValue ?? null
   }
   try {

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,45 +1,5 @@
-import type { Options } from '../defs'
-import type { Parser } from '../parsers'
-
 export function isEmpty(query: string | Iterable<string> | null): boolean {
   return query === null || (Array.isArray(query) && query.length === 0)
-}
-
-export function read<T>(
-  parser: Parser<T> &
-    Options & {
-      defaultValue?: T
-    },
-  key: string,
-  searchParams: URLSearchParams,
-  strict: boolean
-): T | null {
-  let result
-  const query =
-    parser.type === 'multi'
-      ? searchParams.getAll(key) // empty key to get all values
-      : searchParams.get(key)
-  if (isEmpty(query)) {
-    return parser.defaultValue ?? null
-  }
-  try {
-    // we have properly narrowed `query` here, but TS doesn't keep track of that
-    // there are probably better ways to do this than a type assertion ¯\_(ツ)_/¯
-    result = parser.parse(query as string & readonly string[])
-  } catch (error) {
-    if (strict) {
-      throw new Error(
-        `[nuqs] Error while parsing query \`${query}\` for key \`${key}\`: ${error}`
-      )
-    }
-    result = null
-  }
-  if (strict && query && result === null) {
-    throw new Error(
-      `[nuqs] Failed to parse query \`${query}\` for key \`${key}\` (got null)`
-    )
-  }
-  return result
 }
 
 export function write(

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -1,11 +1,11 @@
-export type QueryParam = string | Array<string>
+export type Query = string | Array<string>
 
-export function isAbsentFromUrl(query: QueryParam | null): query is null | [] {
+export function isAbsentFromUrl(query: Query | null): query is null | [] {
   return query === null || (Array.isArray(query) && query.length === 0)
 }
 
 export function write(
-  serialized: QueryParam,
+  serialized: Query,
   key: string,
   searchParams: URLSearchParams
 ): URLSearchParams {

--- a/packages/nuqs/src/lib/sync.ts
+++ b/packages/nuqs/src/lib/sync.ts
@@ -1,8 +1,9 @@
 import { createEmitter, type Emitter } from './emitter'
+import type { QueryParam } from './search-params'
 
 export type CrossHookSyncPayload = {
   state: any
-  query: Iterable<string> | null
+  query: QueryParam | null
 }
 
 type EventMap = {

--- a/packages/nuqs/src/lib/sync.ts
+++ b/packages/nuqs/src/lib/sync.ts
@@ -2,7 +2,7 @@ import { createEmitter, type Emitter } from './emitter'
 
 export type CrossHookSyncPayload = {
   state: any
-  query: string | null
+  query: Iterable<string> | null
 }
 
 type EventMap = {

--- a/packages/nuqs/src/lib/sync.ts
+++ b/packages/nuqs/src/lib/sync.ts
@@ -1,9 +1,9 @@
 import { createEmitter, type Emitter } from './emitter'
-import type { QueryParam } from './search-params'
+import type { Query } from './search-params'
 
 export type CrossHookSyncPayload = {
   state: any
-  query: QueryParam | null
+  query: Query | null
 }
 
 type EventMap = {

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -1,6 +1,6 @@
 import type { UrlKeys } from './defs'
 import { type inferParserType, type ParserMap } from './parsers'
-import { isEmpty } from './lib/search-params'
+import { isAbsentFromUrl } from './lib/search-params'
 
 export type LoaderInput =
   | URL
@@ -101,7 +101,7 @@ export function createLoader<Parsers extends ParserMap>(
         parser.type === 'multi'
           ? searchParams.getAll(urlKey)
           : searchParams.get(urlKey)
-      if (isEmpty(query)) {
+      if (isAbsentFromUrl(query)) {
         result[key] = parser.defaultValue ?? null
         continue
       }

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -108,7 +108,7 @@ export function createLoader<Parsers extends ParserMap>(
       let parsedValue
       try {
         // we have properly narrowed `query` here, but TS doesn't keep track of that
-        parsedValue = parser.parse(query as string & readonly string[])
+        parsedValue = parser.parse(query as string & Array<string>)
       } catch (error) {
         if (strict) {
           throw new Error(

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -1,6 +1,6 @@
 import type { UrlKeys } from './defs'
-import { type inferParserType, type ParserMap } from './parsers'
 import { isAbsentFromUrl } from './lib/search-params'
+import type { inferParserType, ParserMap } from './parsers'
 
 export type LoaderInput =
   | URL

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -1,5 +1,6 @@
 import type { UrlKeys } from './defs'
-import type { inferParserType, ParserMap } from './parsers'
+import { type inferParserType, type ParserMap } from './parsers'
+import { read } from './lib/search-params'
 
 export type LoaderInput =
   | URL
@@ -96,27 +97,7 @@ export function createLoader<Parsers extends ParserMap>(
     const result = {} as any
     for (const [key, parser] of Object.entries(parsers)) {
       const urlKey = urlKeys[key] ?? key
-      const query = searchParams.get(urlKey)
-      if (query === null) {
-        result[key] = parser.defaultValue ?? null
-        continue
-      }
-      let parsedValue
-      try {
-        parsedValue = parser.parse(query)
-      } catch (error) {
-        if (strict) {
-          throw new Error(
-            `[nuqs] Error while parsing query \`${query}\` for key \`${key}\`: ${error}`
-          )
-        }
-        parsedValue = null
-      }
-      if (strict && query && parsedValue === null) {
-        throw new Error(
-          `[nuqs] Failed to parse query \`${query}\` for key \`${key}\` (got null)`
-        )
-      }
+      const parsedValue = read(parser, urlKey, searchParams, strict)
       result[key] = parsedValue ?? parser.defaultValue ?? null
     }
     return result

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -316,6 +316,11 @@ describe('parsers', () => {
       const parser = parseAsNativeArrayOf(parseAsInteger)
       expect(parser.parse(['not', 'a', 'number'])).toStrictEqual(null)
     })
+    it('is bijective', () => {
+      const parser = parseAsNativeArrayOf(parseAsString)
+      expect(isParserBijective(parser, ['a', 'b'], ['a', 'b'])).toBe(true)
+      expect(() => isParserBijective(parser, ['1', '2'], ['a', 'b'])).toThrow()
+    })
   })
 
   it('parseServerSide with default (#384)', () => {

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -12,6 +12,7 @@ import {
   parseAsIsoDate,
   parseAsIsoDateTime,
   parseAsJson,
+  parseAsNativeArrayOf,
   parseAsNumberLiteral,
   parseAsString,
   parseAsStringEnum,
@@ -298,6 +299,23 @@ describe('parsers', () => {
     expect(() =>
       isParserBijective(parser, 'not-an-array', ['a', 'b'])
     ).toThrow()
+  })
+
+  describe('parseAsNativeArrayOf', () => {
+    it('serializes', () => {
+      const parser = parseAsNativeArrayOf(parseAsString)
+      expect(parser.serialize([])).toStrictEqual([])
+      expect(parser.serialize(['a', ',', 'b'])).toStrictEqual(['a', ',', 'b'])
+    })
+    it('parses', () => {
+      const parser = parseAsNativeArrayOf(parseAsInteger)
+      expect(parser.parse([])).toStrictEqual([])
+      expect(parser.parse(['1', '2'])).toStrictEqual([1, 2])
+    })
+    it('defaults to empty array', () => {
+      const parser = parseAsNativeArrayOf(parseAsInteger)
+      expect(parser.parse(['not', 'a', 'number'])).toStrictEqual([])
+    })
   })
 
   it('parseServerSide with default (#384)', () => {

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -309,12 +309,12 @@ describe('parsers', () => {
     })
     it('parses', () => {
       const parser = parseAsNativeArrayOf(parseAsInteger)
-      expect(parser.parse([])).toStrictEqual([])
+      expect(parser.parse([])).toStrictEqual(null)
       expect(parser.parse(['1', '2'])).toStrictEqual([1, 2])
     })
-    it('defaults to empty array', () => {
+    it('defaults to null', () => {
       const parser = parseAsNativeArrayOf(parseAsInteger)
-      expect(parser.parse(['not', 'a', 'number'])).toStrictEqual([])
+      expect(parser.parse(['not', 'a', 'number'])).toStrictEqual(null)
     })
   })
 

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -38,9 +38,17 @@ export type MultiParser<T> = {
   eq?: (a: T, b: T) => boolean
 }
 
-export type Parser<T> = SingleParser<T> | MultiParser<T>
+export type GenericParser<T> = SingleParser<T> | MultiParser<T>
+export type GenericParserBuilder<T> =
+  | SingleParserBuilder<T>
+  | MultiParserBuilder<T>
 
-export type ParserBuilder<T> = SingleParserBuilder<T> | MultiParserBuilder<T>
+/* type aliases for backwards compatibility */
+/** @deprecated use SingleParser instead */
+export type Parser<T> = SingleParser<T>
+/** @deprecated use SingleParserBuilder instead */
+export type ParserBuilder<T> = SingleParserBuilder<T>
+
 export type SingleParserBuilder<T> = Required<SingleParser<T>> &
   Options & {
     /**
@@ -524,17 +532,19 @@ export function parseAsNativeArrayOf<ItemType>(
   }).withDefault([])
 }
 
-type inferSingleParserType<Parser> = Parser extends ParserBuilder<
+type inferSingleParserType<Parser> = Parser extends GenericParserBuilder<
   infer Value
 > & {
   defaultValue: infer Value
 }
   ? Value
-  : Parser extends ParserBuilder<infer Value>
+  : Parser extends GenericParserBuilder<infer Value>
     ? Value | null
     : never
 
-type inferParserRecordType<Map extends Record<string, ParserBuilder<any>>> = {
+type inferParserRecordType<
+  Map extends Record<string, GenericParserBuilder<any>>
+> = {
   [Key in keyof Map]: inferSingleParserType<Map[Key]>
 } & {}
 
@@ -563,13 +573,13 @@ type inferParserRecordType<Map extends Record<string, ParserBuilder<any>>> = {
  * ```
  */
 export type inferParserType<Input> =
-  Input extends ParserBuilder<any>
+  Input extends GenericParserBuilder<any>
     ? inferSingleParserType<Input>
-    : Input extends Record<string, ParserBuilder<any>>
+    : Input extends Record<string, GenericParserBuilder<any>>
       ? inferParserRecordType<Input>
       : never
 
-export type ParserWithOptionalDefault<T> = ParserBuilder<T> & {
+export type ParserWithOptionalDefault<T> = GenericParserBuilder<T> & {
   defaultValue?: T
 }
 export type ParserMap = Record<string, ParserWithOptionalDefault<any>>

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -504,11 +504,14 @@ export function parseAsNativeArrayOf<ItemType>(
         .filter(value => value !== null && value !== undefined) as ItemType[]
       return parsed.length === 0 ? null : parsed
     },
-    serialize: values =>
-      values.flatMap(value => {
+    serialize: values => {
+      // defensive check because we potentially get a single value passed from a standard schema
+      const safeValues = Array.isArray(values) ? values : [values]
+      return safeValues.flatMap(value => {
         const serialized = itemParser.serialize?.(value) ?? String(value)
         return typeof serialized === 'string' ? [serialized] : [...serialized]
-      }),
+      })
+    },
     eq(a, b) {
       if (a === b) {
         return true // Referentially stable

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -499,9 +499,10 @@ export function parseAsNativeArrayOf<ItemType>(
   const itemEq = itemParser.eq ?? ((a: ItemType, b: ItemType) => a === b)
   return createMultiParser({
     parse: query => {
-      return query
+      const parsed = query
         .map((item, index) => safeParse(itemParser.parse, item, `[${index}]`))
         .filter(value => value !== null && value !== undefined) as ItemType[]
+      return parsed.length === 0 ? null : parsed
     },
     serialize: values =>
       values.flatMap(value => {

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -130,8 +130,16 @@ export type MultiParserBuilder<T> = Required<MultiParser<T>> &
       defaultValue: NonNullable<T>
     ): Omit<MultiParserBuilder<T>, 'parseServerSide'> & {
       readonly defaultValue: NonNullable<T>
+      /**
+       * @deprecated exposed for symmetry with SingleParserBuilder only,
+       * prefer using loaders instead.
+       */
       parseServerSide(value: string | string[] | undefined): NonNullable<T>
     }
+    /**
+     * @deprecated exposed for symmetry with SingleParserBuilder only,
+     * prefer using loaders instead.
+     */
     parseServerSide(value: string | string[] | undefined): T | null
   }
 

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -495,7 +495,7 @@ export function parseAsArrayOf<ItemType>(
 
 export function parseAsNativeArrayOf<ItemType>(
   itemParser: SingleParser<ItemType>
-): MultiParserBuilder<ItemType[]> {
+): ReturnType<MultiParserBuilder<ItemType[]>['withDefault']> {
   const itemEq = itemParser.eq ?? ((a: ItemType, b: ItemType) => a === b)
   return createMultiParser({
     parse: query => {

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -521,7 +521,7 @@ export function parseAsNativeArrayOf<ItemType>(
       }
       return a.every((value, index) => itemEq(value, b[index]!))
     }
-  })
+  }).withDefault([])
 }
 
 type inferSingleParserType<Parser> = Parser extends ParserBuilder<

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -34,7 +34,7 @@ export type SingleParser<T> = {
 export type MultiParser<T> = {
   type: 'multi'
   parse: (value: ReadonlyArray<string>) => T | null
-  serialize?: (value: T) => Iterable<string>
+  serialize?: (value: T) => Array<string>
   eq?: (a: T, b: T) => boolean
 }
 

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -5,6 +5,7 @@ import {
   parseAsBoolean,
   parseAsInteger,
   parseAsJson,
+  parseAsNativeArrayOf,
   parseAsString
 } from './parsers'
 import { createSerializer } from './serializer'
@@ -12,7 +13,8 @@ import { createSerializer } from './serializer'
 const parsers = {
   str: parseAsString,
   int: parseAsInteger,
-  bool: parseAsBoolean
+  bool: parseAsBoolean,
+  multi: parseAsNativeArrayOf(parseAsString)
 }
 
 describe('serializer', () => {
@@ -200,6 +202,11 @@ describe('serializer', () => {
       str: 'foo?bar'
     })
     expect(result).toBe('https://example.com/path?issue=is?here&str=foo?bar')
+  })
+  it('supports native array values', () => {
+    const serialize = createSerializer(parsers)
+    const result = serialize({ multi: ['a', 'b', 'c'] })
+    expect(result).toBe('?multi=a&multi=b&multi=c')
   })
   describe('supports processUrlSearchParams', () => {
     it('modifies search params in place', () => {

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,6 +1,7 @@
 import type { Nullable, Options, UrlKeys } from './defs'
 import { renderQueryString } from './lib/url-encoding'
 import type { inferParserType, ParserMap } from './parsers'
+import { write } from './lib/search-params'
 
 type Base = string | URLSearchParams | URL
 
@@ -97,7 +98,8 @@ export function createSerializer<
       ) {
         search.delete(urlKey)
       } else {
-        search.set(urlKey, parser.serialize(value))
+        const serialized = parser.serialize(value)
+        search = write(serialized, urlKey, search)
       }
     }
     if (processUrlSearchParams) {

--- a/packages/nuqs/src/testing.ts
+++ b/packages/nuqs/src/testing.ts
@@ -1,4 +1,4 @@
-import type { ParserBuilder, SingleParserBuilder } from './parsers'
+import type { SingleParserBuilder } from './parsers'
 
 /**
  * Test that a parser is bijective (serialize then parse gives back the same value).

--- a/packages/nuqs/src/testing.ts
+++ b/packages/nuqs/src/testing.ts
@@ -1,4 +1,4 @@
-import type { ParserBuilder } from './parsers'
+import type { ParserBuilder, SingleParserBuilder } from './parsers'
 
 /**
  * Test that a parser is bijective (serialize then parse gives back the same value).
@@ -21,7 +21,7 @@ import type { ParserBuilder } from './parsers'
  * @returns `true` if the test passes, otherwise it will throw.
  */
 export function isParserBijective<T>(
-  parser: ParserBuilder<T>,
+  parser: SingleParserBuilder<T>,
   serialized: string,
   input: T
 ): boolean {
@@ -69,7 +69,7 @@ export function isParserBijective<T>(
  * @returns `true` if the test passes, otherwise it will throw.
  */
 export function testSerializeThenParse<T>(
-  parser: ParserBuilder<T>,
+  parser: SingleParserBuilder<T>,
   input: T
 ): boolean {
   const serialized = parser.serialize(input)
@@ -109,7 +109,7 @@ export function testSerializeThenParse<T>(
  * @returns `true` if the test passes, otherwise it will throw.
  */
 export function testParseThenSerialize<T>(
-  parser: ParserBuilder<T>,
+  parser: SingleParserBuilder<T>,
   input: string
 ): boolean {
   const parsed = parser.parse(input)

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
 import type { Options } from './defs'
-import type { Parser } from './parsers'
+import type { GenericParser } from './parsers'
 import { useQueryStates } from './useQueryStates'
 
-export type UseQueryStateOptions<T> = Parser<T> & Options
+export type UseQueryStateOptions<T> = GenericParser<T> & Options
 
 export type UseQueryStateReturn<Parsed, Default> = [
   Default extends undefined
@@ -90,7 +90,7 @@ export function useQueryState(
     // Note: Ensure this overload isn't picked when specifying a default
     // value and spreading a parser for which the default would be invalid.
     // See https://github.com/47ng/nuqs/pull/1057
-    [K in keyof Parser<unknown>]?: never
+    [K in keyof GenericParser<unknown>]?: never
   }
 ): UseQueryStateReturn<string, typeof options.defaultValue>
 
@@ -206,7 +206,7 @@ export function useQueryState<T = string>(
         serialize,
         eq,
         defaultValue
-      } as Parser<T>
+      } as GenericParser<T>
     },
     hookOptions
   )

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -3,7 +3,7 @@ import type { Options } from './defs'
 import type { Parser } from './parsers'
 import { useQueryStates } from './useQueryStates'
 
-export interface UseQueryStateOptions<T> extends Parser<T>, Options {}
+export type UseQueryStateOptions<T> = Parser<T> & Options
 
 export type UseQueryStateReturn<Parsed, Default> = [
   Default extends undefined
@@ -197,21 +197,16 @@ export function useQueryState<T = string>(
     defaultValue?: T
   } = {}
 ) {
-  const {
-    parse = x => x as unknown as T,
-    serialize,
-    eq,
-    defaultValue,
-    ...hookOptions
-  } = options
+  const { parse, type, serialize, eq, defaultValue, ...hookOptions } = options
   const [{ [key]: state }, setState] = useQueryStates(
     {
       [key]: {
-        parse,
+        parse: parse ?? ((x: any) => x as unknown as T),
+        type,
         serialize,
         eq,
         defaultValue
-      }
+      } as Parser<T>
     },
     hookOptions
   )

--- a/packages/nuqs/src/useQueryStates.test.ts
+++ b/packages/nuqs/src/useQueryStates.test.ts
@@ -11,6 +11,7 @@ import {
   parseAsArrayOf,
   parseAsInteger,
   parseAsJson,
+  parseAsNativeArrayOf,
   parseAsString
 } from './parsers'
 import { useQueryState } from './useQueryState'
@@ -107,6 +108,11 @@ describe('useQueryStates: referential equality', () => {
       {
         initial: 'state'
       }
+    ],
+    multi: [
+      {
+        initial: 'state'
+      }
     ]
   }
 
@@ -116,7 +122,10 @@ describe('useQueryStates: referential equality', () => {
     return useQueryStates({
       str: parseAsString.withDefault(defaultValue),
       obj: parseAsJson<any>(x => x).withDefault(defaults.obj),
-      arr: parseAsArrayOf(parseAsJson<any>(x => x)).withDefault(defaults.arr)
+      arr: parseAsArrayOf(parseAsJson<any>(x => x)).withDefault(defaults.arr),
+      multi: parseAsNativeArrayOf(parseAsJson<any>(x => x)).withDefault(
+        defaults.multi
+      )
     })
   }
 
@@ -129,6 +138,7 @@ describe('useQueryStates: referential equality', () => {
     expect(state.obj).toBe(defaults.obj)
     expect(state.arr).toBe(defaults.arr)
     expect(state.arr[0]).toBe(defaults.arr[0])
+    expect(state.multi[0]).toBe(defaults.multi[0])
   })
 
   it('should keep referential equality when resetting to defaults', async () => {
@@ -137,7 +147,8 @@ describe('useQueryStates: referential equality', () => {
         searchParams: {
           str: 'foo',
           obj: '{"hello":"world"}',
-          arr: '{"obj":true},{"arr":true}'
+          arr: '{"obj":true},{"arr":true}',
+          multi: '{"obj":true},{"arr":true}'
         }
       })
     })
@@ -147,6 +158,8 @@ describe('useQueryStates: referential equality', () => {
     expect(state.obj).toBe(defaults.obj)
     expect(state.arr).toBe(defaults.arr)
     expect(state.arr[0]).toBe(defaults.arr[0])
+    expect(state.multi).toBe(defaults.multi)
+    expect(state.multi[0]).toBe(defaults.multi[0])
   })
 
   it('should keep referential equality when unrelated keys change', async () => {
@@ -178,6 +191,8 @@ describe('useQueryStates: referential equality', () => {
     expect(state.obj).toBe(defaults.obj)
     expect(state.arr).toBe(defaults.arr)
     expect(state.arr[0]).toBe(defaults.arr[0])
+    expect(state.multi).toBe(defaults.multi)
+    expect(state.multi[0]).toBe(defaults.multi[0])
   })
 })
 

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -14,12 +14,12 @@ import {
   type UpdateQueuePushArgs
 } from './lib/queues/throttle'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
-import { type Parser } from './parsers'
+import { type GenericParser } from './parsers'
 import { isAbsentFromUrl } from './lib/search-params'
 import { safeParse } from './lib/safe-parse'
 import { compareQuery } from './lib/compare'
 
-type KeyMapValue<Type> = Parser<Type> &
+type KeyMapValue<Type> = GenericParser<Type> &
   Options & {
     defaultValue?: Type
   }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -382,9 +382,8 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   hasChanged: boolean
 } {
   let hasChanged = false
-  const state = Object.keys(keyMap).reduce((out, stateKey) => {
+  const state = Object.entries(keyMap).reduce((out, [stateKey, parser]) => {
     const urlKey = urlKeys?.[stateKey] ?? stateKey
-    const parser = keyMap[stateKey]!
     const queuedQuery = queuedQueries[urlKey]
     const query =
       queuedQuery === undefined

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -5,6 +5,7 @@ import {
   useAdapterProcessUrlSearchParams
 } from './adapters/lib/context'
 import type { Nullable, Options, UrlKeys } from './defs'
+import { compareQuery } from './lib/compare'
 import { debug } from './lib/debug'
 import { error } from './lib/errors'
 import { debounceController } from './lib/queues/debounce'
@@ -13,11 +14,10 @@ import {
   globalThrottleQueue,
   type UpdateQueuePushArgs
 } from './lib/queues/throttle'
+import { safeParse } from './lib/safe-parse'
+import { isAbsentFromUrl, type Query } from './lib/search-params'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
 import { type GenericParser } from './parsers'
-import { isAbsentFromUrl, type QueryParam } from './lib/search-params'
-import { safeParse } from './lib/safe-parse'
-import { compareQuery } from './lib/compare'
 
 type KeyMapValue<Type> = GenericParser<Type> &
   Options & {
@@ -99,7 +99,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   )
   const adapter = useAdapter(Object.values(resolvedUrlKeys))
   const initialSearchParams = adapter.searchParams
-  const queryRef = useRef<Record<string, QueryParam | null>>({})
+  const queryRef = useRef<Record<string, Query | null>>({})
   const defaultValues = useMemo(
     () =>
       Object.fromEntries(
@@ -375,8 +375,8 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   keyMap: KeyMap,
   urlKeys: Partial<Record<keyof KeyMap, string>>,
   searchParams: URLSearchParams,
-  queuedQueries: Record<string, QueryParam | null | undefined>,
-  cachedQuery?: Record<string, QueryParam | null>,
+  queuedQueries: Record<string, Query | null | undefined>,
+  cachedQuery?: Record<string, Query | null>,
   cachedState?: NullableValues<KeyMap>
 ): {
   state: NullableValues<KeyMap>

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -386,17 +386,17 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   const state = Object.entries(keyMap).reduce((out, [stateKey, parser]) => {
     const urlKey = urlKeys?.[stateKey] ?? stateKey
     const queuedQuery = queuedQueries[urlKey]
-    const defaultValue = parser.type === 'multi' ? [] : null
+    const fallbackValue = parser.type === 'multi' ? [] : null
     const query =
       queuedQuery === undefined
         ? ((parser.type === 'multi'
             ? searchParams?.getAll(urlKey)
-            : searchParams?.get(urlKey)) ?? defaultValue)
+            : searchParams?.get(urlKey)) ?? fallbackValue)
         : queuedQuery
     if (
       cachedQuery &&
       cachedState &&
-      compareQuery(cachedQuery[urlKey] ?? defaultValue, query)
+      compareQuery(cachedQuery[urlKey] ?? fallbackValue, query)
     ) {
       // Cache hit
       out[stateKey as keyof KeyMap] = cachedState[stateKey] ?? null

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -15,7 +15,7 @@ import {
 } from './lib/queues/throttle'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
 import { type GenericParser } from './parsers'
-import { isAbsentFromUrl } from './lib/search-params'
+import { isAbsentFromUrl, type QueryParam } from './lib/search-params'
 import { safeParse } from './lib/safe-parse'
 import { compareQuery } from './lib/compare'
 
@@ -99,7 +99,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   )
   const adapter = useAdapter(Object.values(resolvedUrlKeys))
   const initialSearchParams = adapter.searchParams
-  const queryRef = useRef<Record<string, Iterable<string> | null>>({})
+  const queryRef = useRef<Record<string, QueryParam | null>>({})
   const defaultValues = useMemo(
     () =>
       Object.fromEntries(
@@ -375,8 +375,8 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   keyMap: KeyMap,
   urlKeys: Partial<Record<keyof KeyMap, string>>,
   searchParams: URLSearchParams,
-  queuedQueries: Record<string, Iterable<string> | null | undefined>,
-  cachedQuery?: Record<string, Iterable<string> | null>,
+  queuedQueries: Record<string, QueryParam | null | undefined>,
+  cachedQuery?: Record<string, QueryParam | null>,
   cachedState?: NullableValues<KeyMap>
 ): {
   state: NullableValues<KeyMap>

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -15,7 +15,7 @@ import {
 } from './lib/queues/throttle'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
 import { type Parser } from './parsers'
-import { isEmpty } from './lib/search-params'
+import { isAbsentFromUrl } from './lib/search-params'
 import { safeParse } from './lib/safe-parse'
 
 type KeyMapValue<Type> = Parser<Type> &
@@ -399,7 +399,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
     }
     // Cache miss
     hasChanged = true
-    const value = isEmpty(query)
+    const value = isAbsentFromUrl(query)
       ? null
       : // we have properly narrowed `query` here, but TS doesn't keep track of that
         safeParse(parser.parse, query as string & Array<string>, urlKey)

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -15,7 +15,7 @@ import {
 } from './lib/queues/throttle'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
 import { type Parser } from './parsers'
-import { isEmpty, read } from './lib/search-params'
+import { isEmpty } from './lib/search-params'
 import { safeParse } from './lib/safe-parse'
 
 type KeyMapValue<Type> = Parser<Type> &
@@ -389,7 +389,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
     const query =
       queuedQuery === undefined
         ? parser.type === 'multi'
-          ? (searchParams?.getAll(urlKey) ?? null)
+          ? (searchParams?.getAll(urlKey) ?? [])
           : (searchParams?.get(urlKey) ?? null)
         : queuedQuery
     // todo this === comparison likely won't work with arrays
@@ -402,7 +402,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
     hasChanged = true
     const value = isEmpty(query)
       ? null
-      : // todo same narrowing problem as in read()
+      : // we have properly narrowed `query` here, but TS doesn't keep track of that
         safeParse(parser.parse, query as string & Array<string>, urlKey)
 
     out[stateKey as keyof KeyMap] = value ?? null


### PR DESCRIPTION
> **note**: Description by @franky47 

MultiParsers allow **key repetition** in the URL.

E.g.: with the built-in `parseAsNativeArrayOf`:
```ts
const [state] = useQueryState('key', parseAsNativeArrayOf(parseAsInteger))
// url:   /?key=1&key=2&key=3
// state: [1, 2, 3]
```

Creating custom multi-parsers allow reducing the array of query values into more complex objects:
```ts
// /?kv=foo:bar&kv=baz:qux
{
  foo: 'bar',
  baz: 'qux'
}
```