### PR TITLE
feat(docs): add TanStack Table parsers

### DIFF
--- a/packages/docs/content/docs/parsers/community/tanstack-table.generator.tsx
+++ b/packages/docs/content/docs/parsers/community/tanstack-table.generator.tsx
@@ -23,7 +23,9 @@ import {
   parseAsIndex,
   parseAsInteger,
   parseAsString,
-  useQueryState
+  parseAsStringEnum,
+  useQueryState,
+  useQueryStates
 } from 'nuqs'
 import { useDeferredValue } from 'react'
 
@@ -184,6 +186,453 @@ export function usePaginationSearchParams() {
                 setPageSizeUrlKey(e.target.value)
               }}
               placeholder="e.g., limit"
+              autoComplete="off"
+            />
+          </div>
+        </aside>
+      </div>
+    </section>
+  )
+}
+
+export function TanStackTableSorting() {
+  const ACCESSOR_KEYS = ['name', 'email', 'role', 'status', 'createdAt']
+
+  const [sortColumnUrlKey, setSortColumnUrlKey] = useQueryState(
+    'sortColumnUrlKey',
+    parseAsString.withDefault('sortColumn')
+  )
+  const [sortDirectionUrlKey, setSortDirectionUrlKey] = useQueryState(
+    'sortDirectionUrlKey',
+    parseAsString.withDefault('sortDirection')
+  )
+  const [defaultSortColumn, setDefaultSortColumn] = useQueryState(
+    'defaultSortColumn',
+    parseAsString.withDefault('name')
+  )
+  const [urlSorting, setUrlSorting] = useQueryStates(
+    {
+      sortColumn: parseAsStringEnum(ACCESSOR_KEYS)
+        .withOptions({
+          clearOnDefault: true
+        })
+        .withDefault(defaultSortColumn),
+      sortDirection: parseAsStringEnum(['asc', 'desc'])
+        .withOptions({
+          clearOnDefault: true
+        })
+        .withDefault('desc')
+    },
+    {
+      urlKeys: {
+        sortColumn: sortColumnUrlKey,
+        sortDirection: sortDirectionUrlKey
+      }
+    }
+  )
+
+  const sorting = urlSorting.sortColumn
+    ? [{ id: urlSorting.sortColumn, desc: urlSorting.sortDirection === 'desc' }]
+    : []
+
+  const parserCode = useDeferredValue(`import React from 'react'
+import { parseAsStringEnum, useQueryStates } from 'nuqs'
+import type { OnChangeFn, SortingState } from '@tanstack/react-table'
+
+export const useSortingSearchParams = (
+  accessorKeys: string[],
+  defaultValue: string
+): [sorting: SortingState, setSorting: OnChangeFn<SortingState>] => {
+  const [urlSorting, setUrlSorting] = useQueryStates(
+    {
+      sortColumn: parseAsStringEnum(accessorKeys)
+        .withOptions({
+          clearOnDefault: true,
+        })
+        .withDefault(defaultValue),
+      sortDirection: parseAsStringEnum(['asc', 'desc'])
+        .withOptions({
+          clearOnDefault: true,
+        })
+        .withDefault('desc'),
+    },
+    {
+      urlKeys: {
+        sortColumn: '${sortColumnUrlKey}',
+        sortDirection: '${sortDirectionUrlKey}',
+      },
+    },
+  )
+
+  const sorting = React.useMemo<SortingState>(
+    () =>
+      urlSorting.sortColumn
+        ? [{ id: urlSorting.sortColumn, desc: urlSorting.sortDirection === 'desc' }]
+        : [],
+    [urlSorting]
+  )
+
+  const setSorting = React.useCallback<OnChangeFn<SortingState>>(
+    (updaterOrValue) => {
+      const firstSortingColumn =
+        typeof updaterOrValue === 'function'
+          ? updaterOrValue(sorting)?.[0]
+          : updaterOrValue?.[0]
+      void setUrlSorting({
+        sortColumn: firstSortingColumn?.id,
+        sortDirection:
+          firstSortingColumn === undefined
+            ? undefined
+            : firstSortingColumn.desc
+              ? 'desc'
+              : 'asc',
+      })
+    },
+    [setUrlSorting, sorting]
+  )
+
+  return [sorting, setSorting]
+}`)
+
+  const internalState = useDeferredValue(`[
+  ${sorting.length > 0 ? `{
+    id: '${sorting[0].id}',
+    desc: ${sorting[0].desc}
+  }` : '// No sorting applied'}
+]`)
+
+  return (
+    <section>
+      <div className="flex flex-wrap items-center justify-start gap-2 rounded-xl border border-dashed p-4">
+        <Label className="flex items-center gap-2">
+          Sort by
+          <Select
+            value={urlSorting.sortColumn || '_'}
+            onValueChange={value =>
+              setUrlSorting({
+                sortColumn: value === '_' ? null : value,
+                sortDirection: urlSorting.sortDirection
+              })
+            }
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_">None</SelectItem>
+              {ACCESSOR_KEYS.map(key => (
+                <SelectItem key={key} value={key}>
+                  {key}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Label>
+        <Label className="flex items-center gap-2">
+          Direction
+          <Select
+            value={urlSorting.sortDirection}
+            onValueChange={value =>
+              setUrlSorting({
+                sortColumn: urlSorting.sortColumn,
+                sortDirection: value as 'asc' | 'desc'
+              })
+            }
+            disabled={!urlSorting.sortColumn}
+          >
+            <SelectTrigger className="w-32">
+              <SelectValue placeholder="desc" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="asc">Ascending</SelectItem>
+              <SelectItem value="desc">Descending</SelectItem>
+            </SelectContent>
+          </Select>
+        </Label>
+      </div>
+      <p className="mb-0">
+        Configure and copy-paste this parser into your application:
+      </p>
+      <div className="flex flex-col gap-6 xl:flex-row">
+        <CodeBlock
+          title="search-params.sorting.ts"
+          lang="ts"
+          icon={
+            <svg
+              fill="none"
+              viewBox="0 0 128 128"
+              xmlns="http://www.w3.org/2000/svg"
+              className="size-4"
+              role="presentation"
+            >
+              <rect fill="currentColor" height="128" rx="6" width="128" />
+              <path
+                clipRule="evenodd"
+                d="m74.2622 99.468v14.026c2.2724 1.168 4.9598 2.045 8.0625 2.629 3.1027.585 6.3728.877 9.8105.877 3.3503 0 6.533-.321 9.5478-.964 3.016-.643 5.659-1.702 7.932-3.178 2.272-1.476 4.071-3.404 5.397-5.786 1.325-2.381 1.988-5.325 1.988-8.8313 0-2.5421-.379-4.7701-1.136-6.6841-.758-1.9139-1.85-3.6159-3.278-5.1062-1.427-1.4902-3.139-2.827-5.134-4.0104-1.996-1.1834-4.246-2.3011-6.752-3.353-1.8352-.7597-3.4812-1.4975-4.9378-2.2134-1.4567-.7159-2.6948-1.4464-3.7144-2.1915-1.0197-.7452-1.8063-1.5341-2.3598-2.3669-.5535-.8327-.8303-1.7751-.8303-2.827 0-.9643.2476-1.8336.7429-2.6079s1.1945-1.4391 2.0976-1.9943c.9031-.5551 2.0101-.9861 3.3211-1.2929 1.311-.3069 2.7676-.4603 4.3699-.4603 1.1658 0 2.3958.0877 3.6928.263 1.296.1753 2.6.4456 3.911.8109 1.311.3652 2.585.8254 3.824 1.3806 1.238.5552 2.381 1.198 3.43 1.9285v-13.1051c-2.127-.8182-4.45-1.4245-6.97-1.819s-5.411-.5917-8.6744-.5917c-3.3211 0-6.4674.3579-9.439 1.0738-2.9715.7159-5.5862 1.8336-7.844 3.353-2.2578 1.5195-4.0422 3.4553-5.3531 5.8075-1.311 2.3522-1.9665 5.1646-1.9665 8.4373 0 4.1785 1.2017 7.7433 3.6052 10.6945 2.4035 2.9513 6.0523 5.4496 10.9466 7.495 1.9228.7889 3.7145 1.5633 5.375 2.323 1.6606.7597 3.0954 1.5486 4.3044 2.3668s2.1628 1.7094 2.8618 2.6736c.7.9643 1.049 2.06 1.049 3.2873 0 .9062-.218 1.7462-.655 2.5202s-1.1 1.446-1.9885 2.016c-.8886.57-1.9956 1.016-3.3212 1.337-1.3255.321-2.8768.482-4.6539.482-3.0299 0-6.0305-.533-9.0021-1.6-2.9715-1.066-5.7245-2.666-8.2591-4.799zm-23.5596-34.9136h18.2974v-11.5544h-51v11.5544h18.2079v51.4456h14.4947z"
+                className="fill-background"
+                fillRule="evenodd"
+              />
+            </svg>
+          }
+          className="flex-grow"
+          code={parserCode}
+        />
+        <aside className="w-full space-y-4 xl:w-64">
+          <Querystring
+            value={
+              urlSorting.sortColumn
+                ? `?${sortColumnUrlKey}=${urlSorting.sortColumn}&${sortDirectionUrlKey}=${urlSorting.sortDirection}`
+                : '?'
+            }
+          />
+          <CodeBlock
+            title="Internal state"
+            code={internalState}
+            allowCopy={false}
+          />
+          <Separator className="my-8" />
+          <div className="space-y-2">
+            <Label htmlFor="sortColumnKey">Sort column URL key</Label>
+            <input
+              id="sortColumnKey"
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              value={sortColumnUrlKey}
+              onChange={e => {
+                setUrlSorting({ sortColumn: null, sortDirection: null })
+                setSortColumnUrlKey(e.target.value)
+              }}
+              placeholder="e.g., sortColumn"
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sortDirectionKey">Sort direction URL key</Label>
+            <input
+              id="sortDirectionKey"
+              value={sortDirectionUrlKey}
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              onChange={e => {
+                setUrlSorting({ sortColumn: null, sortDirection: null })
+                setSortDirectionUrlKey(e.target.value)
+              }}
+              placeholder="e.g., sortDirection"
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="defaultSortColumn">Default sort column</Label>
+            <Select
+              value={defaultSortColumn}
+              onValueChange={value => setDefaultSortColumn(value)}
+            >
+              <SelectTrigger id="defaultSortColumn">
+                <SelectValue placeholder="name" />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCESSOR_KEYS.map(key => (
+                  <SelectItem key={key} value={key}>
+                    {key}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </aside>
+      </div>
+    </section>
+  )
+}
+
+export function TanStackTableFiltering() {
+  const ACCESSOR_KEYS = ['name', 'email', 'role', 'status', 'createdAt']
+
+  const [filterColumnUrlKey, setFilterColumnUrlKey] = useQueryState(
+    'filterColumnUrlKey',
+    parseAsString.withDefault('filterColumn')
+  )
+  const [filterValueUrlKey, setFilterValueUrlKey] = useQueryState(
+    'filterValueUrlKey',
+    parseAsString.withDefault('filterValue')
+  )
+  const [urlFilter, setUrlFilter] = useQueryStates(
+    {
+      filterColumn: parseAsStringEnum(ACCESSOR_KEYS),
+      filterValue: parseAsString
+    },
+    {
+      urlKeys: {
+        filterColumn: filterColumnUrlKey,
+        filterValue: filterValueUrlKey
+      }
+    }
+  )
+
+  const filter = urlFilter.filterColumn
+    ? [{ id: urlFilter.filterColumn, value: urlFilter.filterValue }]
+    : []
+
+  const parserCode = useDeferredValue(`import React from 'react'
+import { parseAsString, parseAsStringEnum, useQueryStates } from 'nuqs'
+import type { ColumnFiltersState, OnChangeFn } from '@tanstack/react-table'
+
+export const useFilteredRowSearchParams = (
+  accessorKeys: string[]
+): [filter: ColumnFiltersState, setFilter: OnChangeFn<ColumnFiltersState>] => {
+  const [urlFilter, setUrlFilter] = useQueryStates(
+    {
+      filterColumn: parseAsStringEnum(accessorKeys),
+      filterValue: parseAsString,
+    },
+    {
+      urlKeys: {
+        filterColumn: '${filterColumnUrlKey}',
+        filterValue: '${filterValueUrlKey}',
+      },
+    },
+  )
+
+  const filter = React.useMemo<ColumnFiltersState>(
+    () =>
+      urlFilter.filterColumn
+        ? [{ id: urlFilter.filterColumn, value: urlFilter.filterValue }]
+        : [],
+    [urlFilter]
+  )
+
+  const setFilter = React.useCallback<OnChangeFn<ColumnFiltersState>>(
+    (updaterOrValue) => {
+      const firstFilterColumn =
+        typeof updaterOrValue === 'function'
+          ? updaterOrValue(filter)?.[0]
+          : updaterOrValue?.[0]
+      void setUrlFilter({
+        filterColumn: firstFilterColumn?.id,
+        filterValue: firstFilterColumn ? String(firstFilterColumn.value) : undefined,
+      })
+    },
+    [filter, setUrlFilter]
+  )
+
+  return [filter, setFilter]
+}`)
+
+  const internalState = useDeferredValue(`[
+  ${filter.length > 0 ? `{
+    id: '${filter[0].id}',
+    value: '${filter[0].value ?? ''}'
+  }` : '// No filter applied'}
+]`)
+
+  return (
+    <section>
+      <div className="flex flex-wrap items-center justify-start gap-2 rounded-xl border border-dashed p-4">
+        <Label className="flex items-center gap-2">
+          Filter by
+          <Select
+            value={urlFilter.filterColumn || '_'}
+            onValueChange={value =>
+              setUrlFilter({
+                filterColumn: value === '_' ? null : value,
+                filterValue: urlFilter.filterValue
+              })
+            }
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="None" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="_">None</SelectItem>
+              {ACCESSOR_KEYS.map(key => (
+                <SelectItem key={key} value={key}>
+                  {key}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Label>
+        <Label className="flex items-center gap-2">
+          Value
+          <input
+            className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-48 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            value={urlFilter.filterValue ?? ''}
+            onChange={e =>
+              setUrlFilter({
+                filterColumn: urlFilter.filterColumn,
+                filterValue: e.target.value || null
+              })
+            }
+            disabled={!urlFilter.filterColumn}
+            placeholder="Enter filter value"
+            autoComplete="off"
+          />
+        </Label>
+      </div>
+      <p className="mb-0">
+        Configure and copy-paste this parser into your application:
+      </p>
+      <div className="flex flex-col gap-6 xl:flex-row">
+        <CodeBlock
+          title="search-params.filtering.ts"
+          lang="ts"
+          icon={
+            <svg
+              fill="none"
+              viewBox="0 0 128 128"
+              xmlns="http://www.w3.org/2000/svg"
+              className="size-4"
+              role="presentation"
+            >
+              <rect fill="currentColor" height="128" rx="6" width="128" />
+              <path
+                clipRule="evenodd"
+                d="m74.2622 99.468v14.026c2.2724 1.168 4.9598 2.045 8.0625 2.629 3.1027.585 6.3728.877 9.8105.877 3.3503 0 6.533-.321 9.5478-.964 3.016-.643 5.659-1.702 7.932-3.178 2.272-1.476 4.071-3.404 5.397-5.786 1.325-2.381 1.988-5.325 1.988-8.8313 0-2.5421-.379-4.7701-1.136-6.6841-.758-1.9139-1.85-3.6159-3.278-5.1062-1.427-1.4902-3.139-2.827-5.134-4.0104-1.996-1.1834-4.246-2.3011-6.752-3.353-1.8352-.7597-3.4812-1.4975-4.9378-2.2134-1.4567-.7159-2.6948-1.4464-3.7144-2.1915-1.0197-.7452-1.8063-1.5341-2.3598-2.3669-.5535-.8327-.8303-1.7751-.8303-2.827 0-.9643.2476-1.8336.7429-2.6079s1.1945-1.4391 2.0976-1.9943c.9031-.5551 2.0101-.9861 3.3211-1.2929 1.311-.3069 2.7676-.4603 4.3699-.4603 1.1658 0 2.3958.0877 3.6928.263 1.296.1753 2.6.4456 3.911.8109 1.311.3652 2.585.8254 3.824 1.3806 1.238.5552 2.381 1.198 3.43 1.9285v-13.1051c-2.127-.8182-4.45-1.4245-6.97-1.819s-5.411-.5917-8.6744-.5917c-3.3211 0-6.4674.3579-9.439 1.0738-2.9715.7159-5.5862 1.8336-7.844 3.353-2.2578 1.5195-4.0422 3.4553-5.3531 5.8075-1.311 2.3522-1.9665 5.1646-1.9665 8.4373 0 4.1785 1.2017 7.7433 3.6052 10.6945 2.4035 2.9513 6.0523 5.4496 10.9466 7.495 1.9228.7889 3.7145 1.5633 5.375 2.323 1.6606.7597 3.0954 1.5486 4.3044 2.3668s2.1628 1.7094 2.8618 2.6736c.7.9643 1.049 2.06 1.049 3.2873 0 .9062-.218 1.7462-.655 2.5202s-1.1 1.446-1.9885 2.016c-.8886.57-1.9956 1.016-3.3212 1.337-1.3255.321-2.8768.482-4.6539.482-3.0299 0-6.0305-.533-9.0021-1.6-2.9715-1.066-5.7245-2.666-8.2591-4.799zm-23.5596-34.9136h18.2974v-11.5544h-51v11.5544h18.2079v51.4456h14.4947z"
+                className="fill-background"
+                fillRule="evenodd"
+              />
+            </svg>
+          }
+          className="flex-grow"
+          code={parserCode}
+        />
+        <aside className="w-full space-y-4 xl:w-64">
+          <Querystring
+            value={
+              urlFilter.filterColumn
+                ? `?${filterColumnUrlKey}=${urlFilter.filterColumn}&${filterValueUrlKey}=${urlFilter.filterValue ?? ''}`
+                : '?'
+            }
+          />
+          <CodeBlock
+            title="Internal state"
+            code={internalState}
+            allowCopy={false}
+          />
+          <Separator className="my-8" />
+          <div className="space-y-2">
+            <Label htmlFor="filterColumnKey">Filter column URL key</Label>
+            <input
+              id="filterColumnKey"
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              value={filterColumnUrlKey}
+              onChange={e => {
+                setUrlFilter({ filterColumn: null, filterValue: null })
+                setFilterColumnUrlKey(e.target.value)
+              }}
+              placeholder="e.g., filterColumn"
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="filterValueKey">Filter value URL key</Label>
+            <input
+              id="filterValueKey"
+              value={filterValueUrlKey}
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              onChange={e => {
+                setUrlFilter({ filterColumn: null, filterValue: null })
+                setFilterValueUrlKey(e.target.value)
+              }}
+              placeholder="e.g., filterValue"
               autoComplete="off"
             />
           </div>

--- a/packages/docs/content/docs/parsers/community/tanstack-table.mdx
+++ b/packages/docs/content/docs/parsers/community/tanstack-table.mdx
@@ -19,20 +19,24 @@ TanStack Table stores pagination under two pieces of state:
 
 You will likely want the URL to follow your UI and be one-based for the page index:
 
-import { TanStackTablePagination } from './tanstack-table.generator'
+import {
+  TanStackTablePagination,
+  TanStackTableSorting,
+  TanStackTableFiltering
+} from './tanstack-table.generator'
 
 <Suspense>
   <TanStackTablePagination />
 </Suspense>
 
-## Filtering
-
-<Callout>
-  This section is empty for now, [contributions](https://github.com/47ng/nuqs) are welcome!
-</Callout>
-
 ## Sorting
 
-<Callout>
-  This section is empty for now, [contributions](https://github.com/47ng/nuqs) are welcome!
-</Callout>
+<Suspense>
+  <TanStackTableSorting />
+</Suspense>
+
+## Filtering
+
+<Suspense>
+  <TanStackTableFiltering />
+</Suspense>


### PR DESCRIPTION
Add a new section in the docs covering how to use custom parsers with TanStack Table for filtering and sorting. The current implementation is somewhat limited as it only supports sorting and filtering one column at a time.

Please note that this PR was implemented by using Claude Code to adjust code copied over from another codebase of mine to the format which the docs expect and I have not reviewed each change in detail. Feel free to close if this is not acceptable. I just thought to leave this here if anyone else searches for it or to at least provide a starting point.