### PR TITLE
test: fix flaky #1099 unit tests

### DIFF
--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -457,7 +457,7 @@ describe('useQueryState: edge cases & repros', () => {
     function TestComponent() {
       const [state, setState] = useQueryState('test')
       const [isNullDetectorEnabled, setIsNullDetectorEnabled] = useState(false)
-      const isLoading = useFakeLoadingState(state)
+      const { isLoading, stopLoading } = useFakeLoadingState(state)
       return (
         <>
           <button
@@ -468,6 +468,7 @@ describe('useQueryState: edge cases & repros', () => {
           >
             Start
           </button>
+          <button onClick={stopLoading}>Stop</button>
           <NullDetector
             state={state}
             enabled={isNullDetectorEnabled}
@@ -490,7 +491,9 @@ describe('useQueryState: edge cases & repros', () => {
       .toHaveTextContent('pass')
     await expect.element(page.getByText('isLoading: false')).toBeInTheDocument()
     await user.click(page.getByRole('button', { name: 'Start' }))
+    // Held until we click Stop, so this no longer races a wall clock.
     await expect.element(page.getByText('isLoading: true')).toBeInTheDocument()
+    await user.click(page.getByRole('button', { name: 'Stop' }))
     await expect.element(page.getByText('isLoading: false')).toBeInTheDocument()
     await expect
       .element(page.getByTestId('null-detector'))

--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -491,7 +491,6 @@ describe('useQueryState: edge cases & repros', () => {
       .toHaveTextContent('pass')
     await expect.element(page.getByText('isLoading: false')).toBeInTheDocument()
     await user.click(page.getByRole('button', { name: 'Start' }))
-    // Held until we click Stop, so this no longer races a wall clock.
     await expect.element(page.getByText('isLoading: true')).toBeInTheDocument()
     await user.click(page.getByRole('button', { name: 'Stop' }))
     await expect.element(page.getByText('isLoading: false')).toBeInTheDocument()

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1014,7 +1014,7 @@ describe('useQueryStates: edge cases & repros', () => {
         test: parseAsString
       })
       const [isNullDetectorEnabled, setIsNullDetectorEnabled] = useState(false)
-      const isLoading = useFakeLoadingState(test)
+      const { isLoading, stopLoading } = useFakeLoadingState(test)
       return (
         <>
           <button
@@ -1025,6 +1025,7 @@ describe('useQueryStates: edge cases & repros', () => {
           >
             Start
           </button>
+          <button onClick={stopLoading}>Stop</button>
           <NullDetector
             state={test}
             enabled={isNullDetectorEnabled}
@@ -1048,6 +1049,7 @@ describe('useQueryStates: edge cases & repros', () => {
     await expect.element(page.getByText('isLoading: false')).toBeInTheDocument()
     await user.click(page.getByRole('button', { name: 'Start' }))
     await expect.element(page.getByText('isLoading: true')).toBeInTheDocument()
+    await user.click(page.getByRole('button', { name: 'Stop' }))
     await expect.element(page.getByText('isLoading: false')).toBeInTheDocument()
     await expect
       .element(page.getByTestId('null-detector'))

--- a/packages/nuqs/tests/components/repro-1099.tsx
+++ b/packages/nuqs/tests/components/repro-1099.tsx
@@ -28,17 +28,22 @@ export function NullDetector({
   return <pre {...props}>{hasBeenNullAtSomePoint ? 'fail' : 'pass'}</pre>
 }
 
-export function useFakeLoadingState(trigger: unknown): boolean {
+export function useFakeLoadingState(trigger: unknown): {
+  isLoading: boolean
+  stopLoading: () => void
+} {
   const [isLoading, setIsLoading] = useState(false)
+  // Enter the loading state in an effect reacting to the trigger change, in the
+  // same render pass as the search params update. This is the load-bearing
+  // sequence that reproduces #1099 and must not change.
   useEffect(() => {
     if (!trigger) {
       return
     }
     setIsLoading(true)
-    const timeout = setTimeout(() => {
-      setIsLoading(false)
-    }, 100)
-    return () => clearTimeout(timeout)
   }, [trigger])
-  return isLoading
+  // Exiting the loading state is driven explicitly by the test (via a button)
+  // rather than a timer, so the transient `isLoading: true` state
+  // can be asserted without racing a wall clock.
+  return { isLoading, stopLoading: () => setIsLoading(false) }
 }


### PR DESCRIPTION
Use a deterministic button click to reset the transient isLoading state of the unit test repro for #1099 to avoid a race in CI that flaked out.