### PR TITLE
feat!: add null to return type of serialize()

### DIFF
--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -564,9 +564,11 @@ export function CustomMultiParserDemo() {
         return Object.entries(values)
           .map(([key, value]) => {
             if (!itemParser.serialize) return null
+            const serialized = itemParser.serialize(value)
+            if (serialized === null) return null
             return parseAsKeyValue.serialize({
               key,
-              value: itemParser.serialize(value)
+              value: serialized
             })
           })
           .filter(v => v !== null)

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -3,8 +3,15 @@ import type { Options } from './defs'
 import { safeParse } from './lib/safe-parse'
 
 type Require<T, Keys extends keyof T> = Pick<Required<T>, Keys> & Omit<T, Keys>
+type InferSerializeNullable<P> = P extends {
+  serialize: (...args: any[]) => infer R
+}
+  ? null extends R
+    ? true
+    : false
+  : false
 
-export type SingleParser<T> = {
+export type SingleParser<T, Nullable extends boolean = false> = {
   type?: 'single'
   /**
    * Convert a query string value into a state value.
@@ -17,7 +24,7 @@ export type SingleParser<T> = {
   /**
    * Render the state value into a query string value.
    */
-  serialize?: (value: T) => string
+  serialize?: (value: T) => Nullable extends true ? string | null : string
 
   /**
    * Check if two state values are equal.
@@ -49,7 +56,9 @@ export type Parser<T> = SingleParser<T>
 /** @deprecated use SingleParserBuilder instead */
 export type ParserBuilder<T> = SingleParserBuilder<T>
 
-export type SingleParserBuilder<T> = Required<SingleParser<T>> &
+export type SingleParserBuilder<T, Nullable extends boolean = false> = Required<
+  SingleParser<T, Nullable>
+> &
   Options & {
     /**
      * Set history type, shallow routing and scroll restoration options
@@ -149,7 +158,7 @@ export type MultiParserBuilder<T> = Required<MultiParser<T>> &
  */
 export function createParser<T>(
   parser: Require<SingleParser<T>, 'parse' | 'serialize'>
-): SingleParserBuilder<T> {
+): SingleParserBuilder<T, InferSerializeNullable<typeof parser>> {
   function parseServerSideNullable(value: string | string[] | undefined) {
     if (typeof value === 'undefined') {
       return null
@@ -492,7 +501,7 @@ export function parseAsArrayOf<ItemType>(
       values
         .map<string>(value => {
           const str = itemParser.serialize
-            ? itemParser.serialize(value)
+            ? (itemParser.serialize(value) ?? '')
             : String(value)
           return str.replaceAll(separator, encodedSeparator)
         })

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -100,7 +100,11 @@ export function createSerializer<
         search.delete(urlKey)
       } else {
         const serialized = parser.serialize(value)
-        search = write(serialized, urlKey, search)
+        if (serialized === null) {
+          search.delete(urlKey)
+        } else {
+          search = write(serialized, urlKey, search)
+        }
       }
     }
     if (processUrlSearchParams) {

--- a/packages/nuqs/tests/parsers.test-d.ts
+++ b/packages/nuqs/tests/parsers.test-d.ts
@@ -20,49 +20,49 @@ describe('types/parsers', () => {
   test('parseAsString', () => {
     const p = parseAsString
     assertType<string | null>(p.parse('foo'))
-    assertType<string>(p.serialize('foo'))
+    assertType<string | null>(p.serialize('foo'))
     assertType<string | null>(p.parseServerSide(undefined))
   })
   test('parseAsInteger', () => {
     const p = parseAsInteger
     assertType<number | null>(p.parse('42'))
-    assertType<string>(p.serialize(42))
+    assertType<string | null>(p.serialize(42))
     assertType<number | null>(p.parseServerSide(undefined))
   })
   test('parseAsHex', () => {
     const p = parseAsHex
     assertType<number | null>(p.parse('42'))
-    assertType<string>(p.serialize(42))
+    assertType<string | null>(p.serialize(42))
     assertType<number | null>(p.parseServerSide(undefined))
   })
   test('parseAsFloat', () => {
     const p = parseAsFloat
     assertType<number | null>(p.parse('42'))
-    assertType<string>(p.serialize(42))
+    assertType<string | null>(p.serialize(42))
     assertType<number | null>(p.parseServerSide(undefined))
   })
   test('parseAsBoolean', () => {
     const p = parseAsBoolean
     assertType<boolean | null>(p.parse('true'))
-    assertType<string>(p.serialize(true))
+    assertType<string | null>(p.serialize(true))
     assertType<boolean | null>(p.parseServerSide(undefined))
   })
   test('parseAsTimestamp', () => {
     const p = parseAsTimestamp
     assertType<Date | null>(p.parse('2020-01-01T00:00:00Z'))
-    assertType<string>(p.serialize(new Date()))
+    assertType<string | null>(p.serialize(new Date()))
     assertType<Date | null>(p.parseServerSide(undefined))
   })
   test('parseAsIsoDateTime', () => {
     const p = parseAsIsoDateTime
     assertType<Date | null>(p.parse('2020-01-01T00:00:00Z'))
-    assertType<string>(p.serialize(new Date()))
+    assertType<string | null>(p.serialize(new Date()))
     assertType<Date | null>(p.parseServerSide(undefined))
   })
   test('parseAsIsoDate', () => {
     const p = parseAsIsoDate
     assertType<Date | null>(p.parse('2020-01-01T00:00:00Z'))
-    assertType<string>(p.serialize(new Date()))
+    assertType<string | null>(p.serialize(new Date()))
     assertType<Date | null>(p.parseServerSide(undefined))
   })
   test('parseAsStringEnum', () => {
@@ -72,32 +72,32 @@ describe('types/parsers', () => {
     }
     const p = parseAsStringEnum<Test>(Object.values(Test))
     assertType<Test | null>(p.parse('a'))
-    assertType<string>(p.serialize(Test.A))
+    assertType<string | null>(p.serialize(Test.A))
     assertType<Test | null>(p.parseServerSide(undefined))
   })
   test('parseAsStringLiteral', () => {
     const p = parseAsStringLiteral(['a', 'b'])
     assertType<'a' | 'b' | null>(p.parse('a'))
-    assertType<string>(p.serialize('a'))
+    assertType<string | null>(p.serialize('a'))
     assertType<'a' | 'b' | null>(p.parseServerSide(undefined))
   })
   test('parseAsNumberLiteral', () => {
     const p = parseAsNumberLiteral([1, 2, 3])
     assertType<1 | 2 | 3 | null>(p.parse('42'))
-    assertType<string>(p.serialize(1))
+    assertType<string | null>(p.serialize(1))
     assertType<1 | 2 | 3 | null>(p.parseServerSide(undefined))
   })
   test('parseAsJson returns the return type of the validator', () => {
     type T = { test: string }
     const p = parseAsJson(value => value as T)
     assertType<T | null>(p.parse('foo'))
-    assertType<string>(p.serialize({ test: 'foo' }))
+    assertType<string | null>(p.serialize({ test: 'foo' }))
     assertType<T | null>(p.parseServerSide(undefined))
   })
   test('parseAsArrayOf composes existing item parsers', () => {
     const p = parseAsArrayOf(parseAsInteger)
     assertType<number[] | null>(p.parse('42'))
-    assertType<string>(p.serialize([42]))
+    assertType<string | null>(p.serialize([42]))
     assertType<number[] | null>(p.parseServerSide(undefined))
   })
 


### PR DESCRIPTION
Allow the `serialize()` function to return `null` to support clearing the query parameter, similar to `useQueryState`.

### Background
In `useQueryState`, `null` consistently represents the absence of a query parameter:
- When reading, the returned value is `null` if the key is not present in the URL.
- When writing, passing `null` to the setter removes the key from the query string.

ref: 
- https://nuqs.dev/docs/basic-usage
- https://nuqs.dev/docs/batching#options

### Example

This change enables parsers to conditionally omit values from the URL. For example, a parser could return `null` for certain values to keep 
the URL clean:

```ts
const parser = createParser({
  parse: (value) => parseInt(value),
  serialize: (value) => value === 0 ? null : String(value)
})
```

When 0 is set, the parameter will be cleared from the URL instead of showing ?key=0.
