### PR TITLE
chore: fix npm pkg set command

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,9 +1,9 @@
 name: PR Preview
 on:
   pull_request:
-    types: [opened, synchronize, labeled]
+    types: [ opened, synchronize, labeled ]
     paths:
-      - 'packages/nuqs/**'
+      - "packages/nuqs/**"
 
 concurrency:
   group: pkg-pr-new-${{ github.event.pull_request.number }}
@@ -32,10 +32,11 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          pnpm pkg set "version=0.0.0-preview.${HEAD_SHA}"
+          npm pkg set "version=0.0.0-preview.${HEAD_SHA}"
           echo "::notice title=Install (PR)::pnpm add https://pkg.pr.new/nuqs@${PR_NUMBER}"
           echo "::notice title=Install (SHA)::pnpm add https://pkg.pr.new/nuqs@${HEAD_SHA}"
           echo "::notice title=Version::0.0.0-preview.${HEAD_SHA}"
         working-directory: packages/nuqs
       - name: Publish to pkg.pr.new
-        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template --packageManager=pnpm --pnpm
+        run: pnpx pkg-pr-new publish --compact './packages/nuqs' --no-template
+          --packageManager=pnpm --pnpm


### PR DESCRIPTION
Bumping the pnpm action setup step in #1392 bundles pnpm v11.0.0-rc.5, which doesn't forward unimplemented commands to npm (like npm set). For other commands, it uses the pinned version in package.json in packageManager.

Waiting until pnpm ships 11 GA in their pnpm/setup-action to upgrade to pnpm 11 everywhere.