### PR TITLE
test(e2e): stop passing router hooks through context

### DIFF
--- a/packages/e2e/next/src/app/providers.tsx
+++ b/packages/e2e/next/src/app/providers.tsx
@@ -4,32 +4,55 @@ import { LinkProvider } from 'e2e-shared/components/link'
 import { type Router, RouterProvider } from 'e2e-shared/components/router'
 import Link from 'next/link'
 import { useRouter as useNextRouter } from 'next/navigation'
-import { type ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
+
+// The Next.js router subscription lives in a null-rendering leaf component,
+// and the Router context value is a stable module-level object reading from
+// a ref: this keeps navigation updates from re-rendering the app shell
+// (which would pollute render-count tests), and avoids calling a hook
+// obtained via context, which breaks under the React Compiler with
+// next@16.3.0-canary.20+ (vercel/next.js#93633).
+const routerRef: { current: ReturnType<typeof useNextRouter> | null } = {
+  current: null
+}
+
+function RouterBinder() {
+  const router = useNextRouter()
+  useEffect(() => {
+    routerRef.current = router
+  }, [router])
+  return null
+}
+
+function getNextRouter() {
+  if (routerRef.current === null) {
+    throw new Error('Next.js router is not bound yet')
+  }
+  return routerRef.current
+}
+
+const router: Router = {
+  replace(url, { shallow }) {
+    if (shallow) {
+      history.replaceState(null, '', url)
+    } else {
+      getNextRouter().replace(url)
+    }
+  },
+  push(url, { shallow }) {
+    if (shallow) {
+      history.pushState(null, '', url)
+    } else {
+      getNextRouter().push(url)
+    }
+  }
+}
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <LinkProvider Link={Link}>
-      <RouterProvider useRouter={useRouter}>{children}</RouterProvider>
+      <RouterBinder />
+      <RouterProvider router={router}>{children}</RouterProvider>
     </LinkProvider>
   )
-}
-
-function useRouter(): Router {
-  const router = useNextRouter()
-  return {
-    replace(url, { shallow }) {
-      if (shallow) {
-        history.replaceState(null, '', url)
-      } else {
-        router.replace(url)
-      }
-    },
-    push(url, { shallow }) {
-      if (shallow) {
-        history.pushState(null, '', url)
-      } else {
-        router.push(url)
-      }
-    }
-  }
 }

--- a/packages/e2e/next/src/pages/_app.tsx
+++ b/packages/e2e/next/src/pages/_app.tsx
@@ -3,8 +3,20 @@ import { LinkProvider } from 'e2e-shared/components/link'
 import { type Router, RouterProvider } from 'e2e-shared/components/router'
 import type { AppProps } from 'next/app'
 import Link from 'next/link'
-import { useRouter as useNextRouter } from 'next/router'
+import NextRouter from 'next/router'
 import { NuqsAdapter } from 'nuqs/adapters/next/pages'
+
+// Using the imperative Router singleton (rather than the useRouter hook)
+// keeps _app free of router subscriptions: a hook here would re-render the
+// whole page tree on navigation and pollute render-count tests.
+const router: Router = {
+  replace(url, options) {
+    NextRouter.replace(url, url, { shallow: options.shallow })
+  },
+  push(url, options) {
+    NextRouter.push(url, url, { shallow: options.shallow })
+  }
+}
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -12,23 +24,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <HydrationMarker />
       <NuqsAdapter>
         <LinkProvider Link={Link}>
-          <RouterProvider useRouter={useRouter}>
+          <RouterProvider router={router}>
             <Component {...pageProps} />
           </RouterProvider>
         </LinkProvider>
       </NuqsAdapter>
     </>
   )
-}
-
-function useRouter(): Router {
-  const router = useNextRouter()
-  return {
-    replace(url, options) {
-      router.replace(url, url, { shallow: options.shallow })
-    },
-    push(url, options) {
-      router.push(url, url, { shallow: options.shallow })
-    }
-  }
 }

--- a/packages/e2e/react-router/v5/src/layout.tsx
+++ b/packages/e2e/react-router/v5/src/layout.tsx
@@ -1,32 +1,53 @@
 import { HydrationMarker } from 'e2e-shared/components/hydration-marker'
 import { LinkProvider, type LinkProps } from 'e2e-shared/components/link'
 import { RouterProvider, type Router } from 'e2e-shared/components/router'
-import { type ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { Link as ReactRouterLink, useHistory } from 'react-router-dom'
 
 function Link({ href, ...props }: LinkProps) {
   return <ReactRouterLink to={href} {...props} />
 }
 
+// The history subscription lives in a null-rendering leaf component, and
+// the Router context value is a stable module-level object reading from a
+// ref: this keeps navigation updates from re-rendering the app shell (which
+// would pollute render-count tests).
+const historyRef: { current: ReturnType<typeof useHistory> | null } = {
+  current: null
+}
+
+function RouterBinder() {
+  const history = useHistory()
+  useEffect(() => {
+    historyRef.current = history
+  }, [history])
+  return null
+}
+
+function getHistory() {
+  if (historyRef.current === null) {
+    throw new Error('Router is not bound yet')
+  }
+  return historyRef.current
+}
+
+const router: Router = {
+  replace(url) {
+    getHistory().replace(url)
+  },
+  push(url) {
+    getHistory().push(url)
+  }
+}
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <>
       <HydrationMarker />
+      <RouterBinder />
       <LinkProvider Link={Link}>
-        <RouterProvider useRouter={useRouter}>{children}</RouterProvider>
+        <RouterProvider router={router}>{children}</RouterProvider>
       </LinkProvider>
     </>
   )
-}
-
-function useRouter(): Router {
-  const history = useHistory()
-  return {
-    replace(url) {
-      history.replace(url)
-    },
-    push(url) {
-      history.push(url)
-    }
-  }
 }

--- a/packages/e2e/react-router/v6/src/layout.tsx
+++ b/packages/e2e/react-router/v6/src/layout.tsx
@@ -1,41 +1,63 @@
 import { HydrationMarker } from 'e2e-shared/components/hydration-marker'
 import { LinkProvider, type LinkProps } from 'e2e-shared/components/link'
 import { RouterProvider, type Router } from 'e2e-shared/components/router'
+import { useEffect } from 'react'
 import { Outlet, Link as ReactRouterLink, useNavigate } from 'react-router-dom'
 
 function Link({ href, ...props }: LinkProps) {
   return <ReactRouterLink to={href} {...props} />
 }
 
+// The navigation subscription lives in a null-rendering leaf component, and
+// the Router context value is a stable module-level object reading from a
+// ref: this keeps navigation updates from re-rendering the app shell (which
+// would pollute render-count tests).
+const navigateRef: { current: ReturnType<typeof useNavigate> | null } = {
+  current: null
+}
+
+function RouterBinder() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    navigateRef.current = navigate
+  }, [navigate])
+  return null
+}
+
+function getNavigate() {
+  if (navigateRef.current === null) {
+    throw new Error('Router is not bound yet')
+  }
+  return navigateRef.current
+}
+
+const router: Router = {
+  replace(url, options) {
+    if (options.shallow) {
+      history.replaceState(history.state, '', url)
+    } else {
+      getNavigate()(url, { replace: true })
+    }
+  },
+  push(url, options) {
+    if (options.shallow) {
+      history.pushState(history.state, '', url)
+    } else {
+      getNavigate()(url, { replace: false })
+    }
+  }
+}
+
 export default function RootLayout() {
   return (
     <>
       <HydrationMarker />
+      <RouterBinder />
       <LinkProvider Link={Link}>
-        <RouterProvider useRouter={useRouter}>
+        <RouterProvider router={router}>
           <Outlet />
         </RouterProvider>
       </LinkProvider>
     </>
   )
-}
-
-function useRouter(): Router {
-  const navigate = useNavigate()
-  return {
-    replace(url, options) {
-      if (options.shallow) {
-        history.replaceState(history.state, '', url)
-      } else {
-        navigate(url, { replace: true })
-      }
-    },
-    push(url, options) {
-      if (options.shallow) {
-        history.pushState(history.state, '', url)
-      } else {
-        navigate(url, { replace: false })
-      }
-    }
-  }
 }

--- a/packages/e2e/react-router/v7/app/layout.tsx
+++ b/packages/e2e/react-router/v7/app/layout.tsx
@@ -1,41 +1,63 @@
 import { HydrationMarker } from 'e2e-shared/components/hydration-marker'
 import { LinkProvider, type LinkProps } from 'e2e-shared/components/link'
 import { RouterProvider, type Router } from 'e2e-shared/components/router'
+import { useEffect } from 'react'
 import { Outlet, Link as ReactRouterLink, useNavigate } from 'react-router'
 
 function Link({ href, ...props }: LinkProps) {
   return <ReactRouterLink to={href} {...props} />
 }
 
+// The navigation subscription lives in a null-rendering leaf component, and
+// the Router context value is a stable module-level object reading from a
+// ref: this keeps navigation updates from re-rendering the app shell (which
+// would pollute render-count tests).
+const navigateRef: { current: ReturnType<typeof useNavigate> | null } = {
+  current: null
+}
+
+function RouterBinder() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    navigateRef.current = navigate
+  }, [navigate])
+  return null
+}
+
+function getNavigate() {
+  if (navigateRef.current === null) {
+    throw new Error('Router is not bound yet')
+  }
+  return navigateRef.current
+}
+
+const router: Router = {
+  replace(url, options) {
+    if (options.shallow) {
+      history.replaceState(history.state, '', url)
+    } else {
+      getNavigate()(url, { replace: true })
+    }
+  },
+  push(url, options) {
+    if (options.shallow) {
+      history.pushState(history.state, '', url)
+    } else {
+      getNavigate()(url, { replace: false })
+    }
+  }
+}
+
 export default function RootLayout() {
   return (
     <>
       <HydrationMarker />
+      <RouterBinder />
       <LinkProvider Link={Link}>
-        <RouterProvider useRouter={useRouter}>
+        <RouterProvider router={router}>
           <Outlet />
         </RouterProvider>
       </LinkProvider>
     </>
   )
-}
-
-function useRouter(): Router {
-  const navigate = useNavigate()
-  return {
-    replace(url, options) {
-      if (options.shallow) {
-        history.replaceState(history.state, '', url)
-      } else {
-        navigate(url, { replace: true })
-      }
-    },
-    push(url, options) {
-      if (options.shallow) {
-        history.pushState(history.state, '', url)
-      } else {
-        navigate(url, { replace: false })
-      }
-    }
-  }
 }

--- a/packages/e2e/react/src/layout.tsx
+++ b/packages/e2e/react/src/layout.tsx
@@ -7,32 +7,30 @@ function Link({ href, ...props }: LinkProps) {
   return <a href={href} {...props} />
 }
 
+const router: Router = {
+  replace(url, options) {
+    if (options.shallow) {
+      history.replaceState(history.state, '', url)
+    } else {
+      location.replace(url)
+    }
+  },
+  push(url, options) {
+    if (options.shallow) {
+      history.pushState(history.state, '', url)
+    } else {
+      location.assign(url)
+    }
+  }
+}
+
 export function RootLayout({ children }: { children: ReactNode }) {
   return (
     <>
       <HydrationMarker />
       <LinkProvider Link={Link}>
-        <RouterProvider useRouter={useRouter}>{children}</RouterProvider>
+        <RouterProvider router={router}>{children}</RouterProvider>
       </LinkProvider>
     </>
   )
-}
-
-function useRouter(): Router {
-  return {
-    replace(url, options) {
-      if (options.shallow) {
-        history.replaceState(history.state, '', url)
-      } else {
-        location.replace(url)
-      }
-    },
-    push(url, options) {
-      if (options.shallow) {
-        history.pushState(history.state, '', url)
-      } else {
-        location.assign(url)
-      }
-    }
-  }
 }

--- a/packages/e2e/remix/app/layout.tsx
+++ b/packages/e2e/remix/app/layout.tsx
@@ -2,40 +2,62 @@ import { Outlet, Link as RemixLink, useNavigate } from '@remix-run/react'
 import { HydrationMarker } from 'e2e-shared/components/hydration-marker'
 import { LinkProvider, type LinkProps } from 'e2e-shared/components/link'
 import { RouterProvider, type Router } from 'e2e-shared/components/router'
+import { useEffect } from 'react'
 
 function Link({ href, ...props }: LinkProps) {
   return <RemixLink to={href} {...props} />
+}
+
+// The navigation subscription lives in a null-rendering leaf component, and
+// the Router context value is a stable module-level object reading from a
+// ref: this keeps navigation updates from re-rendering the app shell (which
+// would pollute render-count tests).
+const navigateRef: { current: ReturnType<typeof useNavigate> | null } = {
+  current: null
+}
+
+function RouterBinder() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    navigateRef.current = navigate
+  }, [navigate])
+  return null
+}
+
+function getNavigate() {
+  if (navigateRef.current === null) {
+    throw new Error('Router is not bound yet')
+  }
+  return navigateRef.current
+}
+
+const router: Router = {
+  replace(url, options) {
+    if (options.shallow) {
+      history.replaceState(history.state, '', url)
+    } else {
+      getNavigate()(url, { replace: true })
+    }
+  },
+  push(url, options) {
+    if (options.shallow) {
+      history.pushState(history.state, '', url)
+    } else {
+      getNavigate()(url, { replace: false })
+    }
+  }
 }
 
 export default function RootLayout() {
   return (
     <>
       <HydrationMarker />
+      <RouterBinder />
       <LinkProvider Link={Link}>
-        <RouterProvider useRouter={useRouter}>
+        <RouterProvider router={router}>
           <Outlet />
         </RouterProvider>
       </LinkProvider>
     </>
   )
-}
-
-function useRouter(): Router {
-  const navigate = useNavigate()
-  return {
-    replace(url, options) {
-      if (options.shallow) {
-        history.replaceState(history.state, '', url)
-      } else {
-        navigate(url, { replace: true })
-      }
-    },
-    push(url, options) {
-      if (options.shallow) {
-        history.pushState(history.state, '', url)
-      } else {
-        navigate(url, { replace: false })
-      }
-    }
-  }
 }

--- a/packages/e2e/shared/components/router.tsx
+++ b/packages/e2e/shared/components/router.tsx
@@ -9,28 +9,24 @@ export type Router = {
   push(url: string, options: RouterOptions): void
 }
 
-type RouterContextValue = () => Router
+const RouterContext = createContext<Router | null>(null)
 
-const RouterContext = createContext<RouterContextValue>(
-  function useAbstractRouter() {
+export function useRouter(): Router {
+  const router = useContext(RouterContext)
+  if (router === null) {
     throw new Error('Router was not provided')
   }
-)
-
-export function useRouter() {
-  return useContext(RouterContext)()
+  return router
 }
 
 export function RouterProvider({
   children,
-  useRouter
+  router
 }: {
   children: React.ReactNode
-  useRouter: () => Router
+  router: Router
 }) {
   return (
-    <RouterContext.Provider value={useRouter}>
-      {children}
-    </RouterContext.Provider>
+    <RouterContext.Provider value={router}>{children}</RouterContext.Provider>
   )
 }

--- a/packages/e2e/tanstack-router/src/layout.tsx
+++ b/packages/e2e/tanstack-router/src/layout.tsx
@@ -2,27 +2,47 @@ import { Link as TanStackLink, useNavigate } from '@tanstack/react-router'
 import { HydrationMarker } from 'e2e-shared/components/hydration-marker'
 import { LinkProvider, type LinkProps } from 'e2e-shared/components/link'
 import { RouterProvider, type Router } from 'e2e-shared/components/router'
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 
 function Link({ href, ...props }: LinkProps) {
   return <TanStackLink to={href} {...props} />
 }
 
-function useRouter(): Router {
+// The navigation subscription lives in a null-rendering leaf component, and
+// the Router context value is a stable module-level object reading from a
+// ref: this keeps navigation updates from re-rendering the app shell (which
+// would pollute render-count tests).
+const navigateRef: { current: ReturnType<typeof useNavigate> | null } = {
+  current: null
+}
+
+function RouterBinder() {
   const navigate = useNavigate()
-  return {
-    replace(url) {
-      navigate({
-        to: url,
-        replace: true
-      })
-    },
-    push(url) {
-      navigate({
-        to: url,
-        replace: false
-      })
-    }
+  useEffect(() => {
+    navigateRef.current = navigate
+  }, [navigate])
+  return null
+}
+
+function getNavigate() {
+  if (navigateRef.current === null) {
+    throw new Error('Router is not bound yet')
+  }
+  return navigateRef.current
+}
+
+const router: Router = {
+  replace(url) {
+    getNavigate()({
+      to: url,
+      replace: true
+    })
+  },
+  push(url) {
+    getNavigate()({
+      to: url,
+      replace: false
+    })
   }
 }
 
@@ -30,8 +50,9 @@ export function RootLayout({ children }: { children: ReactNode }) {
   return (
     <>
       <HydrationMarker />
+      <RouterBinder />
       <LinkProvider Link={Link}>
-        <RouterProvider useRouter={useRouter}>{children}</RouterProvider>
+        <RouterProvider router={router}>{children}</RouterProvider>
       </LinkProvider>
     </>
   )


### PR DESCRIPTION
Calling a hook obtained from context crashes under next@16.3.0-canary.20+ with the React Compiler enabled (https://github.com/vercel/next.js/issues/93633).

Context now carries a stable router facade; each app binds its framework hook in a null-rendering leaf so navigation updates don't re-render the app shell and pollute render-count tests.

Repro at https://github.com/franky47/next-16.3.0-canary.20-repro.