### PR TITLE
doc: fix React Router icon size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default function App() {
 
 </details>
 
-<details><summary><img width="1em" height="1em" style="width:1em;height:1em;" src="https://reactrouter.com/_brand/React%20Router%20Brand%20Assets/React%20Router%20Logo/Dark.svg" /> React Router v6
+<details><summary><span style="width:16px;height:16px;background:#fff;border-radius:2px;"><img width="16px" height="16px" src="https://reactrouter.com/_brand/React%20Router%20Brand%20Assets/React%20Router%20Logo/Light.svg" /></span> React Router v6
 </summary>
 
 > Supported React Router versions: `react-router-dom@^6`
@@ -148,7 +148,7 @@ export function ReactRouter() {
 
 </details>
 
-<details><summary><img width="1em" height="1em" style="width:1em;height:1em;" src="https://reactrouter.com/_brand/React%20Router%20Brand%20Assets/React%20Router%20Logo/Dark.svg" /> React Router v7
+<details><summary><span style="width:16px;height:16px;background:#fff;border-radius:2px;"><img width="16px" height="16px" src="https://reactrouter.com/_brand/React%20Router%20Brand%20Assets/React%20Router%20Logo/Light.svg" /></span> React Router v7
 </summary>
 
 > Supported React Router versions: `react-router@^7`


### PR DESCRIPTION
On npmjs.com, it renders super big:

<img width="1792" height="1952" alt="CleanShot 2025-10-10 at 00 29 44@2x" src="https://github.com/user-attachments/assets/284f923b-97af-4461-8ed1-ec2dcfb1f41c" />

After:
<img width="770" height="638" alt="CleanShot 2025-10-10 at 00 49 45@2x" src="https://github.com/user-attachments/assets/101649da-cad0-4f00-bdda-4a1623367557" />