### PR TITLE
chore: split size-limit script from build process

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -131,7 +131,7 @@
     "dev": "tsdown --watch",
     "prebuild": "rm -rf dist",
     "build": "tsdown",
-    "postbuild": "size-limit --json > size.json",
+    "build:size-json": "size-limit --json > size.json",
     "test": "pnpm run --stream '/^test:/'",
     "test:unit": "vitest run --typecheck",
     "test:size": "size-limit",

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,11 @@
       "dependsOn": ["^build"]
     },
     "nuqs#build": {
-      "outputs": ["dist/**", "size.json", ".tsup/**", ".tsbuildinfo"]
+      "outputs": ["dist/**", ".tsup/**", ".tsbuildinfo"]
+    },
+    "nuqs#build:size-json": {
+      "outputs": ["size.json"],
+      "dependsOn": ["build"]
     },
     "e2e-next#build": {
       "outputs": [".next/**", "!.next/cache/**", "cypress/**"],
@@ -48,7 +52,7 @@
     },
     "docs#build": {
       "outputs": [".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "nuqs#build:size-json"],
       "env": [
         "VERCEL_ENV",
         "VERCEL_URL",


### PR DESCRIPTION
## Summary
Split size-limit operations into two separate scripts:

1. `build:size-json` - Only generates `size.json` for docs
2. `test:size` - Only validates size thresholds

Update `turbo.json` to:
- Remove `size.json` from `nuqs#build` outputs
- Add `nuqs#build:size-json` task
- Make `docs#build` depend on `nuqs#build:size-json`

## Changes
#### `package.json`
- Removed postbuild script that ran `size-limit --json > size.json`
- Added `build:size-json` script: `size-limit --json > size.json`
- Kept `test:size` script: `size-limit` (for validation)

#### `turbo.json`
- Removed `size.json` from `nuqs#build` outputs
- Added `nuqs#build:size-json` task with `dependsOn: ["build"]`
- Updated `docs#build` dependsOn to include `nuqs#build:size-json`

## Testing
- ✅ `pnpm turbo run docs#build` succeeds with proper task order:
  - `nuqs:build` → generates dist/
  - `nuqs:build:size-json` → generates size.json
  - `docs:build` → uses both dist/ and size.json
- ✅ `pnpm run build:size-json` generates size.json independently
- ✅ `pnpm run test:size` validates size thresholds independently
- ✅ Bundle size display in docs landing page works correctly

Closes #1135.