### PR TITLE
fix: forward processUrlSearchParams through the debounce queue

### DIFF
--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -335,7 +335,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           const debouncedPromise = debounceController.push(
             update,
             timeMs,
-            adapter
+            adapter,
+            processUrlSearchParams
           )
           if (maxDebounceTime < timeMs) {
             // The largest debounce is likely to be the last URL update,


### PR DESCRIPTION
The processUrlSearchParams callback wasn't passed properly down the debounce -> throttle queue chain, and so wasn't called for debounced updates.

- [x] Check for closures staleness & see if we can pass it the same way we do the adapter.

Closes #1249.