### PR TITLE
doc: add redirect from /changelog to /docs/changelog

### DIFF
--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -37,6 +37,11 @@ const config = {
         destination: '/docs/changelog',
         permanent: false
       },
+      {
+        source: '/changelog.md', // Shorthand
+        destination: '/docs/changelog.md',
+        permanent: false
+      },
       // Cool URLs don't break
       {
         source: '/docs/parsers',

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -32,6 +32,11 @@ const config = {
         destination: '/docs/parsers/community/tanstack-table',
         permanent: false
       },
+      {
+        source: '/changelog', // Shorthand
+        destination: '/docs/changelog',
+        permanent: false
+      },
       // Cool URLs don't break
       {
         source: '/docs/parsers',


### PR DESCRIPTION
I tend to type /changelog directly so allowing the shorthand.

- [x] Check if `/changelog.md` works