### PR TITLE
doc: add 1771 Technologies as sidebar sponsor

### DIFF
--- a/packages/docs/src/app/(pages)/_landing/sponsors.tsx
+++ b/packages/docs/src/app/(pages)/_landing/sponsors.tsx
@@ -390,6 +390,9 @@ export function AsideSponsors() {
         <li>
           <ShadcnStudioAsideSponsor />
         </li>
+        <li>
+          <LyteNyteGridAsideSponsor />
+        </li>
       </ul>
     </aside>
   )
@@ -423,6 +426,34 @@ export function NextJSWeeklyAsideSponsor() {
         <p className="text-sm">Stay up to date on Next.js</p>
         <p className="text-muted-foreground text-xs">
           A weekly newsletter to keep up with what's happening in the ecosystem.
+        </p>
+      </section>
+    </a>
+  )
+}
+
+export function LyteNyteGridAsideSponsor() {
+  return (
+    <a
+      href="https://1771technologies.com/?utm_source=nuqs&utm_medium=banner&utm_campaign=nuqs"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group"
+    >
+      <section className="text-muted-foreground space-y-4 rounded-md border border-dashed px-4 py-6 transition-colors group-hover:text-current group-active:text-current">
+        <header className="mx-auto flex items-center justify-center gap-2">
+          <img
+            src="https://avatars.githubusercontent.com/u/148620833?s=200&v=4"
+            alt="1771 Technologies"
+            className="size-8 rounded-full grayscale opacity-50 transition-all group-hover:grayscale-0 group-hover:opacity-100 group-active:grayscale-0 group-active:opacity-100"
+            width={32}
+            height={32}
+          />
+          <span className="font-semibold">1771 Technologies</span>
+        </header>
+        <p className="text-muted-foreground text-center text-xs">
+          Ship faster with LyteNyte Grid. The fastest React data grid ever built
+          on the modern web.
         </p>
       </section>
     </a>

--- a/packages/docs/src/app/(pages)/_landing/sponsors.tsx
+++ b/packages/docs/src/app/(pages)/_landing/sponsors.tsx
@@ -385,20 +385,20 @@ export function AsideSponsors() {
       </a>
       <ul className="space-y-2">
         <li>
-          <NextJSWeeklyAsideSponsor />
+          <AsideSponsorNextJSWeekly />
         </li>
         <li>
-          <ShadcnStudioAsideSponsor />
+          <AsideSponsorShadcnStudio />
         </li>
         <li>
-          <LyteNyteGridAsideSponsor />
+          <AsideSponsor1771Technologies />
         </li>
       </ul>
     </aside>
   )
 }
 
-export function NextJSWeeklyAsideSponsor() {
+export function AsideSponsorNextJSWeekly() {
   return (
     <a
       href="https://nextjsweekly.com?utm_source=nuqs&utm_medium=sponsor&utm_campaign=nuqs"
@@ -432,7 +432,7 @@ export function NextJSWeeklyAsideSponsor() {
   )
 }
 
-export function LyteNyteGridAsideSponsor() {
+export function AsideSponsor1771Technologies() {
   return (
     <a
       href="https://1771technologies.com/?utm_source=nuqs&utm_medium=banner&utm_campaign=nuqs"
@@ -460,7 +460,7 @@ export function LyteNyteGridAsideSponsor() {
   )
 }
 
-export function ShadcnStudioAsideSponsor() {
+export function AsideSponsorShadcnStudio() {
   return (
     <a
       href="https://shadcnstudio.com/?utm_source=nuqs&utm_medium=banner&utm_campaign=github"


### PR DESCRIPTION
## Summary
- Adds 1771 Technologies to the docs sidebar sponsor list alongside Next.js Weekly and shadcn/studio
- Reuses their existing URL from the landing page sponsors section
- Logo is grayscale + muted by default, full color on hover (matching the other sidebar sponsors)

## Preview:

Idle:

<img width="586" height="362" alt="CleanShot 2026-04-07 at 22 17 06@2x" src="https://github.com/user-attachments/assets/98e33418-1e93-4b6d-ba64-3e9e4887cab7" />

Hover:
<img width="588" height="362" alt="CleanShot 2026-04-07 at 22 17 37@2x" src="https://github.com/user-attachments/assets/0e1f1dc1-389b-4408-8858-b37522b481b0" />

## Test plan
- [x] Verify the sidebar sponsor renders correctly on docs pages
- [x] Verify hover state shows full-color logo and text