### PR TITLE
chore(ci): disable pnpm cache in deployment job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -425,9 +425,10 @@ jobs:
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
         with:
           node-version-file: .node-version
-          cache: pnpm
-      # Note: we do not use an external Turbo cache for publishing
-      # to prevent against possible cache collision attacks.
+          # No pnpm cache restore in CD: a poisoned cache could inject
+          # compromised packages into the published build. Fresh install
+          # from the registry ensures integrity (same rationale as
+          # skipping external Turbo cache below).
       - name: Update npm # Ensure npm 11.5.1 or later is installed for OIDC trusted publishing
         run: npm install -g npm@latest
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Remove `cache: pnpm` from `setup-node` in the CD job to prevent cache poisoning
- A poisoned Actions cache could inject tampered packages into the published build
- Fresh install from registry ensures integrity, matching the existing policy of skipping external Turbo cache during publishing

See: https://grith.ai/blog/clinejection-when-your-ai-tool-installs-another

## Test plan
- [ ] Verify CD job still installs dependencies and publishes successfully without the pnpm cache