### PR TITLE
doc: update images alt attributes

### DIFF
--- a/packages/docs/src/app/(pages)/blog/[slug]/_components/author.tsx
+++ b/packages/docs/src/app/(pages)/blog/[slug]/_components/author.tsx
@@ -7,6 +7,7 @@ export function Author() {
     >
       <img
         src="/avatar-128.jpeg"
+        alt="François Best"
         role="presentation"
         className="size-9 rounded-full"
       />

--- a/packages/docs/src/app/registry/[name]/author.tsx
+++ b/packages/docs/src/app/registry/[name]/author.tsx
@@ -12,7 +12,7 @@ export function Author({ author }: { author: string }) {
         <img
           src={`https://github.com/${githubUser}.png`}
           role="presentation"
-          alt=""
+          alt={name}
           className="size-9 rounded-full"
         />
         <div>


### PR DESCRIPTION
## Summary

- Add descriptive `alt` attribute to blog author avatar (`avatar-128.jpeg`) on all `/blog/*` pages
- Use dynamic `alt={name}` for registry author avatars on `/registry/*` pages (was `alt=""`)
- Images keep `role="presentation"` to stay hidden from the a11y tree

Fixes missing alt attributes flagged by Ahrefs SEO audit.

## Test plan
- [x] Verify blog pages render author avatar with `alt="François Best"`
- [x] Verify registry pages render author avatar with dynamic alt text