### PR TITLE
chore: enable pnpm trust policy no-downgrade

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,10 +26,6 @@ catalogs:
 enablePrePostScripts: true
 
 trustPolicy: no-downgrade
-trustPolicyExclude:
-  # chokidar 4.0.3 lost provenance attestation (restored in 5.0.0),
-  # pinned by fumadocs-mdx
-  - chokidar@4.0.3
 
 onlyBuiltDependencies:
   - '@sentry/cli'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,10 @@ catalogs:
 enablePrePostScripts: true
 
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  # chokidar 4.0.3 lost provenance attestation (restored in 5.0.0),
+  # pinned by fumadocs-mdx
+  - chokidar@4.0.3
 
 onlyBuiltDependencies:
   - '@sentry/cli'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,8 @@ catalogs:
 
 enablePrePostScripts: true
 
+trustPolicy: no-downgrade
+
 onlyBuiltDependencies:
   - '@sentry/cli'
   - '@swc/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ catalogs:
 
 enablePrePostScripts: true
 
+trustPolicy: no-downgrade
+
 allowBuilds:
   '@swc/core': true
   '@tailwindcss/oxide': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,10 @@ catalogs:
 enablePrePostScripts: true
 
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  # chokidar 4.0.3 lost provenance attestation (restored in 5.0.0),
+  # pinned by fumadocs-mdx
+  - chokidar@4.0.3
 
 allowBuilds:
   '@swc/core': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,10 +32,6 @@ catalogs:
 enablePrePostScripts: true
 
 trustPolicy: no-downgrade
-trustPolicyExclude:
-  # chokidar 4.0.3 lost provenance attestation (restored in 5.0.0),
-  # pinned by fumadocs-mdx
-  - chokidar@4.0.3
 
 allowBuilds:
   '@swc/core': true


### PR DESCRIPTION
Note: blocked by Fumadocs upgrade, see comment below about chokidar provenance issues.

## Summary

- Adds `trustPolicy: no-downgrade` to `pnpm-workspace.yaml`

This prevents installing packages whose trust level has decreased compared to previous releases. For example, if a package was previously published by a trusted publisher but now only has provenance or no trust evidence, `pnpm install` will fail — catching potential supply chain compromises early.

See: https://pnpm.io/settings#trustpolicy

## Test plan

- [ ] CI passes (setting is purely additive, no lockfile changes)
- [ ] Verify `pnpm install` still works with the policy enabled