### PR TITLE
fix: undefined means "leave as-is" in useQueryStates

### DIFF
--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -83,6 +83,11 @@ describe('serializer', () => {
     const result = serialize('?str=bar&int=-1', null)
     expect(result).toBe('')
   })
+  it('keeps search params in the base when given undefined as value', () => {
+    const serialize = createSerializer(parsers)
+    const result = serialize('?str=foo', { str: undefined })
+    expect(result).toBe('?str=foo')
+  })
   it('keeps search params not managed by the serializer when fed null', () => {
     const serialize = createSerializer(parsers)
     const result = serialize('?str=foo&external=kept', null)

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -5,8 +5,8 @@ import React, {
   type ReactNode
 } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import { page, userEvent } from 'vitest/browser'
 import { render, renderHook } from 'vitest-browser-react'
+import { page, userEvent } from 'vitest/browser'
 import {
   NullDetector,
   useFakeLoadingState
@@ -112,6 +112,52 @@ describe('useQueryStates', () => {
     expect(result.current[0].b).toBeNull()
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('')
+  })
+  it('accepts undefined for keys to leave them unchanged', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () =>
+      useQueryStates({
+        a: parseAsString,
+        b: parseAsString
+      })
+    const { result, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        searchParams: '?a=init&b=init',
+        onUrlUpdate
+      })
+    })
+    expect(result.current[0].a).toEqual('init')
+    expect(result.current[0].b).toEqual('init')
+    await act(() => result.current[1]({ a: undefined, b: 'changed' }))
+    expect(result.current[0].a).toEqual('init')
+    expect(result.current[0].b).toEqual('changed')
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual(
+      '?a=init&b=changed'
+    )
+  })
+  it('accepts undefined for keys to leave them unchanged (updater function version)', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () =>
+      useQueryStates({
+        a: parseAsString,
+        b: parseAsString
+      })
+    const { result, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        searchParams: '?a=init&b=init',
+        onUrlUpdate
+      })
+    })
+    expect(result.current[0].a).toEqual('init')
+    expect(result.current[0].b).toEqual('init')
+    await act(() => result.current[1](() => ({ a: undefined, b: 'changed' })))
+    expect(result.current[0].a).toEqual('init')
+    expect(result.current[0].b).toEqual('changed')
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual(
+      '?a=init&b=changed'
+    )
   })
 })
 

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -288,7 +288,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       for (let [stateKey, value] of Object.entries(newState)) {
         const parser = keyMap[stateKey]
         const urlKey = resolvedUrlKeys[stateKey]!
-        if (!parser) {
+        if (!parser || value === undefined) {
           continue
         }
         if (


### PR DESCRIPTION
The issue was that we could do this (allowed by the type-level):
```ts
const [, setState] = useQueryStates({ foo: parseAsWhatever })

setState({ foo: undefined })
```

This should have left `foo` as-is in the URL (as is the case for the serializer when given a base: `undefined` values won't affect the base), but instead it was trying to serialise it, causing issues with parsers that expect defined values, or emitting `?foo=undefined` as a string in the URL.

This aligns the behaviour:

- `null`: remove from the URL
- `undefined`: leave as-is
- any other value: set the state to that

One trick to get the correct behaviour before was to only spread values in when they are defined (to avoid iterating on expliticly `undefined` fields):

```ts
setState({ ...(foo ? { foo } : {}) }) // Statements dreamt up by the utterly deranged
```

God I hate JavaScript sometimes..