### PR TITLE
doc: change dominik koch founder url to notra

### DIFF
--- a/packages/docs/src/app/(pages)/_landing/sponsors.tsx
+++ b/packages/docs/src/app/(pages)/_landing/sponsors.tsx
@@ -121,7 +121,7 @@ const SPONSORS: Sponsors = [
       <>
         Founder of{' '}
         <a href="https://usenotra.com" className="hover:underline">
-          Marble
+          Notra
         </a>
       </>
     )


### PR DESCRIPTION
As per GDPR compliance all personal information has to be correct, so I changed Dominik Kochs sponsor entry to [Notra](https://usenotra.com) instead of [Marble](https://marblecms.com).