### PR TITLE
fix: remove 'use client' directive in .d.ts definition files

### DIFF
--- a/packages/nuqs/tsdown.config.ts
+++ b/packages/nuqs/tsdown.config.ts
@@ -46,7 +46,8 @@ const config: UserConfig = defineConfig([
     ...commonConfig,
     entry: entrypoints.client,
     outputOptions: {
-      intro: ({ isEntry }) => (isEntry ? "'use client';\n" : '')
+      intro: ({ isEntry, fileName }) =>
+        isEntry && !fileName.endsWith('.d.ts') ? "'use client';\n" : ''
     },
     async onSuccess() {
       // Mark the un-versionned React Router adapter as deprecated


### PR DESCRIPTION
Fixes #1257.

Skips the adding of `'use client';` for Typescript definition files.