### PR TITLE
fix: don't bundle when running in esm.sh

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -193,7 +193,6 @@
     "zod": "^4.1.5"
   },
   "esm.sh": {
-    "// note": "Don't bundle React in esm.sh - See https://github.com/47ng/nuqs/issues/1145",
     "bundle": false
   },
   "size-limit": [

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -192,6 +192,10 @@
     "vitest-package-exports": "^0.1.1",
     "zod": "^4.1.5"
   },
+  "esm.sh": {
+    "// note": "Don't bundle React in esm.sh - See https://github.com/47ng/nuqs/issues/1145",
+    "bundle": false
+  },
   "size-limit": [
     {
       "name": "Client",


### PR DESCRIPTION
This causes the React peer dependency to be bundled alongside the nuqs code, causing duplicate React modules to be used, and with it the classic "cannot read {hookName} of null".

Fixes #1145.