### PR TITLE
perf: bail out of state updates for equal values

### DIFF
--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -189,11 +189,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
   // Sync all hooks together & with external URL changes
   useEffect(() => {
-    function updateInternalState(state: V) {
-      debug('[nuq+ %s `%s`] updateInternalState %O', hookId, stateKeys, state)
-      stateRef.current = state
-      setInternalState(state)
-    }
     const handlers = Object.keys(keyMap).reduce(
       (handlers, stateKey) => {
         handlers[stateKey as keyof KeyMap] = ({
@@ -218,7 +213,27 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             defaultValue,
             stateRef.current
           )
-          updateInternalState(stateRef.current)
+          if (
+            Object.is(
+              internalState[stateKey as keyof KeyMap] ?? defaultValue ?? null,
+              stateRef.current[stateKey as keyof KeyMap]
+            )
+          ) {
+            debug(
+              '[nuq+ %s `%s`] Cross-hook key sync %s: no change, skipping',
+              hookId,
+              stateKeys,
+              urlKey
+            )
+            return
+          }
+          debug(
+            '[nuq+ %s `%s`] updateInternalState %O',
+            hookId,
+            stateKeys,
+            stateRef.current
+          )
+          setInternalState(stateRef.current)
         }
         return handlers
       },


### PR DESCRIPTION
When `useQueryStates` receives an event that should update its internal state. we should bail out of that update if we already store the same value.

This is what React’s `useState` does per default (by comparing with `Object.is`), however, it doesn’t work to delegate this to React because the internal state of `useQueryStates` is an object. When an event comes in, we only update a single value of that object:

```
stateRef.current = {
  ...stateRef.current,
  [stateKey as keyof KeyMap]: state ?? defaultValue ?? null
}
```

so we can optimize ourselves by comparing the current state for that key with the new state that comes in from the emit and skip calling `setInternalState` for those cases.