### PR TITLE
chore: harden CI/CD workflow against supply-chain and injection vectors

### DIFF
--- a/.github/workflows/analyse-nextjs-release.yml
+++ b/.github/workflows/analyse-nextjs-release.yml
@@ -34,7 +34,7 @@ jobs:
             console.log(\`Version '\${version}' is valid SemVer\`);
           "
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,7 +81,7 @@ jobs:
         run: pnpm build --filter nuqs
       - name: Run publint on package.json
         run: pnpm publint packages/nuqs
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -154,7 +154,7 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -238,7 +238,7 @@ jobs:
           path: packages/e2e/next/.playwright/*
           name: playwright-next-${{ matrix.next-version }}${{ matrix.base-path && '-basePath' || ''}}${{ matrix.react-compiler && '-react-compiler' || ''}}${{ matrix.cache-components && '-cache-components' || ''}}
           include-hidden-files: true
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -278,7 +278,7 @@ jobs:
           path: packages/e2e/react/.playwright/*
           name: playwright-react-fpn-${{ matrix.full-page-nav-on-shallow-false }}
           include-hidden-files: true
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -319,7 +319,7 @@ jobs:
           path: packages/e2e/react-router/${{ matrix.react-router-version }}/.playwright/*
           name: playwright-react-router-${{ matrix.react-router-version }}
           include-hidden-files: true
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -354,7 +354,7 @@ jobs:
           path: packages/e2e/remix/.playwright/*
           name: playwright-remix
           include-hidden-files: true
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -389,7 +389,7 @@ jobs:
           path: packages/e2e/tanstack-router/.playwright/*
           name: playwright-tanstack-router
           include-hidden-files: true
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -413,7 +413,7 @@ jobs:
       - e2e-remix
       - e2e-tanstack-router
     steps:
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         with:
           status: ${{ job.status }}
           jobName: Continuous Integration

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -489,20 +489,23 @@ jobs:
         if: ${{ github.event_name == 'push' && steps.package-version.outputs.version != '0.0.0-semantically-released' }}
         run: |
           NOTES=$(./release-notes-automation.ts)
-          echo "$NOTES" >> $GITHUB_STEP_SUMMARY
+          echo "$NOTES" >> "$GITHUB_STEP_SUMMARY"
+          # Random delimiter so notes content cannot close the heredoc
+          # early and inject additional output variables.
+          delim="EOF_$(openssl rand -hex 16)"
           {
-            echo 'notes<<EOF'
-            echo "$NOTES"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+            printf 'notes<<%s\n' "$delim"
+            printf '%s\n' "$NOTES"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_OUTPUT"
         working-directory: packages/scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update GitHub release notes
         if: ${{ github.event_name == 'push' && steps.package-version.outputs.version != '0.0.0-semantically-released' }}
-        run: |
-          echo "${{ steps.release-notes.outputs.notes }}" | \
-           gh release edit "v${{ steps.package-version.outputs.version }}" \
-            --notes-file -
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ steps.release-notes.outputs.notes }}
+          VERSION: ${{ steps.package-version.outputs.version }}
+        run: |
+          printf '%s' "$NOTES" | gh release edit "v$VERSION" --notes-file -

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 3 # Diplay chalk colors
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -73,7 +73,7 @@ jobs:
     needs: [ci-core]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -139,7 +139,7 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -211,7 +211,7 @@ jobs:
             react-compiler: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -260,7 +260,7 @@ jobs:
         full-page-nav-on-shallow-false: [false, true]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -302,7 +302,7 @@ jobs:
           - "v7"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -337,7 +337,7 @@ jobs:
     needs: [ci-core]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -372,7 +372,7 @@ jobs:
     needs: [ci-core]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -445,7 +445,7 @@ jobs:
     if: ${{ github.ref_name == 'master' || github.ref_name == 'beta' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           # Node.js pinned via .node-version must ship npm >= 11.5.1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -448,13 +448,17 @@ jobs:
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
+          # Node.js pinned via .node-version must ship npm >= 11.5.1
+          # so that OIDC trusted publishing works (semantic-release ->
+          # npm publish). The bundled npm in current Node satisfies
+          # this; if .node-version is downgraded to a Node release
+          # with older bundled npm, the publish step will fail with
+          # a clear OIDC error and this comment is the breadcrumb.
           node-version-file: .node-version
           # No pnpm cache restore in CD: a poisoned cache could inject
           # compromised packages into the published build. Fresh install
           # from the registry ensures integrity (same rationale as
           # skipping external Turbo cache below).
-      - name: Update npm # Ensure npm 11.5.1 or later is installed for OIDC trusted publishing
-        run: npm install -g npm@latest
       - name: Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs...
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Build package
         run: pnpm build --filter nuqs
       - name: Set package version
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          pnpm pkg set version=0.0.0-preview.${{ github.event.pull_request.head.sha }}
-          echo "::notice title=Install (PR)::pnpm add https://pkg.pr.new/nuqs@${{ github.event.pull_request.number }}"
-          echo "::notice title=Install (SHA)::pnpm add https://pkg.pr.new/nuqs@${{ github.event.pull_request.head.sha }}"
-          echo "::notice title=Version::0.0.0-preview.${{ github.event.pull_request.head.sha }}"
+          pnpm pkg set "version=0.0.0-preview.${HEAD_SHA}"
+          echo "::notice title=Install (PR)::pnpm add https://pkg.pr.new/nuqs@${PR_NUMBER}"
+          echo "::notice title=Install (SHA)::pnpm add https://pkg.pr.new/nuqs@${HEAD_SHA}"
+          echo "::notice title=Version::0.0.0-preview.${HEAD_SHA}"
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
         run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template --packageManager=pnpm --pnpm

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -24,7 +24,7 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install --ignore-scripts --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs...
       - name: Build package
         run: pnpm build --filter nuqs
       - name: Set package version

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -24,7 +24,7 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts --frozen-lockfile
       - name: Build package
         run: pnpm build --filter nuqs
       - name: Set package version

--- a/.github/workflows/pr-base-enforcement.yml
+++ b/.github/workflows/pr-base-enforcement.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   prevent-pr-targetting-master:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -24,38 +24,7 @@ jobs:
       - name: Lint PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          node --input-type=module -e '
-            import { readFileSync, appendFileSync } from "node:fs";
-            const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
-            const types = pkg.commitlint?.rules?.["type-enum"]?.[2];
-            if (!Array.isArray(types) || !types.every((t) => typeof t === "string")) {
-              throw new Error("package.json missing commitlint.rules.type-enum string[]");
-            }
-            // Matches the @commitlint/config-conventional default. Update if
-            // the project ever overrides header-max-length in package.json.
-            const MAX_LEN = 100;
-            const FORMAT = /^([a-z]+)(?:\(([^)]+)\))?(!)?: (.+)$/;
-            const title = process.env.TITLE ?? "";
-            const errors = [];
-            const m = title.match(FORMAT);
-            if (!m) {
-              errors.push("Title does not match `type(scope)?(!)?: subject` format");
-            } else if (!types.includes(m[1])) {
-              errors.push(`Type \`${m[1]}\` is not allowed. Allowed types: ${types.join(", ")}`);
-            }
-            if (title.length > MAX_LEN) {
-              errors.push(`Title exceeds ${MAX_LEN} characters (got ${title.length})`);
-            }
-            const summary = errors.length
-              ? `## ❌ PR Title Lint\n${errors.map((e) => `- ${e}`).join("\n")}\n`
-              : `## ✅ PR Title Lint\n- Valid\n`;
-            appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
-            if (errors.length) {
-              for (const e of errors) console.error(e);
-              process.exit(1);
-            }
-          '
+        run: ./packages/scripts/lint-pr-title.ts
       - name: Get changed files
         id: changed-files
         env:
@@ -68,55 +37,4 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
-        run: |
-          node --input-type=module -e '
-            import { appendFileSync } from "node:fs";
-            const VERSION_BUMPING = ["feat", "fix", "perf", "revert"];
-            const NON_BUMPING = ["build", "chore", "ci", "clean", "doc", "ref", "style", "test"];
-            const m = (process.env.TITLE ?? "").match(/^([a-z]+)/);
-            const type = m?.[1];
-            if (!VERSION_BUMPING.includes(type)) {
-              console.log(`Commit type \`${type}\` does not trigger a version bump. Skipping core package check.`);
-              process.exit(0);
-            }
-            console.log(`Commit type \`${type}\` triggers a version bump. Checking for changes in packages/nuqs...`);
-            const files = (process.env.CHANGED_FILES ?? "").trim().split(" ").filter(Boolean);
-            if (files.some((f) => f.startsWith("packages/nuqs/"))) {
-              appendFileSync(
-                process.env.GITHUB_STEP_SUMMARY,
-                `## ✅ Version Bump Check Passed\n\nCommit type \`${type}\` is valid because the PR includes changes to \`packages/nuqs\`.\n`
-              );
-              process.exit(0);
-            }
-            const summary = [
-              `## ❌ Version Bump Check Failed`,
-              ``,
-              `Your PR title uses the commit type **\`${type}\`** which triggers a version bump, but no changes were found in the core package (\`packages/nuqs\`).`,
-              ``,
-              `### What to do:`,
-              ``,
-              `If this PR does not include changes to the core \`nuqs\` package, please use a non-bumping commit type instead:`,
-              ``,
-              `| Type | Use for |`,
-              `|------|---------|`,
-              `| \`doc\` | Documentation updates |`,
-              `| \`chore\` | Maintenance, CI/CD, dependencies |`,
-              `| \`test\` | Test additions or modifications |`,
-              `| \`ci\` | CI configuration changes |`,
-              `| \`build\` | Build system changes |`,
-              `| \`style\` | Code style/formatting |`,
-              `| \`ref\` | Refactoring (non-core) |`,
-              ``,
-              `### Version-bumping types (require core package changes):`,
-              `- \`feat\` → minor version bump`,
-              `- \`fix\` → patch version bump`,
-              `- \`perf\` → patch version bump`,
-              `- \`revert\` → depends on reverted commit`,
-              ``,
-            ].join("\n");
-            appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
-            console.error(`Error: PR title uses version-bumping type "${type}" but contains no changes in packages/nuqs`);
-            console.error(`Changed files: ${files.join(", ")}`);
-            console.error(`\nPlease use a non-bumping commit type: ${NON_BUMPING.join(", ")}`);
-            process.exit(1);
-          '
+        run: ./packages/scripts/check-version-bump.ts

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -58,7 +58,12 @@ jobs:
           '
       - name: Get changed files
         id: changed-files
-        run: echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
       - name: Check version-bumping commits target core package
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -35,8 +35,14 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          files=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" | tr '\n' ' ')
-          echo "files=$files" >> "$GITHUB_OUTPUT"
+          # NUL-delimited from git, then NUL -> newline for $GITHUB_OUTPUT
+          # transport. Filenames containing whitespace survive the round trip.
+          delim="EOF_$(openssl rand -hex 16)"
+          {
+            printf 'files<<%s\n' "$delim"
+            git diff -z --name-only "$BASE_SHA...$HEAD_SHA" | tr '\0' '\n'
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_OUTPUT"
       - name: Check version-bumping commits target core package
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -18,9 +18,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
+          cache: pnpm
+      - name: Install scripts dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile --filter scripts
       - name: Lint PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -18,32 +18,44 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm add -D @commitlint/load @commitlint/lint @commitlint/parse
       - name: Lint PR title
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          node -e "
-            import loadConfig from '@commitlint/load';
-            import lint from '@commitlint/lint';
-            import pkgJson from './package.json' with { type: 'json' };
-            const config = await loadConfig(pkgJson.commitlint);
-            const result = await lint(process.env.TITLE, config.rules, config.parserPreset ? { parserOpts: config.parserPreset.parserOpts } : {});
-            process.env.GITHUB_STEP_SUMMARY += \`## Linting Result\n- Valid: \${result.valid}\n\`;
-            if (result.valid === false) {
-              for (const { message } of result.errors) {
-                process.env.GITHUB_STEP_SUMMARY += \`- Error: \${message}\n\`;
-                console.error(message);
-              }
+          node --input-type=module -e '
+            import { readFileSync, appendFileSync } from "node:fs";
+            const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
+            const types = pkg.commitlint?.rules?.["type-enum"]?.[2];
+            if (!Array.isArray(types) || !types.every((t) => typeof t === "string")) {
+              throw new Error("package.json missing commitlint.rules.type-enum string[]");
+            }
+            // Matches the @commitlint/config-conventional default. Update if
+            // the project ever overrides header-max-length in package.json.
+            const MAX_LEN = 100;
+            const FORMAT = /^([a-z]+)(?:\(([^)]+)\))?(!)?: (.+)$/;
+            const title = process.env.TITLE ?? "";
+            const errors = [];
+            const m = title.match(FORMAT);
+            if (!m) {
+              errors.push("Title does not match `type(scope)?(!)?: subject` format");
+            } else if (!types.includes(m[1])) {
+              errors.push(`Type \`${m[1]}\` is not allowed. Allowed types: ${types.join(", ")}`);
+            }
+            if (title.length > MAX_LEN) {
+              errors.push(`Title exceeds ${MAX_LEN} characters (got ${title.length})`);
+            }
+            const summary = errors.length
+              ? `## ❌ PR Title Lint\n${errors.map((e) => `- ${e}`).join("\n")}\n`
+              : `## ✅ PR Title Lint\n- Valid\n`;
+            appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+            if (errors.length) {
+              for (const e of errors) console.error(e);
               process.exit(1);
             }
-          "
+          '
       - name: Get changed files
         id: changed-files
         run: echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
@@ -52,61 +64,54 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
         run: |
-          node -e "
-            import parse from '@commitlint/parse';
-            import { appendFile } from 'node:fs/promises';
-
-            // Commit types that trigger version bumps (semantic-release defaults)
-            const VERSION_BUMPING_TYPES = ['feat', 'fix', 'perf', 'revert'];
-            // Non-bumping types for reference in error messages
-            const NON_BUMPING_TYPES = ['build', 'chore', 'ci', 'clean', 'doc', 'ref', 'style', 'test'];
-
-            const parsed = await parse(process.env.TITLE);
-            const commitType = parsed.type;
-
-            if (!VERSION_BUMPING_TYPES.includes(commitType)) {
-              console.log(\`Commit type '\${commitType}' does not trigger a version bump. Skipping core package check.\`);
+          node --input-type=module -e '
+            import { appendFileSync } from "node:fs";
+            const VERSION_BUMPING = ["feat", "fix", "perf", "revert"];
+            const NON_BUMPING = ["build", "chore", "ci", "clean", "doc", "ref", "style", "test"];
+            const m = (process.env.TITLE ?? "").match(/^([a-z]+)/);
+            const type = m?.[1];
+            if (!VERSION_BUMPING.includes(type)) {
+              console.log(`Commit type \`${type}\` does not trigger a version bump. Skipping core package check.`);
               process.exit(0);
             }
-
-            console.log(\`Commit type '\${commitType}' triggers a version bump. Checking for changes in packages/nuqs...\`);
-
-            const changedFiles = process.env.CHANGED_FILES.trim().split(' ').filter(Boolean);
-            const hasCoreChanges = changedFiles.some(file => file.startsWith('packages/nuqs/'));
-
-            if (!hasCoreChanges) {
-              const summary = \`## ❌ Version Bump Check Failed
-
-            Your PR title uses the commit type **\\\`\${commitType}\\\`** which triggers a version bump, but no changes were found in the core package (\\\`packages/nuqs\\\`).
-
-            ### What to do:
-
-            If this PR does not include changes to the core \\\`nuqs\\\` package, please use a non-bumping commit type instead:
-
-            | Type | Use for |
-            |------|---------|
-            | \\\`doc\\\` | Documentation updates |
-            | \\\`chore\\\` | Maintenance, CI/CD, dependencies |
-            | \\\`test\\\` | Test additions or modifications |
-            | \\\`ci\\\` | CI configuration changes |
-            | \\\`build\\\` | Build system changes |
-            | \\\`style\\\` | Code style/formatting |
-            | \\\`ref\\\` | Refactoring (non-core) |
-
-            ### Version-bumping types (require core package changes):
-            - \\\`feat\\\` → minor version bump
-            - \\\`fix\\\` → patch version bump
-            - \\\`perf\\\` → patch version bump
-            - \\\`revert\\\` → depends on reverted commit
-            \`;
-
-              await appendFile(process.env.GITHUB_STEP_SUMMARY, summary);
-              console.error(\`Error: PR title uses version-bumping type '\${commitType}' but contains no changes in packages/nuqs\`);
-              console.error(\`Changed files: \${changedFiles.join(', ')}\`);
-              console.error(\`\nPlease use a non-bumping commit type: \${NON_BUMPING_TYPES.join(', ')}\`);
-              process.exit(1);
+            console.log(`Commit type \`${type}\` triggers a version bump. Checking for changes in packages/nuqs...`);
+            const files = (process.env.CHANGED_FILES ?? "").trim().split(" ").filter(Boolean);
+            if (files.some((f) => f.startsWith("packages/nuqs/"))) {
+              appendFileSync(
+                process.env.GITHUB_STEP_SUMMARY,
+                `## ✅ Version Bump Check Passed\n\nCommit type \`${type}\` is valid because the PR includes changes to \`packages/nuqs\`.\n`
+              );
+              process.exit(0);
             }
-
-            console.log('✓ Version-bumping commit type is valid: core package has changes.');
-            await appendFile(process.env.GITHUB_STEP_SUMMARY, \`## ✅ Version Bump Check Passed\n\nCommit type \\\`\${commitType}\\\` is valid because the PR includes changes to \\\`packages/nuqs\\\`.\n\`);
-          "
+            const summary = [
+              `## ❌ Version Bump Check Failed`,
+              ``,
+              `Your PR title uses the commit type **\`${type}\`** which triggers a version bump, but no changes were found in the core package (\`packages/nuqs\`).`,
+              ``,
+              `### What to do:`,
+              ``,
+              `If this PR does not include changes to the core \`nuqs\` package, please use a non-bumping commit type instead:`,
+              ``,
+              `| Type | Use for |`,
+              `|------|---------|`,
+              `| \`doc\` | Documentation updates |`,
+              `| \`chore\` | Maintenance, CI/CD, dependencies |`,
+              `| \`test\` | Test additions or modifications |`,
+              `| \`ci\` | CI configuration changes |`,
+              `| \`build\` | Build system changes |`,
+              `| \`style\` | Code style/formatting |`,
+              `| \`ref\` | Refactoring (non-core) |`,
+              ``,
+              `### Version-bumping types (require core package changes):`,
+              `- \`feat\` → minor version bump`,
+              `- \`fix\` → patch version bump`,
+              `- \`perf\` → patch version bump`,
+              `- \`revert\` → depends on reverted commit`,
+              ``,
+            ].join("\n");
+            appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+            console.error(`Error: PR title uses version-bumping type "${type}" but contains no changes in packages/nuqs`);
+            console.error(`Changed files: ${files.join(", ")}`);
+            console.error(`\nPlease use a non-bumping commit type: ${NON_BUMPING.join(", ")}`);
+            process.exit(1);
+          '

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   lint-pr-title:
     name: Lint PR Title

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -42,7 +42,7 @@ jobs:
             console.log(\`Version '\${version}' is valid SemVer\`);
           "
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
@@ -91,7 +91,7 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -70,7 +70,7 @@ jobs:
           path: packages/e2e/next/.playwright/*
           name: playwright-next-${{ env.VERSION }}${{ matrix.base-path && '-basePath' || ''}}${{ matrix.react-compiler && '-react-compiler' || ''}}${{ matrix.cache-components && '-cache-components' || ''}}
           include-hidden-files: true
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -107,7 +107,7 @@ jobs:
         run: pnpm run build --filter docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         name: Notify on Slack
         if: failure()
         with:
@@ -135,7 +135,7 @@ jobs:
       - docs
     if: ${{ needs.test_against_nextjs_release.result == 'success' && (needs.docs.result == 'success' || needs.docs.result == 'skipped') }}
     steps:
-      - uses: 47ng/actions-slack-notify@main
+      - uses: 47ng/actions-slack-notify@0917ccc17666d2ca5eb8b8a1afced5048da8c8b5 # 1.0.2
         with:
           status: ${{ job.status }}
           jobName: "${{ env.VERSION }}"

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 3 # Diplay chalk colors
   VERSION: ${{ inputs.version }}

--- a/packages/scripts/check-version-bump.test.ts
+++ b/packages/scripts/check-version-bump.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractType,
+  formatFailSummary,
+  formatPassSummary,
+  hasCoreChanges,
+  isVersionBumping,
+  parseChangedFiles
+} from './check-version-bump'
+
+describe('extractType', () => {
+  it('extracts type from "feat: subject"', () => {
+    expect(extractType('feat: subject')).toBe('feat')
+  })
+
+  it('extracts type from "fix(scope): subject"', () => {
+    expect(extractType('fix(scope): subject')).toBe('fix')
+  })
+
+  it('returns undefined for empty title', () => {
+    expect(extractType('')).toBeUndefined()
+  })
+
+  it('returns undefined for non-letter prefix', () => {
+    expect(extractType('123 something')).toBeUndefined()
+  })
+})
+
+describe('isVersionBumping', () => {
+  it('returns true for bumping types', () => {
+    for (const t of ['feat', 'fix', 'perf', 'revert']) {
+      expect(isVersionBumping(t)).toBe(true)
+    }
+  })
+
+  it('returns false for non-bumping types', () => {
+    for (const t of ['chore', 'doc', 'ci', 'build', 'style']) {
+      expect(isVersionBumping(t)).toBe(false)
+    }
+  })
+
+  it('returns false for undefined', () => {
+    expect(isVersionBumping(undefined)).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isVersionBumping('')).toBe(false)
+  })
+})
+
+describe('hasCoreChanges', () => {
+  it('returns true when any file is under packages/nuqs/', () => {
+    expect(
+      hasCoreChanges(['docs/intro.md', 'packages/nuqs/src/index.ts'])
+    ).toBe(true)
+  })
+
+  it('returns false when no file is under packages/nuqs/', () => {
+    expect(hasCoreChanges(['docs/intro.md', 'README.md'])).toBe(false)
+  })
+
+  it('returns false for empty list', () => {
+    expect(hasCoreChanges([])).toBe(false)
+  })
+
+  it('does not match similarly-prefixed paths', () => {
+    expect(hasCoreChanges(['packages/nuqs-other/file.ts'])).toBe(false)
+  })
+})
+
+describe('parseChangedFiles', () => {
+  it('splits space-separated entries and trims', () => {
+    expect(parseChangedFiles('  a.ts b.ts  c.ts ')).toEqual([
+      'a.ts',
+      'b.ts',
+      'c.ts'
+    ])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseChangedFiles('')).toEqual([])
+    expect(parseChangedFiles('   ')).toEqual([])
+  })
+})
+
+describe('formatPassSummary', () => {
+  it('mentions the type and the core package', () => {
+    const out = formatPassSummary('feat')
+    expect(out).toContain('feat')
+    expect(out).toContain('packages/nuqs')
+    expect(out).toContain('✅')
+  })
+})
+
+describe('formatFailSummary', () => {
+  it('mentions the type and the non-bumping alternatives', () => {
+    const out = formatFailSummary('feat')
+    expect(out).toContain('feat')
+    expect(out).toContain('chore')
+    expect(out).toContain('Use for')
+    expect(out).toContain('❌')
+  })
+})

--- a/packages/scripts/check-version-bump.test.ts
+++ b/packages/scripts/check-version-bump.test.ts
@@ -69,12 +69,26 @@ describe('hasCoreChanges', () => {
 })
 
 describe('parseChangedFiles', () => {
-  it('splits space-separated entries and trims', () => {
-    expect(parseChangedFiles('  a.ts b.ts  c.ts ')).toEqual([
+  it('splits newline-separated entries and trims', () => {
+    expect(parseChangedFiles('a.ts\nb.ts\nc.ts')).toEqual([
       'a.ts',
       'b.ts',
       'c.ts'
     ])
+  })
+
+  it('preserves filenames containing spaces', () => {
+    expect(
+      parseChangedFiles('packages/nuqs/src/My Component.ts\ndocs/README.md')
+    ).toEqual(['packages/nuqs/src/My Component.ts', 'docs/README.md'])
+  })
+
+  it('tolerates a trailing newline', () => {
+    expect(parseChangedFiles('a.ts\nb.ts\n')).toEqual(['a.ts', 'b.ts'])
+  })
+
+  it('drops blank lines', () => {
+    expect(parseChangedFiles('a.ts\n\nb.ts')).toEqual(['a.ts', 'b.ts'])
   })
 
   it('returns empty array for empty input', () => {

--- a/packages/scripts/check-version-bump.ts
+++ b/packages/scripts/check-version-bump.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from 'node:fs'
+
+export const BUMPING_TYPES = ['feat', 'fix', 'perf', 'revert'] as const
+export const NON_BUMPING_TYPES = [
+  'build',
+  'chore',
+  'ci',
+  'clean',
+  'doc',
+  'ref',
+  'style',
+  'test'
+] as const
+
+export const CORE_PACKAGE_PREFIX = 'packages/nuqs/'
+
+export function extractType(title: string): string | undefined {
+  return title.match(/^([a-z]+)/)?.[1]
+}
+
+export function isVersionBumping(type: string | undefined): boolean {
+  if (!type) return false
+  return (BUMPING_TYPES as readonly string[]).includes(type)
+}
+
+export function hasCoreChanges(files: string[]): boolean {
+  return files.some(f => f.startsWith(CORE_PACKAGE_PREFIX))
+}
+
+export function parseChangedFiles(raw: string): string[] {
+  return raw.trim().split(' ').filter(Boolean)
+}
+
+export function formatPassSummary(type: string): string {
+  const corePath = CORE_PACKAGE_PREFIX.replace(/\/$/, '')
+  return `## ✅ Version Bump Check Passed\n\nCommit type \`${type}\` is valid because the PR includes changes to \`${corePath}\`.\n`
+}
+
+export function formatFailSummary(type: string): string {
+  const corePath = CORE_PACKAGE_PREFIX.replace(/\/$/, '')
+  return [
+    `## ❌ Version Bump Check Failed`,
+    ``,
+    `Your PR title uses the commit type **\`${type}\`** which triggers a version bump, but no changes were found in the core package (\`${corePath}\`).`,
+    ``,
+    `### What to do:`,
+    ``,
+    `If this PR does not include changes to the core \`nuqs\` package, please use a non-bumping commit type instead:`,
+    ``,
+    `| Type | Use for |`,
+    `|------|---------|`,
+    `| \`doc\` | Documentation updates |`,
+    `| \`chore\` | Maintenance, CI/CD, dependencies |`,
+    `| \`test\` | Test additions or modifications |`,
+    `| \`ci\` | CI configuration changes |`,
+    `| \`build\` | Build system changes |`,
+    `| \`style\` | Code style/formatting |`,
+    `| \`ref\` | Refactoring (non-core) |`,
+    ``,
+    `### Version-bumping types (require core package changes):`,
+    `- \`feat\` → minor version bump`,
+    `- \`fix\` → patch version bump`,
+    `- \`perf\` → patch version bump`,
+    `- \`revert\` → depends on reverted commit`,
+    ``
+  ].join('\n')
+}
+
+function main(): void {
+  const title = process.env.TITLE ?? ''
+  const changedRaw = process.env.CHANGED_FILES ?? ''
+  const type = extractType(title)
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY
+
+  if (!isVersionBumping(type)) {
+    console.log(
+      `Commit type \`${type ?? '(none)'}\` does not trigger a version bump. Skipping core package check.`
+    )
+    process.exit(0)
+  }
+
+  console.log(
+    `Commit type \`${type}\` triggers a version bump. Checking for changes in ${CORE_PACKAGE_PREFIX}...`
+  )
+
+  const files = parseChangedFiles(changedRaw)
+  if (hasCoreChanges(files)) {
+    if (summaryFile) {
+      appendFileSync(summaryFile, formatPassSummary(type!))
+    }
+    process.exit(0)
+  }
+
+  if (summaryFile) {
+    appendFileSync(summaryFile, formatFailSummary(type!))
+  }
+  console.error(
+    `Error: PR title uses version-bumping type "${type}" but contains no changes in ${CORE_PACKAGE_PREFIX}`
+  )
+  console.error(`Changed files: ${files.join(', ')}`)
+  console.error(
+    `\nPlease use a non-bumping commit type: ${NON_BUMPING_TYPES.join(', ')}`
+  )
+  process.exit(1)
+}
+
+const isMainModule =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('check-version-bump.ts')
+
+if (isMainModule) {
+  main()
+}

--- a/packages/scripts/check-version-bump.ts
+++ b/packages/scripts/check-version-bump.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { appendFileSync } from 'node:fs'
+import { createEnv } from '@t3-oss/env-core'
+import { z } from 'zod'
 
 export const BUMPING_TYPES = ['feat', 'fix', 'perf', 'revert'] as const
 export const NON_BUMPING_TYPES = [
@@ -74,10 +76,16 @@ export function formatFailSummary(type: string): string {
 }
 
 function main(): void {
-  const title = process.env.TITLE ?? ''
-  const changedRaw = process.env.CHANGED_FILES ?? ''
-  const type = extractType(title)
-  const summaryFile = process.env.GITHUB_STEP_SUMMARY
+  const env = createEnv({
+    server: {
+      TITLE: z.string(),
+      CHANGED_FILES: z.string().default(''),
+      GITHUB_STEP_SUMMARY: z.string().optional()
+    },
+    isServer: true,
+    runtimeEnv: process.env
+  })
+  const type = extractType(env.TITLE)
 
   if (!isVersionBumping(type)) {
     console.log(
@@ -90,16 +98,16 @@ function main(): void {
     `Commit type \`${type}\` triggers a version bump. Checking for changes in ${CORE_PACKAGE_PREFIX}...`
   )
 
-  const files = parseChangedFiles(changedRaw)
+  const files = parseChangedFiles(env.CHANGED_FILES)
   if (hasCoreChanges(files)) {
-    if (summaryFile) {
-      appendFileSync(summaryFile, formatPassSummary(type))
+    if (env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(env.GITHUB_STEP_SUMMARY, formatPassSummary(type))
     }
     process.exit(0)
   }
 
-  if (summaryFile) {
-    appendFileSync(summaryFile, formatFailSummary(type))
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(env.GITHUB_STEP_SUMMARY, formatFailSummary(type))
   }
   console.error(
     `Error: PR title uses version-bumping type "${type}" but contains no changes in ${CORE_PACKAGE_PREFIX}`

--- a/packages/scripts/check-version-bump.ts
+++ b/packages/scripts/check-version-bump.ts
@@ -37,7 +37,14 @@ export function hasCoreChanges(files: string[]): boolean {
 }
 
 export function parseChangedFiles(raw: string): string[] {
-  return raw.trim().split(' ').filter(Boolean)
+  // The workflow emits one filename per line (NUL-delimited from git, then
+  // converted to newlines for $GITHUB_OUTPUT). Newlines are not legal in
+  // filenames on the filesystems we care about, so splitting on '\n' is the
+  // unambiguous choice and survives whitespace-in-filenames.
+  return raw
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
 }
 
 export function formatPassSummary(type: string): string {

--- a/packages/scripts/check-version-bump.ts
+++ b/packages/scripts/check-version-bump.ts
@@ -14,15 +14,20 @@ export const NON_BUMPING_TYPES = [
   'test'
 ] as const
 
+export type BumpingType = (typeof BUMPING_TYPES)[number]
+
 export const CORE_PACKAGE_PREFIX = 'packages/nuqs/'
 
 export function extractType(title: string): string | undefined {
   return title.match(/^([a-z]+)/)?.[1]
 }
 
-export function isVersionBumping(type: string | undefined): boolean {
-  if (!type) return false
-  return (BUMPING_TYPES as readonly string[]).includes(type)
+export function isVersionBumping(
+  type: string | undefined
+): type is BumpingType {
+  return (
+    type !== undefined && (BUMPING_TYPES as readonly string[]).includes(type)
+  )
 }
 
 export function hasCoreChanges(files: string[]): boolean {
@@ -88,13 +93,13 @@ function main(): void {
   const files = parseChangedFiles(changedRaw)
   if (hasCoreChanges(files)) {
     if (summaryFile) {
-      appendFileSync(summaryFile, formatPassSummary(type!))
+      appendFileSync(summaryFile, formatPassSummary(type))
     }
     process.exit(0)
   }
 
   if (summaryFile) {
-    appendFileSync(summaryFile, formatFailSummary(type!))
+    appendFileSync(summaryFile, formatFailSummary(type))
   }
   console.error(
     `Error: PR title uses version-bumping type "${type}" but contains no changes in ${CORE_PACKAGE_PREFIX}`

--- a/packages/scripts/lint-pr-title.test.ts
+++ b/packages/scripts/lint-pr-title.test.ts
@@ -46,6 +46,11 @@ describe('parseTitle', () => {
   it('returns null for non-letter prefix', () => {
     expect(parseTitle('123: subject')).toBeNull()
   })
+
+  it('returns null for an uppercase type prefix', () => {
+    expect(parseTitle('Feat: add parser')).toBeNull()
+    expect(parseTitle('FIX: bug')).toBeNull()
+  })
 })
 
 describe('readTypeEnum', () => {
@@ -101,6 +106,21 @@ describe('validateTitle', () => {
     const longSubject = 'feat: ' + 'x'.repeat(HEADER_MAX_LENGTH)
     const errors = validateTitle(longSubject, allowed)
     expect(errors.some(e => /exceeds.*characters/.test(e))).toBe(true)
+  })
+
+  it('accepts a title at exactly the max length', () => {
+    const prefix = 'feat: '
+    const title = prefix + 'x'.repeat(HEADER_MAX_LENGTH - prefix.length)
+    expect(title.length).toBe(HEADER_MAX_LENGTH)
+    expect(validateTitle(title, allowed)).toEqual([])
+  })
+
+  it('flags a title one character over the max length', () => {
+    const prefix = 'feat: '
+    const title = prefix + 'x'.repeat(HEADER_MAX_LENGTH - prefix.length + 1)
+    expect(title.length).toBe(HEADER_MAX_LENGTH + 1)
+    const errors = validateTitle(title, allowed)
+    expect(errors.some(e => /exceeds/.test(e))).toBe(true)
   })
 
   it('reports format and length errors together', () => {

--- a/packages/scripts/lint-pr-title.test.ts
+++ b/packages/scripts/lint-pr-title.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatSummary,
+  HEADER_MAX_LENGTH,
+  parseTitle,
+  readTypeEnum,
+  validateTitle
+} from './lint-pr-title'
+
+describe('parseTitle', () => {
+  it('parses simple type and subject', () => {
+    expect(parseTitle('feat: add parser')).toEqual({
+      type: 'feat',
+      scope: undefined,
+      breaking: false,
+      subject: 'add parser'
+    })
+  })
+
+  it('parses type with scope', () => {
+    expect(parseTitle('fix(parser): handle null')).toEqual({
+      type: 'fix',
+      scope: 'parser',
+      breaking: false,
+      subject: 'handle null'
+    })
+  })
+
+  it('parses breaking marker', () => {
+    expect(parseTitle('feat(parser)!: drop legacy adapter')).toEqual({
+      type: 'feat',
+      scope: 'parser',
+      breaking: true,
+      subject: 'drop legacy adapter'
+    })
+  })
+
+  it('returns null for missing colon', () => {
+    expect(parseTitle('no colon here')).toBeNull()
+  })
+
+  it('returns null for empty title', () => {
+    expect(parseTitle('')).toBeNull()
+  })
+
+  it('returns null for non-letter prefix', () => {
+    expect(parseTitle('123: subject')).toBeNull()
+  })
+})
+
+describe('readTypeEnum', () => {
+  it('extracts the third element of type-enum', () => {
+    const json = JSON.stringify({
+      commitlint: {
+        rules: { 'type-enum': [2, 'always', ['feat', 'fix']] }
+      }
+    })
+    expect(readTypeEnum(json)).toEqual(['feat', 'fix'])
+  })
+
+  it('throws when commitlint config is missing', () => {
+    expect(() => readTypeEnum('{}')).toThrow(
+      /missing commitlint.rules.type-enum/
+    )
+  })
+
+  it('throws when type-enum is not a string array', () => {
+    const json = JSON.stringify({
+      commitlint: { rules: { 'type-enum': [2, 'always', [1, 2]] } }
+    })
+    expect(() => readTypeEnum(json)).toThrow()
+  })
+
+  it('throws when type-enum is missing the third element', () => {
+    const json = JSON.stringify({
+      commitlint: { rules: { 'type-enum': [2, 'always'] } }
+    })
+    expect(() => readTypeEnum(json)).toThrow()
+  })
+})
+
+describe('validateTitle', () => {
+  const allowed = ['feat', 'fix', 'chore']
+
+  it('returns no errors for a valid title', () => {
+    expect(validateTitle('feat: add parser', allowed)).toEqual([])
+  })
+
+  it('flags disallowed type', () => {
+    const errors = validateTitle('wip: experiment', allowed)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/wip.*not allowed/)
+  })
+
+  it('flags missing colon (format)', () => {
+    const errors = validateTitle('no colon here', allowed)
+    expect(errors[0]).toMatch(/format/)
+  })
+
+  it('flags titles over the max length', () => {
+    const longSubject = 'feat: ' + 'x'.repeat(HEADER_MAX_LENGTH)
+    const errors = validateTitle(longSubject, allowed)
+    expect(errors.some(e => /exceeds.*characters/.test(e))).toBe(true)
+  })
+
+  it('reports format and length errors together', () => {
+    const errors = validateTitle('x'.repeat(150), allowed)
+    expect(errors).toHaveLength(2)
+  })
+})
+
+describe('formatSummary', () => {
+  it('returns valid section for empty errors', () => {
+    const out = formatSummary([])
+    expect(out).toContain('✅')
+    expect(out).toContain('Valid')
+  })
+
+  it('lists all errors as bullet items', () => {
+    const out = formatSummary(['err one', 'err two'])
+    expect(out).toContain('❌')
+    expect(out).toContain('- err one')
+    expect(out).toContain('- err two')
+  })
+})

--- a/packages/scripts/lint-pr-title.ts
+++ b/packages/scripts/lint-pr-title.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from 'node:fs'
+
+// Matches the @commitlint/config-conventional default. If the project ever
+// overrides header-max-length in package.json, update this constant.
+export const HEADER_MAX_LENGTH = 100
+
+const TITLE_FORMAT = /^([a-z]+)(?:\(([^)]+)\))?(!)?: (.+)$/
+
+export type ParsedTitle = {
+  type: string
+  scope: string | undefined
+  breaking: boolean
+  subject: string
+}
+
+export function parseTitle(title: string): ParsedTitle | null {
+  const m = title.match(TITLE_FORMAT)
+  if (!m || !m[1] || !m[4]) return null
+  return {
+    type: m[1],
+    scope: m[2],
+    breaking: m[3] === '!',
+    subject: m[4]
+  }
+}
+
+export function readTypeEnum(packageJsonContents: string): string[] {
+  const pkg: unknown = JSON.parse(packageJsonContents)
+  const types =
+    typeof pkg === 'object' && pkg !== null
+      ? (pkg as Record<string, unknown>).commitlint
+      : undefined
+  const rules =
+    typeof types === 'object' && types !== null
+      ? (types as Record<string, unknown>).rules
+      : undefined
+  const typeEnum =
+    typeof rules === 'object' && rules !== null
+      ? (rules as Record<string, unknown>)['type-enum']
+      : undefined
+  const value = Array.isArray(typeEnum) ? typeEnum[2] : undefined
+  if (
+    !Array.isArray(value) ||
+    !value.every((t: unknown) => typeof t === 'string')
+  ) {
+    throw new Error(
+      'package.json missing commitlint.rules.type-enum string[]'
+    )
+  }
+  return value as string[]
+}
+
+export function validateTitle(
+  title: string,
+  allowedTypes: string[],
+  maxLen: number = HEADER_MAX_LENGTH
+): string[] {
+  const errors: string[] = []
+  const parsed = parseTitle(title)
+  if (!parsed) {
+    errors.push('Title does not match `type(scope)?(!)?: subject` format')
+  } else if (!allowedTypes.includes(parsed.type)) {
+    errors.push(
+      `Type \`${parsed.type}\` is not allowed. Allowed types: ${allowedTypes.join(', ')}`
+    )
+  }
+  if (title.length > maxLen) {
+    errors.push(`Title exceeds ${maxLen} characters (got ${title.length})`)
+  }
+  return errors
+}
+
+export function formatSummary(errors: string[]): string {
+  if (errors.length === 0) {
+    return '## ✅ PR Title Lint\n- Valid\n'
+  }
+  return `## ❌ PR Title Lint\n${errors.map(e => `- ${e}`).join('\n')}\n`
+}
+
+function main(): void {
+  const title = process.env.TITLE ?? ''
+  const types = readTypeEnum(readFileSync('./package.json', 'utf8'))
+  const errors = validateTitle(title, types)
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY
+  if (summaryFile) {
+    appendFileSync(summaryFile, formatSummary(errors))
+  }
+  if (errors.length > 0) {
+    for (const e of errors) console.error(e)
+    process.exit(1)
+  }
+}
+
+const isMainModule =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('lint-pr-title.ts')
+
+if (isMainModule) {
+  main()
+}

--- a/packages/scripts/lint-pr-title.ts
+++ b/packages/scripts/lint-pr-title.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { appendFileSync, readFileSync } from 'node:fs'
+import { z } from 'zod'
 
 // Matches the @commitlint/config-conventional default. If the project ever
 // overrides header-max-length in package.json, update this constant.
@@ -26,28 +27,23 @@ export function parseTitle(title: string): ParsedTitle | null {
   }
 }
 
+// Validates only the subset of package.json we care about. The third tuple
+// element is the rule's value per @commitlint/types — the first two slots
+// (severity, applicable) are intentionally unconstrained here.
+const PackageJsonSchema = z.object({
+  commitlint: z.object({
+    rules: z.object({
+      'type-enum': z.tuple([z.unknown(), z.unknown(), z.array(z.string())])
+    })
+  })
+})
+
 export function readTypeEnum(packageJsonContents: string): string[] {
-  const pkg: unknown = JSON.parse(packageJsonContents)
-  const types =
-    typeof pkg === 'object' && pkg !== null
-      ? (pkg as Record<string, unknown>).commitlint
-      : undefined
-  const rules =
-    typeof types === 'object' && types !== null
-      ? (types as Record<string, unknown>).rules
-      : undefined
-  const typeEnum =
-    typeof rules === 'object' && rules !== null
-      ? (rules as Record<string, unknown>)['type-enum']
-      : undefined
-  const value = Array.isArray(typeEnum) ? typeEnum[2] : undefined
-  if (
-    !Array.isArray(value) ||
-    !value.every((t: unknown) => typeof t === 'string')
-  ) {
+  const parsed = PackageJsonSchema.safeParse(JSON.parse(packageJsonContents))
+  if (!parsed.success) {
     throw new Error('package.json missing commitlint.rules.type-enum string[]')
   }
-  return value as string[]
+  return parsed.data.commitlint.rules['type-enum'][2]
 }
 
 export function validateTitle(

--- a/packages/scripts/lint-pr-title.ts
+++ b/packages/scripts/lint-pr-title.ts
@@ -45,9 +45,7 @@ export function readTypeEnum(packageJsonContents: string): string[] {
     !Array.isArray(value) ||
     !value.every((t: unknown) => typeof t === 'string')
   ) {
-    throw new Error(
-      'package.json missing commitlint.rules.type-enum string[]'
-    )
+    throw new Error('package.json missing commitlint.rules.type-enum string[]')
   }
   return value as string[]
 }

--- a/packages/scripts/lint-pr-title.ts
+++ b/packages/scripts/lint-pr-title.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { appendFileSync, readFileSync } from 'node:fs'
+import { createEnv } from '@t3-oss/env-core'
 import { z } from 'zod'
 
 // Matches the @commitlint/config-conventional default. If the project ever
@@ -30,7 +31,7 @@ export function parseTitle(title: string): ParsedTitle | null {
 // Validates only the subset of package.json we care about. The third tuple
 // element is the rule's value per @commitlint/types — the first two slots
 // (severity, applicable) are intentionally unconstrained here.
-const PackageJsonSchema = z.object({
+const packageJsonSchema = z.object({
   commitlint: z.object({
     rules: z.object({
       'type-enum': z.tuple([z.unknown(), z.unknown(), z.array(z.string())])
@@ -39,7 +40,7 @@ const PackageJsonSchema = z.object({
 })
 
 export function readTypeEnum(packageJsonContents: string): string[] {
-  const parsed = PackageJsonSchema.safeParse(JSON.parse(packageJsonContents))
+  const parsed = packageJsonSchema.safeParse(JSON.parse(packageJsonContents))
   if (!parsed.success) {
     throw new Error('package.json missing commitlint.rules.type-enum string[]')
   }
@@ -74,12 +75,18 @@ export function formatSummary(errors: string[]): string {
 }
 
 function main(): void {
-  const title = process.env.TITLE ?? ''
+  const env = createEnv({
+    server: {
+      TITLE: z.string(),
+      GITHUB_STEP_SUMMARY: z.string().optional()
+    },
+    isServer: true,
+    runtimeEnv: process.env
+  })
   const types = readTypeEnum(readFileSync('./package.json', 'utf8'))
-  const errors = validateTitle(title, types)
-  const summaryFile = process.env.GITHUB_STEP_SUMMARY
-  if (summaryFile) {
-    appendFileSync(summaryFile, formatSummary(errors))
+  const errors = validateTitle(env.TITLE, types)
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(env.GITHUB_STEP_SUMMARY, formatSummary(errors))
   }
   if (errors.length > 0) {
     for (const e of errors) console.error(e)

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0-internal",
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "pnpm run --stream '/^test:/'",
+    "test:unit": "vitest run",
+    "test:types": "tsc --noEmit"
   },
   "dependencies": {
     "@mailpace/mailpace.js": "^0.1.3",

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -4,7 +4,7 @@
     // Type checking
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "alwaysStrict": false, // Don't emit "use strict" to avoid conflicts with "use client"
+    "types": ["node"],
     // Modules
     "module": "ESNext",
     "moduleResolution": "Bundler",
@@ -19,7 +19,6 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
 
-    "downlevelIteration": true,
     // Interop
     "allowJs": true,
     "isolatedModules": true,


### PR DESCRIPTION
Hardens the publication pipeline against supply-chain (unpinned action refs, lifecycle scripts on PR code) and script-injection (`${{ }}` into shell, fixed-`EOF` heredoc) patterns. One commit per change.

- Pin `47ng/actions-slack-notify` (was `@main`).
- Workflow-level `permissions: contents: read` on 4 workflows (was inheriting default token scope, which is read, but better be explicit).
- `pkg.pr.new` install: add `--ignore-scripts --frozen-lockfile`.
- `pkg.pr.new` version step: env-pass `head.sha` / `number` (was `${{ }}`-into-shell).
- Drop `npm install -g npm@latest` from cd job (bundled npm in Node 24.11.0 is 11.6.1, above OIDC trusted-publishing minimum).
- Pin `pnpm/action-setup` to `v6.0.3` SHA (was a non-tagged main-branch snapshot between v4.4.0 and v6.0.0).
- Replace `pnpm add -D @commitlint/{load,lint,parse}` in `pr-lint` with an inline regex `node -e` reading `commitlint.rules.type-enum` from `package.json`. Fixes a latent bug where step-summary writes mutated the env var instead of the file.
- `pr-lint` changed-files step: env-pass `base.sha` / `head.sha`.
- Release-notes generation: randomized heredoc delimiter + env-passed notes/version (was fixed `EOF` and `${{ outputs.notes }}` interpolated into `gh release edit`).

## Test plan

- [ ] CI green.
- [x] Inline lint regex tested locally: valid conventional types pass; disallowed type, missing colon, title >100 chars, and missing `commitlint.rules.type-enum` config all fail.
- [ ] Release-notes step only runs on push to `master`/`beta`; will be observed on next release.