### PR TITLE
doc: update recharts & replace partialLine implementation

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -60,7 +60,7 @@
     "nuqs": "workspace:*",
     "react": "catalog:react19",
     "react-dom": "catalog:react19",
-    "recharts": "3.7.0",
+    "recharts": "3.8.0",
     "remark-smartypants": "^3.0.2",
     "res": "workspace:*",
     "server-only": "^0.0.1",

--- a/packages/docs/src/app/(pages)/stats/_components/partial-line.tsx
+++ b/packages/docs/src/app/(pages)/stats/_components/partial-line.tsx
@@ -1,46 +1,9 @@
 'use client'
 
-import { Line, LineProps, usePlotArea, useYAxisDomain } from 'recharts'
-
-const Y_AXIS_TICK_COUNT = 5
-const Y_AXIS_STEP_COUNT = Y_AXIS_TICK_COUNT * 2
-
-function map(
-  input: number,
-  inMin: number,
-  inMax: number,
-  outMin: number,
-  outMax: number
-) {
-  return ((input - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin
-}
+import { Line, LineProps, usePlotArea, useYAxisScale } from 'recharts'
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
-}
-
-function tickStep(start: number, stop: number, count: number) {
-  const span = Math.abs(stop - start)
-  if (span === 0 || !Number.isFinite(span)) return 0
-  const step0 = span / Math.max(1, count)
-  const power = Math.floor(Math.log10(step0))
-  const error = step0 / Math.pow(10, power)
-  let step = 1
-  if (error >= Math.sqrt(50)) {
-    step = 10
-  } else if (error >= Math.sqrt(10)) {
-    step = 5
-  } else if (error >= Math.sqrt(2)) {
-    step = 2
-  }
-  return step * Math.pow(10, power)
-}
-
-function niceTickMax(min: number, max: number, ticks: number) {
-  if (ticks <= 0) return max
-  const step = tickStep(min, max, ticks)
-  if (step === 0) return max
-  return Math.ceil(max / step) * step
 }
 
 function getMonotoneSlopes(points: Point[]) {
@@ -169,7 +132,6 @@ type UseStrokeDashArrayProps = {
 }
 
 type Point = { x: number; y: number }
-type Tangent = { x: number; y: number }
 
 function getDashArray(solidLength: number, dashedLength: number) {
   const targetDashPattern = [2, 2]
@@ -191,22 +153,19 @@ function useStrokeDashArray({
   padding = {}
 }: UseStrokeDashArrayProps) {
   const area = usePlotArea()
-  const yAxisDomain = useYAxisDomain()
-  if (!partialLast || !area || !yAxisDomain) return undefined
+  const yScale = useYAxisScale()
+  if (!partialLast || !area || !yScale) return undefined
   const p = {
     t: padding.top ?? 0,
     r: padding.right ?? 0,
     b: padding.bottom ?? 0,
     l: padding.left ?? 0
   }
-  const minY = Number(yAxisDomain[0])
-  const maxY = niceTickMax(minY, Number(yAxisDomain[1]), Y_AXIS_STEP_COUNT)
   const stepX = (area.width - (p.l + p.r)) / (data.length - 1)
-  const coordinates = data.map((d, i) => {
-    const x = area.x + p.l + i * stepX
-    const y = map(d, minY, maxY, area.y + area.height, area.y)
-    return { x, y }
-  })
+  const coordinates = data.map((d, i) => ({
+    x: area.x + p.l + i * stepX,
+    y: yScale(d)
+  }))
   const slopes = getMonotoneSlopes(coordinates)
   const { total, last } = getMonotoneLengths(coordinates, slopes)
   const solidLength = total - last
@@ -219,22 +178,19 @@ function useDebugPoints({
   enabled
 }: Pick<UseStrokeDashArrayProps, 'data' | 'padding'> & { enabled: boolean }) {
   const area = usePlotArea()
-  const yAxisDomain = useYAxisDomain()
-  if (!enabled || !area || !yAxisDomain) return null
+  const yScale = useYAxisScale()
+  if (!enabled || !area || !yScale) return null
   const p = {
     t: padding.top ?? 0,
     r: padding.right ?? 0,
     b: padding.bottom ?? 0,
     l: padding.left ?? 0
   }
-  const minY = Number(yAxisDomain[0])
-  const maxY = niceTickMax(minY, Number(yAxisDomain[1]), Y_AXIS_STEP_COUNT)
   const stepX = (area.width - (p.l + p.r)) / (data.length - 1)
-  const points = data.map((d, i) => {
-    const x = area.x + p.l + i * stepX
-    const y = map(d, minY, maxY, area.y + area.height, area.y)
-    return { x, y }
-  })
+  const points = data.map((d, i) => ({
+    x: area.x + p.l + i * stepX,
+    y: yScale(d)
+  }))
   const slopes = getMonotoneSlopes(points)
   return { points, slopes, enabled }
 }

--- a/packages/docs/src/app/(pages)/stats/_components/partial-line.tsx
+++ b/packages/docs/src/app/(pages)/stats/_components/partial-line.tsx
@@ -164,7 +164,7 @@ function useStrokeDashArray({
   const stepX = (area.width - (p.l + p.r)) / (data.length - 1)
   const coordinates = data.map((d, i) => ({
     x: area.x + p.l + i * stepX,
-    y: yScale(d)
+    y: yScale(d) ?? 0
   }))
   const slopes = getMonotoneSlopes(coordinates)
   const { total, last } = getMonotoneLengths(coordinates, slopes)
@@ -189,7 +189,7 @@ function useDebugPoints({
   const stepX = (area.width - (p.l + p.r)) / (data.length - 1)
   const points = data.map((d, i) => ({
     x: area.x + p.l + i * stepX,
-    y: yScale(d)
+    y: yScale(d) ?? 0
   }))
   const slopes = getMonotoneSlopes(points)
   return { points, slopes, enabled }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
         specifier: catalog:react19
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: 3.7.0
-        version: 3.7.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
+        specifier: 3.8.0
+        version: 3.8.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
       remark-smartypants:
         specifier: ^3.0.2
         version: 3.0.2
@@ -7814,8 +7814,8 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
-  recharts@3.7.0:
-    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+  recharts@3.8.0:
+    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -16871,7 +16871,7 @@ snapshots:
     dependencies:
       '@types/use-sync-external-store': 0.0.6
       react: 19.2.4
-      use-sync-external-store: 1.5.0(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.10
       redux: 5.0.1
@@ -17035,7 +17035,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.7.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1):
+  recharts@3.8.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.9.2(react-redux@9.2.0(@types/react@19.2.10)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
       clsx: 2.1.1
@@ -17049,7 +17049,7 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.2.10)(react@19.2.4)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
-      use-sync-external-store: 1.5.0(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.4)
       victory-vendor: 37.3.6
     transitivePeerDependencies:
       - '@types/react'


### PR DESCRIPTION
## Summary

- Bumps `recharts` to 3.8.0 in the docs package
- Replaces the manual Y-axis coordinate math in `PartialLine` with the new `useYAxisScale` hook

## What changed in `partial-line.tsx`

The old implementation re-implemented recharts' internal Y axis scale in userland in order to map data values to pixel coordinates:

- `tickStep()` — re-implemented recharts' tick step algorithm
- `niceTickMax()` — approximated the "nice" Y axis ceiling recharts would render
- `map()` — manually linearly interpolated data values to pixel Y positions

This worked, but was fragile: if recharts changed its tick/domain logic internally, the dashed partial line would drift from where the actual line renders.

`useYAxisScale()` (new in 3.8.0) returns the exact same scale function recharts uses internally, so `yScale(dataValue)` gives the correct pixel Y directly — no approximation needed.

**Net result:** −44 lines, no behaviour change.