### PR TITLE
Add a countdown to Next.js conf

### DIFF
--- a/packages/docs/src/app/banners.tsx
+++ b/packages/docs/src/app/banners.tsx
@@ -79,3 +79,61 @@ export function ReactParis2025SideBanner() {
     </div>
   )
 }
+
+export function NextJSConf2025TopBanner() {
+  return (
+    <Banner
+      variant="primary"
+      className="text-md flex flex-wrap items-center justify-center gap-3 font-semibold"
+      id="nextjs-conf-2025"
+    >
+      <span aria-hidden>📺</span>
+      <Link
+        href="https://nextjs.org/conf"
+        className="decoration-slice decoration-1 transition-all hover:underline hover:underline-offset-8 focus-visible:underline focus-visible:outline-none"
+        prefetch={false}
+      >
+        Watch nuqs at Next.js Conf (Oct 22, 1:55pm PT)
+      </Link>
+      <span aria-hidden>·</span>
+      <Suspense>
+        <Countdown
+          targetDate={new Date('2025-10-22T13:55:00-07:00')}
+          expiredMessage={
+            <span>
+              Live now —{' '}
+              <Link
+                href="https://nextjs.org/conf"
+                className="underline"
+                prefetch={false}
+              >
+                join the livestream
+              </Link>
+            </span>
+          }
+        />
+      </Suspense>
+    </Banner>
+  )
+}
+
+export function NextJSConf2025SideBanner() {
+  return (
+    <div className="my-2 flex flex-col items-center gap-1.5 rounded-lg border border-gray-500/40 bg-gray-100/50 px-2 py-4 dark:bg-gray-700/10">
+      <p className="text-muted-foreground">🎤 nuqs at Next.js Conf</p>
+      <a
+        href="https://nextjs.org/conf"
+        className="text-sm hover:underline"
+      >
+        Livestream link
+      </a>
+      <Suspense>
+        <Countdown
+          targetDate={new Date('2025-10-22T13:55:00-07:00')}
+          className="my-2"
+          expiredMessage={<span className="text-sm">Live now!</span>}
+        />
+      </Suspense>
+    </div>
+  )
+}

--- a/packages/docs/src/app/docs/layout.tsx
+++ b/packages/docs/src/app/docs/layout.tsx
@@ -2,6 +2,7 @@ import { source } from '@/src/app/source'
 import { getSharedLayoutProps } from '@/src/components/shared-layout'
 import { DocsLayout } from 'fumadocs-ui/layouts/notebook'
 import { Suspense, type ReactNode } from 'react'
+import { NextJSConf2025SideBanner } from '../banners'
 
 export default function RootDocsLayout({ children }: { children: ReactNode }) {
   const shared = getSharedLayoutProps()
@@ -13,7 +14,7 @@ export default function RootDocsLayout({ children }: { children: ReactNode }) {
       nav={{ ...shared.nav, mode: 'top' }}
       sidebar={{
         collapsible: false,
-        // banner: <ReactParis2025SideBanner />,
+        banner: <NextJSConf2025SideBanner />,
         footer: (
           <Suspense>
             <SidebarFooter />

--- a/packages/docs/src/app/layout.tsx
+++ b/packages/docs/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Script from 'next/script'
 import { NuqsAdapter } from 'nuqs/adapters/next'
 import type { ReactNode } from 'react'
 import { ResponsiveHelper } from '../components/responsive-helpers'
+import { NextJSConf2025TopBanner } from './banners'
 import { cn } from '../lib/utils'
 import './globals.css'
 
@@ -47,6 +48,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       </head>
       <body>
         {/* Top-level banners go here */}
+        <NextJSConf2025TopBanner />
         <RootProvider>
           <NuqsAdapter>{children}</NuqsAdapter>
         </RootProvider>

--- a/packages/docs/src/app/playground/layout.tsx
+++ b/packages/docs/src/app/playground/layout.tsx
@@ -2,6 +2,7 @@ import { getSharedLayoutProps } from '@/src/components/shared-layout'
 import { DocsLayout } from 'fumadocs-ui/layouts/notebook'
 import { DocsBody, DocsPage } from 'fumadocs-ui/page'
 import React, { Suspense } from 'react'
+import { NextJSConf2025SideBanner } from '../banners'
 import { getPlaygroundTree } from './(demos)/demos'
 import { DebugControl } from './debug-control'
 
@@ -26,7 +27,7 @@ export default function PlaygroundLayout({
         {...shared}
         nav={{ ...shared.nav, mode: 'top' }}
         sidebar={{
-          // banner: <ReactParis2025SideBanner />,
+          banner: <NextJSConf2025SideBanner />,
           footer: (
             <Suspense fallback={<DebugControlsSkeleton />}>
               <DebugControl />


### PR DESCRIPTION
I added a Next.js Conf countdown banner using the existing Countdown component.
Top banner shows on every page; sidebar banner shows in docs and playground.
Changes:
packages/docs/src/app/banners.tsx: added NextJSConf2025TopBanner and NextJSConf2025SideBanner with link to the livestream and countdown to 2025-10-22 13:55 PT.
packages/docs/src/app/layout.tsx: renders NextJSConf2025TopBanner above the root provider.
packages/docs/src/app/docs/layout.tsx: enables sidebar banner with NextJSConf2025SideBanner.
packages/docs/src/app/playground/layout.tsx: enables sidebar banner with NextJSConf2025SideBanner.