### PR TITLE
doc: use www.usenotra.com for Notra sponsor link

### DIFF
--- a/packages/docs/src/app/(pages)/_landing/sponsors.tsx
+++ b/packages/docs/src/app/(pages)/_landing/sponsors.tsx
@@ -150,7 +150,7 @@ const SPONSORS: Sponsors = [
     title: (
       <>
         Founder of{' '}
-        <a href="https://usenotra.com" className="hover:underline">
+        <a href="https://www.usenotra.com" className="hover:underline">
           Notra
         </a>
       </>


### PR DESCRIPTION
## Summary

Updates the Notra sponsor link to use the `www.` subdomain (`https://www.usenotra.com`).

## Test plan

- [x] Confirm the "Founder of Notra" link in the Sponsors section points to `https://www.usenotra.com`
