### PR TITLE
feat: add Storybook adapter for @storybook/nextjs-vite

### DIFF
--- a/packages/nuqs/adapters/storybook.d.ts
+++ b/packages/nuqs/adapters/storybook.d.ts
@@ -1,0 +1,7 @@
+// This file is needed for projects that have `moduleResolution` set to `node`
+// in their tsconfig.json to be able to `import {} from 'nuqs/adapters/storybook'`.
+// Other module resolutions strategies will look for the `exports` in `package.json`,
+// but with `node`, TypeScript will look for a .d.ts file with that name at the
+// root of the package.
+
+export * from '../dist/adapters/storybook'

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -48,7 +48,8 @@
     "adapters/react-router/v7.d.ts",
     "adapters/tanstack-router.d.ts",
     "adapters/custom.d.ts",
-    "adapters/testing.d.ts"
+    "adapters/testing.d.ts",
+    "adapters/storybook.d.ts"
   ],
   "type": "module",
   "sideEffects": false,
@@ -125,6 +126,11 @@
       "types": "./dist/adapters/testing.d.ts",
       "import": "./dist/adapters/testing.js",
       "default": "./dist/adapters/testing.js"
+    },
+    "./adapters/storybook": {
+      "types": "./dist/adapters/storybook.d.ts",
+      "import": "./dist/adapters/storybook.js",
+      "default": "./dist/adapters/storybook.js"
     }
   },
   "scripts": {

--- a/packages/nuqs/src/adapters/storybook.ts
+++ b/packages/nuqs/src/adapters/storybook.ts
@@ -1,0 +1,112 @@
+import { useSearchParams } from 'next/navigation.js'
+import {
+  createElement,
+  useCallback,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode
+} from 'react'
+import { debug } from '../lib/debug'
+import { resetQueues } from '../lib/queues/reset'
+import { renderQueryString } from './custom'
+import { context, type AdapterProps } from './lib/context'
+import type { AdapterInterface } from './lib/defs'
+import type { OnUrlUpdateFunction } from './testing'
+
+export type { UrlUpdateEvent, OnUrlUpdateFunction } from './testing'
+
+type StorybookAdapterProps = Pick<
+  AdapterInterface,
+  'autoResetQueueOnUpdate'
+> & {
+  /**
+   * A function that will be called whenever the URL is updated.
+   * Connect that to a Storybook action to see URL updates in the actions panel.
+   */
+  onUrlUpdate?: OnUrlUpdateFunction
+
+  /**
+   * Internal: enable throttling.
+   *
+   * @default 0 (no throttling)
+   */
+  rateLimitFactor?: number
+
+  children: ReactNode
+} & AdapterProps
+
+export function NuqsStorybookAdapter({
+  autoResetQueueOnUpdate = true,
+  defaultOptions,
+  processUrlSearchParams,
+  rateLimitFactor = 0,
+  onUrlUpdate,
+  children
+}: StorybookAdapterProps): ReactElement {
+  // Read initial search params from Storybook's mock SearchParamsContext
+  // (provided by @storybook/nextjs-vite's AppRouterProvider)
+  const nextSearchParams = useSearchParams()
+  const initialSearchParams = nextSearchParams.toString()
+  debug('[nuqs storybook] Initial search params: %s', initialSearchParams)
+  const locationSearchRef = useRef(initialSearchParams)
+  resetQueues()
+  const [searchParams, setSearchParams] = useState(
+    () => new URLSearchParams(locationSearchRef.current)
+  )
+  const updateUrl = useCallback<AdapterInterface['updateUrl']>(
+    (search, options) => {
+      const queryString = renderQueryString(search)
+      debug('[nuqs storybook] Updating url: %s', queryString)
+      const searchParams = new URLSearchParams(search)
+      setSearchParams(searchParams)
+      locationSearchRef.current = queryString
+      onUrlUpdate?.({
+        searchParams,
+        queryString,
+        options
+      })
+    },
+    [onUrlUpdate]
+  )
+  const getSearchParamsSnapshot = useCallback(() => {
+    return new URLSearchParams(locationSearchRef.current)
+  }, [initialSearchParams])
+  const useAdapter = (): AdapterInterface => ({
+    searchParams,
+    updateUrl,
+    getSearchParamsSnapshot,
+    rateLimitFactor,
+    autoResetQueueOnUpdate
+  })
+  return createElement(
+    context.Provider,
+    { value: { useAdapter, defaultOptions, processUrlSearchParams } },
+    children
+  )
+}
+
+/**
+ * A Storybook decorator that wraps stories with the NuqsStorybookAdapter.
+ *
+ * The adapter reads initial search params from Storybook's mock router
+ * (configured via story parameters), then manages state internally
+ * so that nuqs updates are reflected in the UI.
+ *
+ * Usage:
+ * ```tsx
+ * // .storybook/preview.tsx
+ * import { withNuqsStorybookAdapter } from 'nuqs/adapters/storybook'
+ *
+ * export const decorators = [withNuqsStorybookAdapter()]
+ * ```
+ */
+export function withNuqsStorybookAdapter(
+  props: Omit<StorybookAdapterProps, 'children'> = {}
+) {
+  return function NuqsStorybookAdapterDecorator(
+    Story: React.ComponentType
+  ): ReactElement {
+    return createElement(NuqsStorybookAdapter, props, createElement(Story))
+  }
+}

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -66,6 +66,10 @@ const exports = `
     "NuqsAdapter": "function",
     "useOptimisticSearchParams": "function",
   },
+  "./adapters/storybook": {
+    "NuqsStorybookAdapter": "function",
+    "withNuqsStorybookAdapter": "function",
+  },
   "./adapters/tanstack-router": {
     "NuqsAdapter": "function",
   },

--- a/packages/nuqs/tsdown.config.ts
+++ b/packages/nuqs/tsdown.config.ts
@@ -38,7 +38,8 @@ const entrypoints = {
     'adapters/react-router/v7': 'src/adapters/react-router/v7.ts',
     'adapters/tanstack-router': 'src/adapters/tanstack-router.ts',
     'adapters/custom': 'src/adapters/custom.ts',
-    'adapters/testing': 'src/adapters/testing.ts'
+    'adapters/testing': 'src/adapters/testing.ts',
+    'adapters/storybook': 'src/adapters/storybook.ts'
   },
   server: {
     server: 'src/index.server.ts',


### PR DESCRIPTION
Add a new `nuqs/adapters/storybook` adapter that works within Storybook's mock Next.js environment. The adapter reads initial search params from Storybook's mock `useSearchParams()` context, then manages state internally so nuqs updates reflect in the UI.

Exports `NuqsStorybookAdapter` component and `withNuqsStorybookAdapter()` decorator factory.