### PR TITLE
doc: make sure nextjs weekly switches color

### DIFF
--- a/packages/docs/src/app/(pages)/_landing/sponsors.tsx
+++ b/packages/docs/src/app/(pages)/_landing/sponsors.tsx
@@ -149,7 +149,7 @@ export function SponsorsSection() {
         >
           <span
             role="presentation"
-            className="mx-auto block h-[25.5px] w-[270px] bg-white [mask-image:url('https://nextjsweekly.com/logo.svg')] [mask-size:100%] [mask-position:center] [mask-repeat:no-repeat]"
+            className="mx-auto block h-[25.5px] w-[270px] bg-foreground [mask-image:url('https://nextjsweekly.com/logo.svg')] [mask-size:100%] [mask-position:center] [mask-repeat:no-repeat]"
           />
           <span className="sr-only">Next.js Weekly</span>
         </a>


### PR DESCRIPTION
Makes sure the nextjs weekly sponsor looks visible on light and dark mode!

Before:
<img width="766" height="232" alt="image" src="https://github.com/user-attachments/assets/eec67930-dbf7-471b-9fd0-366583283a7c" />

After: 
<img width="677" height="207" alt="image" src="https://github.com/user-attachments/assets/185dddb1-f7a8-4880-93af-a63a6e8184ef" />
