### PR TITLE
doc: changelog reads DTO from releases

### DIFF
--- a/.github/workflows/release-edited.yml
+++ b/.github/workflows/release-edited.yml
@@ -1,0 +1,118 @@
+name: Refresh changelog on release edit
+
+# Companion to release-finalize.yml. Finalize busts the `releases` ISR tag on
+# publish (so a freshly published release appears on the docs changelog); this
+# handles the *after*: a maintainer fixing a docs-only preamble or a broken DTO
+# in an already-published release body has no other way to refresh the page
+# short of waiting for the next release. It exists separately from finalize on
+# purpose — finalize stays `published`-only, because re-running its comment/label
+# loop on a content edit would re-notify every impacted issue/PR. This workflow
+# never touches issues/PRs: it only calls /api/isr.
+#
+# Sequenced after the slice-7 backfill (see the changelog-dto PRD): the backfill
+# PATCHes ~dozens of release bodies, and each would otherwise fire a bust here.
+
+on:
+  release:
+    types: [edited]
+
+# Coalesce rapid successive edits to the same release: the bust is idempotent,
+# so cancelling an in-flight one to run the latest loses nothing. Keyed on the
+# stable numeric release id (not the tag), which never changes across edits.
+concurrency:
+  group: release-edited-${{ github.event.release.id }}
+  cancel-in-progress: true
+
+# The only GitHub interaction is checkout reading the code; the ISR call goes to
+# the docs endpoint, not the API. So contents:read (checkout's minimum) is all
+# the workflow token needs — never write, never id-token.
+permissions:
+  contents: read
+
+jobs:
+  refresh-changelog:
+    name: Bust the releases ISR cache
+    runs-on: ubuntu-24.04-arm
+    # Published GA releases only.
+    #   - draft: a draft edit can't affect the page (it reads only published
+    #     releases), and draft notes churn constantly while staging — pointless
+    #     to bust on each. `release.draft` is true while drafting, false once
+    #     published.
+    #   - beta: the changelog page filters to GA, so a beta edit can never change
+    #     it. Same GA-only gate finalize uses for its `releases` bust.
+    if: ${{ !github.event.release.draft && !contains(github.event.release.tag_name, '-beta.') }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # The DTO gate below runs the shared codec, which only exists on the
+          # default branch — NOT in the tree of the (possibly years-old, possibly
+          # backfilled) release being edited, which is what a `release` event
+          # checks out by default. Pin to the default branch so the gate always
+          # runs the current codec — the same one (modulo additive-only evolution)
+          # the docs build parses with. Shallow is fine: only the working tree is
+          # needed, no history.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          # No package-manager cache: this job has the ISR token in scope (the
+          # bust step) and runs installed code, so it must not restore a
+          # potentially-poisoned store (same stance as the privileged release
+          # jobs). The install is tiny (scripts only) and lockfile-frozen.
+          package-manager-cache: false
+      - name: Install scripts dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile --filter scripts
+
+      - name: Validate the edited release body's changelog DTO
+        id: dto
+        # Gate the bust on the body actually carrying a valid DTO. The renderer
+        # reads ONLY the embedded comment and degrades a release whose DTO is
+        # absent/invalid to a bare title+link — so an edit that doesn't yield a
+        # valid DTO would at best change nothing on the page and at worst repaint
+        # a previously-good release into a degraded entry. Either way, don't bust.
+        # The gate runs the same codec the renderer uses, so it can't drift from
+        # what the page will actually do. Never fails the job: a non-valid body is
+        # an expected outcome (e.g. editing prose on a pre-DTO release), recorded
+        # as a warning, not a red run.
+        run: |
+          set -uo pipefail
+          if ./validate-changelog-dto.ts; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Edited release body carries no valid changelog DTO; skipping ISR invalidation (the changelog page would render this release as a degraded title+link entry, or show no change)."
+          fi
+        working-directory: packages/scripts
+        env:
+          # Untrusted free-form text: passed via env (never interpolated into a
+          # shell) and read by the script from $RELEASE_BODY as pure parser input.
+          RELEASE_BODY: ${{ github.event.release.body }}
+
+      - name: Invalidate releases ISR cache in the docs
+        # Only when the body parses to a renderable DTO (see the gate above).
+        if: ${{ steps.dto.outputs.valid == 'true' }}
+        # Mirrors finalize's `releases` bust, but best-effort (unlike finalize,
+        # which is fatal). The changelog page reads each release's embedded DTO
+        # at ISR time, so busting this tag re-renders an edited body. A failed
+        # bust only warns; it never fails the job. Two reasons:
+        #   1. Low stakes: this is a convenience for hand-edits to already-
+        #      published bodies. The page self-heals on the next release/build,
+        #      and a red run on every edit — which the maintainer isn't watching
+        #      for — would be pure noise.
+        #   2. Deploy ordering: the `releases` tag is allowlisted in /api/isr by
+        #      the same change that adds this workflow. Until that ships to docs
+        #      prod, the endpoint 400s on `tag=releases`, so an early edit would
+        #      otherwise go red during the deploy gap. Idempotent regardless.
+        run: |
+          set -euo pipefail
+          if ! curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"; then
+            echo "::warning::Could not bust the 'releases' ISR cache. The changelog page will refresh on the next release or build."
+          fi
+        env:
+          # Passed via env and read as $ISR_TOKEN at runtime, so the literal
+          # secret never appears in the workflow YAML text (same stance as
+          # release-finalize.yml).
+          ISR_TOKEN: ${{ secrets.ISR_TOKEN }}

--- a/.github/workflows/release-edited.yml
+++ b/.github/workflows/release-edited.yml
@@ -4,28 +4,18 @@ name: Refresh changelog on release edit
 # publish (so a freshly published release appears on the docs changelog); this
 # handles the *after*: a maintainer fixing a docs-only preamble or a broken DTO
 # in an already-published release body has no other way to refresh the page
-# short of waiting for the next release. It exists separately from finalize on
-# purpose — finalize stays `published`-only, because re-running its comment/label
-# loop on a content edit would re-notify every impacted issue/PR. This workflow
-# never touches issues/PRs: it only calls /api/isr.
-#
-# Sequenced after the slice-7 backfill (see the changelog-dto PRD): the backfill
-# PATCHes ~dozens of release bodies, and each would otherwise fire a bust here.
+# short of waiting for the next release.
 
 on:
   release:
     types: [edited]
 
 # Coalesce rapid successive edits to the same release: the bust is idempotent,
-# so cancelling an in-flight one to run the latest loses nothing. Keyed on the
-# stable numeric release id (not the tag), which never changes across edits.
+# so cancelling an in-flight one to run the latest loses nothing.
 concurrency:
   group: release-edited-${{ github.event.release.id }}
   cancel-in-progress: true
 
-# The only GitHub interaction is checkout reading the code; the ISR call goes to
-# the docs endpoint, not the API. So contents:read (checkout's minimum) is all
-# the workflow token needs — never write, never id-token.
 permissions:
   contents: read
 
@@ -33,35 +23,20 @@ jobs:
   refresh-changelog:
     name: Bust the releases ISR cache
     runs-on: ubuntu-24.04-arm
-    # Published GA releases only.
-    #   - draft: a draft edit can't affect the page (it reads only published
-    #     releases), and draft notes churn constantly while staging — pointless
-    #     to bust on each. `release.draft` is true while drafting, false once
-    #     published.
-    #   - beta: the changelog page filters to GA, so a beta edit can never change
-    #     it. Same GA-only gate finalize uses for its `releases` bust.
+    # Run on published GA releases only.
     if: ${{ !github.event.release.draft && !contains(github.event.release.tag_name, '-beta.') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # The DTO gate below runs the shared codec, which only exists on the
-          # default branch — NOT in the tree of the (possibly years-old, possibly
-          # backfilled) release being edited, which is what a `release` event
-          # checks out by default. Pin to the default branch so the gate always
-          # runs the current codec — the same one (modulo additive-only evolution)
-          # the docs build parses with. Shallow is fine: only the working tree is
-          # needed, no history.
+          # Checkout from `next`, not the release's branch
+          # (which might not contain the code we need to run).
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version-file: .node-version
-          # No package-manager cache: this job has the ISR token in scope (the
-          # bust step) and runs installed code, so it must not restore a
-          # potentially-poisoned store (same stance as the privileged release
-          # jobs). The install is tiny (scripts only) and lockfile-frozen.
           package-manager-cache: false
       - name: Install scripts dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile --filter scripts

--- a/.github/workflows/release-edited.yml
+++ b/.github/workflows/release-edited.yml
@@ -68,22 +68,28 @@ jobs:
 
       - name: Validate the edited release body's changelog DTO
         id: dto
-        # Gate the bust on the body actually carrying a valid DTO. The renderer
-        # reads ONLY the embedded comment and degrades a release whose DTO is
-        # absent/invalid to a bare title+link — so an edit that doesn't yield a
-        # valid DTO would at best change nothing on the page and at worst repaint
-        # a previously-good release into a degraded entry. Either way, don't bust.
-        # The gate runs the same codec the renderer uses, so it can't drift from
-        # what the page will actually do. Never fails the job: a non-valid body is
-        # an expected outcome (e.g. editing prose on a pre-DTO release), recorded
-        # as a warning, not a red run.
         run: |
           set -uo pipefail
           if ./validate-changelog-dto.ts; then
             echo "valid=true" >> "$GITHUB_OUTPUT"
           else
-            echo "valid=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Edited release body carries no valid changelog DTO; skipping ISR invalidation (the changelog page would render this release as a degraded title+link entry, or show no change)."
+            code=$?
+            if [ "$code" -eq 1 ]; then
+              echo "valid=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::Edited release body carries no changelog DTO; skipping ISR invalidation."
+            fi
+            # Exit 2 means the DTO is invalid
+            if [ "$code" -eq 2 ]; then
+              echo "::error::Edited release body carries an INVALID changelog DTO; skipping ISR invalidation."
+              echo "valid=false" >> "$GITHUB_OUTPUT"
+              exit "$code"
+            fi
+            # Exit >=3 means the codec itself threw (a regression): fail the job loud
+            if [ "$code" -ge 3 ]; then
+              echo "::error::validate-changelog-dto crashed (exit $code) — likely a codec regression."
+              echo "valid=false" >> "$GITHUB_OUTPUT"
+              exit "$code"
+            fi
           fi
         working-directory: packages/scripts
         env:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -108,6 +108,18 @@ jobs:
           # secret never appears in the workflow YAML text (same stance as TAG).
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
+      - name: Invalidate releases ISR cache in the docs
+        # Same gating as the contributors bust: GA-only, after a green comment
+        # loop. The changelog page reads each release's embedded DTO at ISR time
+        # (no GitHub enrichment), so busting the `releases` tag here is what makes
+        # the just-published release appear — the prod build usually runs just
+        # ahead of publish, so the tag bust, not the build, picks it up. Not
+        # best-effort: a failed bust fails the job (the curl is idempotent).
+        if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
+        run: curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"
+        env:
+          ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
+
       - name: Notify on Slack
         # Last, and always: on success a 🚀/🧪 release card (packageName +
         # version + channel → the action derives the npm + release-notes links);

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -109,14 +109,12 @@ jobs:
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
       - name: Invalidate releases ISR cache in the docs
-        # Same gating as the contributors bust: GA-only, after a green comment
-        # loop. The changelog page reads each release's embedded DTO at ISR time
-        # (no GitHub enrichment), so busting the `releases` tag here is what makes
-        # the just-published release appear — the prod build usually runs just
-        # ahead of publish, so the tag bust, not the build, picks it up. Not
-        # best-effort: a failed bust fails the job (the curl is idempotent).
         if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
-        run: curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"
+        run: |
+          set -euo pipefail
+          if ! curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"; then
+            echo "::warning::Could not bust the 'releases' ISR cache. The changelog page will refresh on the next release or build."
+          fi
         env:
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 

--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,13 @@
       "ignoreDependencies": ["@commitlint/config-conventional"]
     },
     "packages/scripts": {
-      "entry": ["next-release-analyser.ts", "release-notes-automation.ts"],
+      "entry": [
+        "compute-version.ts",
+        "next-release-analyser.ts",
+        "release-finalize.ts",
+        "release-notes-automation.ts",
+        "verify-staged-release/verify.ts"
+      ],
       "project": ["**/*.ts"]
     },
     "packages/nuqs": {

--- a/knip.json
+++ b/knip.json
@@ -11,6 +11,7 @@
         "next-release-analyser.ts",
         "release-finalize.ts",
         "release-notes-automation.ts",
+        "validate-changelog-dto.ts",
         "verify-staged-release/verify.ts"
       ],
       "project": ["**/*.ts"]

--- a/knip.json
+++ b/knip.json
@@ -46,7 +46,8 @@
         "src/components/audience.tsx",
         "src/components/code-block-highlighter.ts",
         "src/components/feature-support-matrix.tsx",
-        "src/components/frameworks.tsx"
+        "src/components/frameworks.tsx",
+        "src/schemas/changelog-dto.gen.ts"
       ],
       "project": ["content/**/*.{ts,tsx}", "src/**/*.{ts,tsx}"],
       "paths": {

--- a/knip.json
+++ b/knip.json
@@ -60,6 +60,7 @@
         "src/components/kibo-ui/**",
         "src/components/release-contribution-graph.client.tsx",
         "src/components/release-contribution-graph.tsx",
+        "src/components/ui/pr-line.tsx",
         "src/components/vercel-oss-badge.tsx",
         "src/lib/typed-links.ts"
       ],

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -16,6 +16,9 @@ const config = {
   },
   reactCompiler: true,
   reactStrictMode: true,
+  // The changelog page imports the IO-free changelog codec straight from the
+  // `scripts` workspace as raw TypeScript; transpile it as part of the build.
+  transpilePackages: ['scripts'],
   experimental: {
     isolatedDevBuild: true
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,9 +18,10 @@
     "build": "pnpm run build:registry && pnpm run build:next",
     "build:next": "next build",
     "build:registry": "./src/registry/assemble.ts && shadcn build",
+    "gen:schema": "./src/schemas/changelog-dto.gen.ts",
     "start": "next start",
     "postinstall": "fumadocs-mdx",
-    "test": "fumadocs-mdx && next typegen && fumadocs-mdx && tsc"
+    "test": "fumadocs-mdx && next typegen && fumadocs-mdx && tsc && vitest run"
   },
   "dependencies": {
     "@databuddy/sdk": "^2.3.29",
@@ -79,7 +80,8 @@
     "shadcn": "^3.8.2",
     "shiki": "^3.22.0",
     "typescript": "catalog:typescript",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "vitest": "catalog:vitest"
   },
   "postcss": {
     "plugins": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -59,6 +59,7 @@
     "react-dom": "catalog:react19",
     "recharts": "3.8.0",
     "remark-smartypants": "^3.0.2",
+    "scripts": "workspace:*",
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",

--- a/packages/docs/public/schemas/changelog-dto.v1.json
+++ b/packages/docs/public/schemas/changelog-dto.v1.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "changes": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "squashedPR"
+              },
+              "prNumber": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "type": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "breaking": {
+                "type": "boolean"
+              },
+              "description": {
+                "type": "string"
+              },
+              "author": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "closingIssues": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                }
+              }
+            },
+            "required": [
+              "source",
+              "prNumber",
+              "type",
+              "breaking",
+              "description",
+              "author",
+              "closingIssues"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "const": "directCommit"
+              },
+              "sha": {
+                "type": "string"
+              },
+              "type": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "breaking": {
+                "type": "boolean"
+              },
+              "description": {
+                "type": "string"
+              },
+              "author": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "source",
+              "sha",
+              "type",
+              "breaking",
+              "description",
+              "author"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "$schema": {
+      "type": "string",
+      "const": "https://nuqs.dev/schemas/changelog-dto.v1.json"
+    }
+  },
+  "required": [
+    "changes",
+    "contributors",
+    "$schema"
+  ],
+  "additionalProperties": false
+}

--- a/packages/docs/public/schemas/changelog-dto.v1.json
+++ b/packages/docs/public/schemas/changelog-dto.v1.json
@@ -32,12 +32,15 @@
                 "type": "boolean"
               },
               "description": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 500
               },
               "author": {
                 "anyOf": [
                   {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[a-zA-Z\\d](?:[a-zA-Z\\d]|-(?=[a-zA-Z\\d])){0,38}$"
                   },
                   {
                     "type": "null"
@@ -72,7 +75,8 @@
                 "const": "directCommit"
               },
               "sha": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[0-9a-f]{7,40}$"
               },
               "type": {
                 "anyOf": [
@@ -88,10 +92,13 @@
                 "type": "boolean"
               },
               "description": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 500
               },
               "author": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             },
             "required": [
@@ -110,7 +117,8 @@
     "contributors": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "pattern": "^[a-zA-Z\\d](?:[a-zA-Z\\d]|-(?=[a-zA-Z\\d])){0,38}$"
       }
     },
     "$schema": {

--- a/packages/docs/src/app/api/isr/route.ts
+++ b/packages/docs/src/app/api/isr/route.ts
@@ -5,7 +5,8 @@ const ACCEPTED_TAGS = [
   'github',
   'github-actions-status',
   'npm-stats',
-  'contributors'
+  'contributors',
+  'releases'
 ]
 
 export async function GET(req: NextRequest) {

--- a/packages/docs/src/app/api/isr/route.ts
+++ b/packages/docs/src/app/api/isr/route.ts
@@ -1,5 +1,6 @@
 import { revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
+import { timingSafeEqual } from 'node:crypto'
 
 const ACCEPTED_TAGS = [
   'github',
@@ -9,11 +10,23 @@ const ACCEPTED_TAGS = [
   'releases'
 ]
 
+// Constant-time string compare. The length is allowed to leak (timingSafeEqual
+// requires equal-length buffers), but the byte comparison doesn't short-circuit.
+function tokensMatch(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
+}
+
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')
-  if (token !== process.env.ISR_TOKEN) {
-    console.log('Invalid token `%s`', req.nextUrl.toString())
-    return NextResponse.json({ error: 'Invalid token' }, { status: 400 })
+  const expected = process.env.ISR_TOKEN
+  // Reject a missing/empty configured token outright, so an unset ISR_TOKEN
+  // can't be matched by an empty `?token=`.
+  if (!expected || !token || !tokensMatch(token, expected)) {
+    // Log the requested token for analysis (sliced to avoid flooding logs)
+    console.log('Invalid token `%s`', token?.slice(0, 256))
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
   }
   const tag = req.nextUrl.searchParams.get('tag')
   if (!tag || !ACCEPTED_TAGS.includes(tag)) {

--- a/packages/docs/src/app/docs/changelog/_lib.test.ts
+++ b/packages/docs/src/app/docs/changelog/_lib.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { bumpHeadings } from './_lib.ts'
+
+describe('bumpHeadings', () => {
+  it('bumps every ATX heading one level deeper', () => {
+    expect(bumpHeadings('# Title\n## Features\n### Detail')).toBe(
+      '## Title\n### Features\n#### Detail'
+    )
+  })
+
+  it('leaves non-heading lines untouched', () => {
+    expect(bumpHeadings('a line\n#tag-no-space\nmore')).toBe(
+      'a line\n#tag-no-space\nmore'
+    )
+  })
+
+  it('does not bump a # line inside a fenced code block', () => {
+    const body = [
+      '## Features',
+      '',
+      '```sh',
+      '# install',
+      'pnpm add nuqs',
+      '```'
+    ].join('\n')
+    expect(bumpHeadings(body)).toBe(
+      ['### Features', '', '```sh', '# install', 'pnpm add nuqs', '```'].join(
+        '\n'
+      )
+    )
+  })
+
+  it('handles ~~~ fences too', () => {
+    const body = [
+      '# Heading',
+      '~~~',
+      '# not a heading',
+      '~~~',
+      '## After'
+    ].join('\n')
+    expect(bumpHeadings(body)).toBe(
+      ['## Heading', '~~~', '# not a heading', '~~~', '### After'].join('\n')
+    )
+  })
+})

--- a/packages/docs/src/app/docs/changelog/_lib.ts
+++ b/packages/docs/src/app/docs/changelog/_lib.ts
@@ -59,10 +59,12 @@ export async function fetchReleases(): Promise<GithubRelease[]> {
 // The render model for one release. `grouped` is null when the release has no
 // valid DTO (missing/malformed/unrecognized) — the page renders a degraded entry
 // (title + date + link) for it rather than dropping it or failing the build.
+// `contributors` is empty in that degraded case (no footer).
 export type ReleaseModel = {
   release: GithubRelease
   grouped: Record<Category, Change[]> | null
   preamble: string | null
+  contributors: string[]
 }
 
 export function buildReleaseModel(release: GithubRelease): ReleaseModel {
@@ -72,12 +74,13 @@ export function buildReleaseModel(release: GithubRelease): ReleaseModel {
       'changelog: release %s has no valid changelog DTO — rendering a degraded entry.',
       release.tag_name
     )
-    return { release, grouped: null, preamble: null }
+    return { release, grouped: null, preamble: null, contributors: [] }
   }
   return {
     release,
     grouped: groupChangesByCategory(parsed.dto.changes),
-    preamble: parsed.preamble
+    preamble: parsed.preamble,
+    contributors: parsed.dto.contributors
   }
 }
 

--- a/packages/docs/src/app/docs/changelog/_lib.ts
+++ b/packages/docs/src/app/docs/changelog/_lib.ts
@@ -1,27 +1,12 @@
 import dayjs from 'dayjs'
+import {
+  type Category,
+  type Change,
+  groupChangesByCategory,
+  parseChangelogComment,
+  stripChangelogComment
+} from 'scripts/lib/changelog-dto'
 import { z } from 'zod'
-
-export const CATEGORY_ORDER = [
-  'features',
-  'bug-fixes',
-  'documentation',
-  'other-changes'
-] as const
-
-type CategoryId = (typeof CATEGORY_ORDER)[number]
-
-export const CATEGORY_LABELS: Record<CategoryId, string> = {
-  features: 'Features',
-  'bug-fixes': 'Bug fixes',
-  documentation: 'Documentation',
-  'other-changes': 'Other changes'
-}
-
-export type ReleaseNoteItem = {
-  number: number
-}
-
-export type ReleaseCategories = Record<CategoryId, ReleaseNoteItem[]>
 
 const GithubReleaseSchema = z.object({
   id: z.number(),
@@ -38,6 +23,12 @@ const GithubReleaseArray = z.array(GithubReleaseSchema)
 
 export type GithubRelease = z.infer<typeof GithubReleaseSchema>
 
+// A single releases-list call (the newest 100), filtered to GA. We deliberately
+// do NOT paginate: older GA releases beyond this page are reached via a "See
+// more on GitHub" link, not rendered — keeping the page bounded rather than
+// dumping the entire history. The call carries the `releases` cache tag (busted
+// by the finalize workflow) and makes zero per-PR/per-commit enrichment calls —
+// the DTO embedded in each release body is all the page reads.
 export async function fetchReleases(): Promise<GithubRelease[]> {
   const headers: HeadersInit = {
     Accept: 'application/vnd.github+json'
@@ -46,15 +37,13 @@ export async function fetchReleases(): Promise<GithubRelease[]> {
   if (token) {
     headers.Authorization = `bearer ${token}`
   }
-
   const response = await fetch(
-    'https://api.github.com/repos/47ng/nuqs/releases?per_page=50',
+    'https://api.github.com/repos/47ng/nuqs/releases?per_page=100',
     {
       headers,
       next: { tags: ['releases'] }
     }
   )
-
   if (!response.ok) {
     console.error(
       'Failed to fetch releases:',
@@ -63,53 +52,33 @@ export async function fetchReleases(): Promise<GithubRelease[]> {
     )
     return []
   }
-
   const data = GithubReleaseArray.parse(await response.json())
   return data.filter(release => !release.draft && !release.prerelease)
 }
 
-function classifyHeading(heading: string): CategoryId {
-  const h = heading.toLowerCase()
-  if (h.includes('feature')) return 'features'
-  if (h.includes('bug') || h.includes('fix')) return 'bug-fixes'
-  if (h.includes('doc')) return 'documentation'
-  return 'other-changes'
+// The render model for one release. `grouped` is null when the release has no
+// valid DTO (missing/malformed/unrecognized) — the page renders a degraded entry
+// (title + date + link) for it rather than dropping it or failing the build.
+export type ReleaseModel = {
+  release: GithubRelease
+  grouped: Record<Category, Change[]> | null
+  preamble: string | null
 }
 
-export function parseReleaseBody(body?: string | null): ReleaseCategories {
-  const categories: ReleaseCategories = {
-    features: [],
-    'bug-fixes': [],
-    documentation: [],
-    'other-changes': []
+export function buildReleaseModel(release: GithubRelease): ReleaseModel {
+  const parsed = parseChangelogComment(release.body)
+  if (parsed === null) {
+    console.warn(
+      'changelog: release %s has no valid changelog DTO — rendering a degraded entry.',
+      release.tag_name
+    )
+    return { release, grouped: null, preamble: null }
   }
-
-  if (!body) return categories
-
-  const lines = body.split(/\r?\n/)
-  let currentCategory: CategoryId = 'other-changes'
-
-  for (const rawLine of lines) {
-    const line = rawLine.trim()
-
-    const headingMatch = /^#{2,3}\s+(.+)$/.exec(line)
-    if (headingMatch) {
-      if (/thanks/i.test(headingMatch[1])) continue
-      currentCategory = classifyHeading(headingMatch[1])
-      continue
-    }
-
-    if (line.startsWith('- ') || line.startsWith('* ')) {
-      const prMatch = /#(\d{1,6})\b/.exec(line)
-      const prNumber = prMatch ? Number(prMatch[1]) : undefined
-
-      if (prNumber) {
-        categories[currentCategory].push({ number: prNumber })
-      }
-    }
+  return {
+    release,
+    grouped: groupChangesByCategory(parsed.dto.changes),
+    preamble: parsed.preamble
   }
-
-  return categories
 }
 
 export function formatDate(date?: string | null): string | null {
@@ -126,25 +95,28 @@ function bumpHeadings(body: string): string {
   return body.replace(/^(#{1,5})(\s)/gm, '#$1$2')
 }
 
+// The `.md`/llms changelog renders the human-readable GitHub notes verbatim
+// (minus the machine DTO comment, stripped so it doesn't leak into the text),
+// not the structured DTO model — that drives the interactive page instead.
 export async function getChangelogMarkdown(): Promise<string> {
   const releases = await fetchReleases()
-  const visible = releases.filter(release => {
-    const categories = parseReleaseBody(release.body)
-    return CATEGORY_ORDER.some(id => categories[id].length > 0)
-  })
-
-  const sections = visible.map(release => {
-    const title = release.name || release.tag_name
-    const date = formatDate(release.published_at)
-    const meta = [
-      date && `Published on ${date}`,
-      `[View on GitHub](${release.html_url})`
-    ]
-      .filter(Boolean)
-      .join(' • ')
-    const body = bumpHeadings((release.body ?? '').trim())
-    return `## ${title}\n\n${meta}\n\n${body}`
-  })
+  const sections = releases
+    .map(release => ({
+      release,
+      body: bumpHeadings(stripChangelogComment(release.body ?? '').trim())
+    }))
+    .filter(({ body }) => body.length > 0)
+    .map(({ release, body }) => {
+      const title = release.name || release.tag_name
+      const date = formatDate(release.published_at)
+      const meta = [
+        date && `Published on ${date}`,
+        `[View on GitHub](${release.html_url})`
+      ]
+        .filter(Boolean)
+        .join(' • ')
+      return `## ${title}\n\n${meta}\n\n${body}`
+    })
 
   return `# Changelog\n\nWhat's new in nuqs.\n\n${sections.join('\n\n---\n\n')}`
 }

--- a/packages/docs/src/app/docs/changelog/_lib.ts
+++ b/packages/docs/src/app/docs/changelog/_lib.ts
@@ -45,12 +45,13 @@ export async function fetchReleases(): Promise<GithubRelease[]> {
     }
   )
   if (!response.ok) {
-    console.error(
-      'Failed to fetch releases:',
-      response.status,
-      response.statusText
+    // Throw rather than return [] — caching an empty changelog hides the outage
+    // until the next bust. A throw fails the build loudly, and during ISR
+    // revalidation Next keeps serving the last good page (consistent with the
+    // malformed-body path beside it, which also throws).
+    throw new Error(
+      `Failed to fetch releases: ${response.status} ${response.statusText}`
     )
-    return []
   }
   const data = GithubReleaseArray.parse(await response.json())
   return data.filter(release => !release.draft && !release.prerelease)
@@ -69,11 +70,19 @@ export type ReleaseModel = {
 
 export function buildReleaseModel(release: GithubRelease): ReleaseModel {
   const parsed = parseChangelogComment(release.body)
-  if (parsed === null) {
-    console.warn(
-      'changelog: release %s has no valid changelog DTO — rendering a degraded entry.',
-      release.tag_name
-    )
+  if (parsed.status !== 'ok') {
+    if (parsed.status === 'invalid') {
+      console.error(
+        'changelog: release %s has an INVALID changelog DTO (%s) — rendering a degraded entry.',
+        release.tag_name,
+        parsed.reason
+      )
+    } else {
+      console.warn(
+        'changelog: release %s has no changelog DTO — rendering a degraded entry.',
+        release.tag_name
+      )
+    }
     return { release, grouped: null, preamble: null, contributors: [] }
   }
   return {
@@ -93,9 +102,21 @@ export function formatDate(date?: string | null): string | null {
 
 // GitHub release bodies use `## Features`, `## Bug fixes`, etc. as section
 // headings, which clash with our per-release `## v1.2.3` title. Bump every
-// ATX heading one level deeper so sections nest under the release title.
-function bumpHeadings(body: string): string {
-  return body.replace(/^(#{1,5})(\s)/gm, '#$1$2')
+// ATX heading one level deeper so sections nest under the release title — but
+// skip lines inside fenced code blocks, where a leading `#` is a comment/shell
+// prompt, not a heading.
+export function bumpHeadings(body: string): string {
+  let inFence = false
+  return body
+    .split('\n')
+    .map(line => {
+      if (/^\s*(```|~~~)/.test(line)) {
+        inFence = !inFence
+        return line
+      }
+      return inFence ? line : line.replace(/^(#{1,5})(\s)/, '#$1$2')
+    })
+    .join('\n')
 }
 
 // The `.md`/llms changelog renders the human-readable GitHub notes verbatim

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -4,6 +4,7 @@ import {
   CopyMarkdownUrlButton,
   ViewOptions
 } from '@/src/components/ai/page-actions'
+import { CommitLine } from '@/src/components/changelog/commit-line'
 import { PullRequestLine } from '@/src/components/changelog/pr-line'
 import { github } from '@/src/lib/utils'
 import { Heading } from 'fumadocs-ui/components/heading'
@@ -16,7 +17,7 @@ import {
 import { ExternalLink } from 'lucide-react'
 import type { Metadata } from 'next'
 import { Fragment } from 'react'
-import { CATEGORIES, type Change } from 'scripts/lib/changelog-dto'
+import { CATEGORIES } from 'scripts/lib/changelog-dto'
 import { H2 } from '../../../components/typography'
 import { buildReleaseModel, fetchReleases, formatDate } from './_lib'
 
@@ -98,14 +99,7 @@ export default async function ChangelogPage() {
                     {grouped && (
                       <div className="mt-6 space-y-6">
                         {CATEGORIES.map(category => {
-                          const items = grouped[category].filter(
-                            (
-                              change
-                            ): change is Extract<
-                              Change,
-                              { source: 'squashedPR' }
-                            > => change.source === 'squashedPR'
-                          )
+                          const items = grouped[category]
                           if (items.length === 0) return null
 
                           return (
@@ -117,14 +111,23 @@ export default async function ChangelogPage() {
                                 {category}
                               </Heading>
                               <ul className="not-prose mt-3 list-none space-y-2 pl-0">
-                                {items.map(item => (
-                                  <PullRequestLine
-                                    key={item.prNumber}
-                                    prNumber={item.prNumber}
-                                    description={item.description}
-                                    author={item.author}
-                                  />
-                                ))}
+                                {items.map(item =>
+                                  item.source === 'squashedPR' ? (
+                                    <PullRequestLine
+                                      key={`pr-${item.prNumber}`}
+                                      prNumber={item.prNumber}
+                                      description={item.description}
+                                      author={item.author}
+                                    />
+                                  ) : (
+                                    <CommitLine
+                                      key={`commit-${item.sha}`}
+                                      sha={item.sha}
+                                      description={item.description}
+                                      author={item.author}
+                                    />
+                                  )
+                                )}
                               </ul>
                             </section>
                           )

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -80,14 +80,16 @@ export default async function ChangelogPage() {
                         {title}
                       </H2>
                       <div className="not-prose text-fd-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
-                        {date && <span>Published on {date}</span>}
                         {date && (
-                          <span
-                            aria-hidden
-                            className="text-fd-muted-foreground/60"
-                          >
-                            •
-                          </span>
+                          <>
+                            <span>Published on {date}</span>
+                            <span
+                              aria-hidden
+                              className="text-fd-muted-foreground/60"
+                            >
+                              •
+                            </span>
+                          </>
                         )}
                         <a
                           href={release.html_url}

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -6,8 +6,8 @@ import {
 } from '@/src/components/ai/page-actions'
 import { CommitLine } from '@/src/components/changelog/commit-line'
 import { ContributorsFooter } from '@/src/components/changelog/contributors-footer'
-import { Preamble } from '@/src/components/changelog/preamble'
 import { PullRequestLine } from '@/src/components/changelog/pr-line'
+import { Preamble } from '@/src/components/changelog/preamble'
 import { github } from '@/src/lib/utils'
 import { Heading } from 'fumadocs-ui/components/heading'
 import {
@@ -145,7 +145,9 @@ export default async function ChangelogPage() {
                           })}
                         </div>
                       )}
-
+                      <Heading as="h3" id={`${tag}-contributors`}>
+                        Contributors
+                      </Heading>
                       <ContributorsFooter contributors={contributors} />
                     </section>
                   </Fragment>

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -4,6 +4,7 @@ import {
   CopyMarkdownUrlButton,
   ViewOptions
 } from '@/src/components/ai/page-actions'
+import { PullRequestLine } from '@/src/components/changelog/pr-line'
 import { github } from '@/src/lib/utils'
 import { Heading } from 'fumadocs-ui/components/heading'
 import {
@@ -12,17 +13,12 @@ import {
   DocsPage,
   DocsTitle
 } from 'fumadocs-ui/page'
+import { ExternalLink } from 'lucide-react'
 import type { Metadata } from 'next'
 import { Fragment } from 'react'
+import { CATEGORIES, type Change } from 'scripts/lib/changelog-dto'
 import { H2 } from '../../../components/typography'
-import { PullRequestLine } from '../../../components/ui/pr-line'
-import {
-  CATEGORY_LABELS,
-  CATEGORY_ORDER,
-  fetchReleases,
-  formatDate,
-  parseReleaseBody
-} from './_lib'
+import { buildReleaseModel, fetchReleases, formatDate } from './_lib'
 
 export const metadata: Metadata = {
   title: 'Changelog'
@@ -33,17 +29,15 @@ export const revalidate = false
 const MARKDOWN_URL = '/docs/changelog.md'
 const SOURCE_URL = `https://github.com/${github.owner}/${github.repo}/blob/${github.branch}/packages/docs/src/app/docs/changelog/page.tsx`
 
+// Slugify a category label into a stable anchor id (e.g. "Bug fixes" → "bug-fixes").
+function categorySlug(category: string): string {
+  return category.toLowerCase().replace(/\s+/g, '-')
+}
+
 export default async function ChangelogPage() {
   const releases = await fetchReleases()
-  const visibleReleases = releases
-    .map(release => ({
-      release,
-      categories: parseReleaseBody(release.body)
-    }))
-    .filter(({ categories }) =>
-      CATEGORY_ORDER.some(id => categories[id].length > 0)
-    )
-  const toc = visibleReleases.map(({ release }) => ({
+  const models = releases.map(buildReleaseModel)
+  const toc = models.map(({ release }) => ({
     url: `#${release.tag_name}`,
     title: release.name || release.tag_name,
     depth: 2
@@ -65,57 +59,70 @@ export default async function ChangelogPage() {
       </div>
 
       <DocsBody>
-        {visibleReleases.length === 0 ? (
+        {models.length === 0 ? (
           <p>No releases could be loaded from GitHub at this time.</p>
         ) : (
           <div className="space-y-10 pb-12 sm:space-y-16">
-            {visibleReleases.map(({ release, categories }, index) => {
-                const date = formatDate(release.published_at)
-                const tag = release.tag_name
-                const title = release.name || tag
+            {models.map(({ release, grouped }, index) => {
+              const date = formatDate(release.published_at)
+              const tag = release.tag_name
+              const title = release.name || tag
 
-                return (
-                  <Fragment key={release.id}>
-                    {index > 0 && <hr className="border-border" />}
-                    <section>
-                      <H2 id={tag} className="mb-2">
-                        {title}
-                      </H2>
-                      <div className="not-prose text-fd-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
-                        {date && <span>Published on {date}</span>}
-                        {date && (
-                          <span
-                            aria-hidden
-                            className="text-fd-muted-foreground/60"
-                          >
-                            •
-                          </span>
-                        )}
-                        <a
-                          href={release.html_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="hover:underline"
+              return (
+                <Fragment key={release.id}>
+                  {index > 0 && <hr className="border-border" />}
+                  <section>
+                    <H2 id={tag} className="mb-2">
+                      {title}
+                    </H2>
+                    <div className="not-prose text-fd-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                      {date && <span>Published on {date}</span>}
+                      {date && (
+                        <span
+                          aria-hidden
+                          className="text-fd-muted-foreground/60"
                         >
-                          View on GitHub
-                        </a>
-                      </div>
+                          •
+                        </span>
+                      )}
+                      <a
+                        href={release.html_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline"
+                      >
+                        View on GitHub
+                      </a>
+                    </div>
 
+                    {grouped && (
                       <div className="mt-6 space-y-6">
-                        {CATEGORY_ORDER.map(categoryId => {
-                          const items = categories[categoryId]
-                          if (!items.length) return null
+                        {CATEGORIES.map(category => {
+                          const items = grouped[category].filter(
+                            (
+                              change
+                            ): change is Extract<
+                              Change,
+                              { source: 'squashedPR' }
+                            > => change.source === 'squashedPR'
+                          )
+                          if (items.length === 0) return null
 
                           return (
-                            <section key={categoryId}>
-                              <Heading as="h3" id={`${tag}-${categoryId}`}>
-                                {CATEGORY_LABELS[categoryId]}
+                            <section key={category}>
+                              <Heading
+                                as="h3"
+                                id={`${tag}-${categorySlug(category)}`}
+                              >
+                                {category}
                               </Heading>
                               <ul className="not-prose mt-3 list-none space-y-2 pl-0">
-                                {items.map((item, itemIndex) => (
+                                {items.map(item => (
                                   <PullRequestLine
-                                    key={`${categoryId}-${release.id}-${itemIndex}`}
-                                    number={item.number}
+                                    key={item.prNumber}
+                                    prNumber={item.prNumber}
+                                    description={item.description}
+                                    author={item.author}
                                   />
                                 ))}
                               </ul>
@@ -123,10 +130,22 @@ export default async function ChangelogPage() {
                           )
                         })}
                       </div>
-                    </section>
-                  </Fragment>
-                )
-              })}
+                    )}
+                  </section>
+                </Fragment>
+              )
+            })}
+            <div className="pt-2">
+              <a
+                href={`https://github.com/${github.owner}/${github.repo}/releases`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-fd-muted-foreground text-sm decoration-current decoration-1 underline-offset-4"
+              >
+                See more releases on GitHub{' '}
+                <ExternalLink className="inline h-4 w-4" />
+              </a>
+            </div>
           </div>
         )}
       </DocsBody>

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -5,6 +5,7 @@ import {
   ViewOptions
 } from '@/src/components/ai/page-actions'
 import { CommitLine } from '@/src/components/changelog/commit-line'
+import { ContributorsFooter } from '@/src/components/changelog/contributors-footer'
 import { PullRequestLine } from '@/src/components/changelog/pr-line'
 import { github } from '@/src/lib/utils'
 import { Heading } from 'fumadocs-ui/components/heading'
@@ -64,7 +65,7 @@ export default async function ChangelogPage() {
           <p>No releases could be loaded from GitHub at this time.</p>
         ) : (
           <div className="space-y-10 pb-12 sm:space-y-16">
-            {models.map(({ release, grouped }, index) => {
+            {models.map(({ release, grouped, contributors }, index) => {
               const date = formatDate(release.published_at)
               const tag = release.tag_name
               const title = release.name || tag
@@ -136,6 +137,8 @@ export default async function ChangelogPage() {
                         })}
                       </div>
                     )}
+
+                    <ContributorsFooter contributors={contributors} />
                   </section>
                 </Fragment>
               )

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -118,6 +118,7 @@ export default async function ChangelogPage() {
                                       prNumber={item.prNumber}
                                       description={item.description}
                                       author={item.author}
+                                      breaking={item.breaking}
                                     />
                                   ) : (
                                     <CommitLine
@@ -125,6 +126,7 @@ export default async function ChangelogPage() {
                                       sha={item.sha}
                                       description={item.description}
                                       author={item.author}
+                                      breaking={item.breaking}
                                     />
                                   )
                                 )}

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -145,10 +145,15 @@ export default async function ChangelogPage() {
                           })}
                         </div>
                       )}
-                      <Heading as="h3" id={`${tag}-contributors`}>
-                        Contributors
-                      </Heading>
-                      <ContributorsFooter contributors={contributors} />
+
+                      {contributors.length > 0 && (
+                        <>
+                          <Heading as="h3" id={`${tag}-contributors`}>
+                            Contributors
+                          </Heading>
+                          <ContributorsFooter contributors={contributors} />
+                        </>
+                      )}
                     </section>
                   </Fragment>
                 )

--- a/packages/docs/src/app/docs/changelog/page.tsx
+++ b/packages/docs/src/app/docs/changelog/page.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/src/components/ai/page-actions'
 import { CommitLine } from '@/src/components/changelog/commit-line'
 import { ContributorsFooter } from '@/src/components/changelog/contributors-footer'
+import { Preamble } from '@/src/components/changelog/preamble'
 import { PullRequestLine } from '@/src/components/changelog/pr-line'
 import { github } from '@/src/lib/utils'
 import { Heading } from 'fumadocs-ui/components/heading'
@@ -65,84 +66,92 @@ export default async function ChangelogPage() {
           <p>No releases could be loaded from GitHub at this time.</p>
         ) : (
           <div className="space-y-10 pb-12 sm:space-y-16">
-            {models.map(({ release, grouped, contributors }, index) => {
-              const date = formatDate(release.published_at)
-              const tag = release.tag_name
-              const title = release.name || tag
+            {models.map(
+              ({ release, grouped, contributors, preamble }, index) => {
+                const date = formatDate(release.published_at)
+                const tag = release.tag_name
+                const title = release.name || tag
 
-              return (
-                <Fragment key={release.id}>
-                  {index > 0 && <hr className="border-border" />}
-                  <section>
-                    <H2 id={tag} className="mb-2">
-                      {title}
-                    </H2>
-                    <div className="not-prose text-fd-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
-                      {date && <span>Published on {date}</span>}
-                      {date && (
-                        <span
-                          aria-hidden
-                          className="text-fd-muted-foreground/60"
+                return (
+                  <Fragment key={release.id}>
+                    {index > 0 && <hr className="border-border" />}
+                    <section>
+                      <H2 id={tag} className="mb-2">
+                        {title}
+                      </H2>
+                      <div className="not-prose text-fd-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                        {date && <span>Published on {date}</span>}
+                        {date && (
+                          <span
+                            aria-hidden
+                            className="text-fd-muted-foreground/60"
+                          >
+                            •
+                          </span>
+                        )}
+                        <a
+                          href={release.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:underline"
                         >
-                          •
-                        </span>
-                      )}
-                      <a
-                        href={release.html_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:underline"
-                      >
-                        View on GitHub
-                      </a>
-                    </div>
-
-                    {grouped && (
-                      <div className="mt-6 space-y-6">
-                        {CATEGORIES.map(category => {
-                          const items = grouped[category]
-                          if (items.length === 0) return null
-
-                          return (
-                            <section key={category}>
-                              <Heading
-                                as="h3"
-                                id={`${tag}-${categorySlug(category)}`}
-                              >
-                                {category}
-                              </Heading>
-                              <ul className="not-prose mt-3 list-none space-y-2 pl-0">
-                                {items.map(item =>
-                                  item.source === 'squashedPR' ? (
-                                    <PullRequestLine
-                                      key={`pr-${item.prNumber}`}
-                                      prNumber={item.prNumber}
-                                      description={item.description}
-                                      author={item.author}
-                                      breaking={item.breaking}
-                                    />
-                                  ) : (
-                                    <CommitLine
-                                      key={`commit-${item.sha}`}
-                                      sha={item.sha}
-                                      description={item.description}
-                                      author={item.author}
-                                      breaking={item.breaking}
-                                    />
-                                  )
-                                )}
-                              </ul>
-                            </section>
-                          )
-                        })}
+                          View on GitHub
+                        </a>
                       </div>
-                    )}
 
-                    <ContributorsFooter contributors={contributors} />
-                  </section>
-                </Fragment>
-              )
-            })}
+                      {preamble && (
+                        <div className="mt-6">
+                          <Preamble markdown={preamble} />
+                        </div>
+                      )}
+
+                      {grouped && (
+                        <div className="mt-6 space-y-6">
+                          {CATEGORIES.map(category => {
+                            const items = grouped[category]
+                            if (items.length === 0) return null
+
+                            return (
+                              <section key={category}>
+                                <Heading
+                                  as="h3"
+                                  id={`${tag}-${categorySlug(category)}`}
+                                >
+                                  {category}
+                                </Heading>
+                                <ul className="not-prose mt-3 list-none space-y-2 pl-0">
+                                  {items.map(item =>
+                                    item.source === 'squashedPR' ? (
+                                      <PullRequestLine
+                                        key={`pr-${item.prNumber}`}
+                                        prNumber={item.prNumber}
+                                        description={item.description}
+                                        author={item.author}
+                                        breaking={item.breaking}
+                                      />
+                                    ) : (
+                                      <CommitLine
+                                        key={`commit-${item.sha}`}
+                                        sha={item.sha}
+                                        description={item.description}
+                                        author={item.author}
+                                        breaking={item.breaking}
+                                      />
+                                    )
+                                  )}
+                                </ul>
+                              </section>
+                            )
+                          })}
+                        </div>
+                      )}
+
+                      <ContributorsFooter contributors={contributors} />
+                    </section>
+                  </Fragment>
+                )
+              }
+            )}
             <div className="pt-2">
               <a
                 href={`https://github.com/${github.owner}/${github.repo}/releases`}

--- a/packages/docs/src/components/changelog/breaking-change-marker.tsx
+++ b/packages/docs/src/components/changelog/breaking-change-marker.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/src/lib/utils'
+import { TriangleAlert } from 'lucide-react'
+import type { ComponentProps } from 'react'
+
+// Inline accessible marker rendered beside a changelog line whose DTO `breaking`
+// flag is set. A real icon carrying an `aria-label` (not an emoji), so assistive
+// tech announces it as "Breaking change". There is deliberately no standalone
+// "Breaking changes" section on the page — that narrative role belongs to the
+// preamble; this marker only flags the individual change within its category
+// section. Shared by both line variants (`PullRequestLine`, `CommitLine`) so the
+// label and styling can't drift between them.
+export function BreakingChangeMarker({
+  className,
+  ...props
+}: Omit<ComponentProps<typeof TriangleAlert>, 'aria-label' | 'role'>) {
+  return (
+    <TriangleAlert
+      role="img"
+      aria-label="Breaking change"
+      className={cn('inline h-4 w-4 text-amber-500', className)}
+      {...props}
+    />
+  )
+}

--- a/packages/docs/src/components/changelog/change-description.tsx
+++ b/packages/docs/src/components/changelog/change-description.tsx
@@ -1,0 +1,19 @@
+import { parseCodeSpans } from 'scripts/lib/changelog-dto'
+
+// A change title rendered from its raw `description`: inline-code spans become
+// <code>, everything else plain text — via the shared span-parser, so the page
+// and the GitHub notes render the description identically. Shared by the PR and
+// direct-commit changelog lines.
+export function ChangeDescription({ description }: { description: string }) {
+  return (
+    <span className="font-medium group-hover:underline">
+      {parseCodeSpans(description).map((segment, index) =>
+        segment.code ? (
+          <code key={index}>{segment.value}</code>
+        ) : (
+          <span key={index}>{segment.value}</span>
+        )
+      )}
+    </span>
+  )
+}

--- a/packages/docs/src/components/changelog/commit-line.tsx
+++ b/packages/docs/src/components/changelog/commit-line.tsx
@@ -34,8 +34,11 @@ export function CommitLine({
         target="_blank"
         rel="noopener noreferrer"
       >
-        <span className="font-mono text-sm text-gray-500 sm:text-base sm:font-medium">
+        <span className="font-mono text-xs text-blue-500 sm:text-sm">
           {sha}
+        </span>
+        <span className="text-muted-foreground" role="presentation">
+          ·
         </span>
         <span className="font-medium group-hover:underline">
           {parseCodeSpans(description).map((segment, index) =>
@@ -46,10 +49,11 @@ export function CommitLine({
             )
           )}
         </span>
-      </a>{' '}
-      <span className="text-sm whitespace-nowrap text-gray-500">
-        <span className="sr-only">by</span> {author}
+      </a>
+      <span className="text-muted-foreground" role="presentation">
+        ·
       </span>
+      <span className="text-sm whitespace-nowrap text-gray-500">{author}</span>
     </li>
   )
 }

--- a/packages/docs/src/components/changelog/commit-line.tsx
+++ b/packages/docs/src/components/changelog/commit-line.tsx
@@ -1,3 +1,4 @@
+import { BreakingChangeMarker } from '@/src/components/changelog/breaking-change-marker'
 import { cn, github } from '@/src/lib/utils'
 import type { ComponentProps } from 'react'
 import { parseCodeSpans } from 'scripts/lib/changelog-dto'
@@ -6,6 +7,7 @@ export type CommitLineProps = Omit<ComponentProps<'li'>, 'children'> & {
   sha: string
   description: string
   author: string
+  breaking: boolean
 }
 
 // Presentational, fetch-free changelog line for a direct-commit change (a commit
@@ -19,11 +21,13 @@ export function CommitLine({
   sha,
   description,
   author,
+  breaking,
   className,
   ...props
 }: CommitLineProps) {
   return (
     <li className={cn('not-prose space-x-2', className)} {...props}>
+      {breaking && <BreakingChangeMarker />}
       <a
         href={`https://github.com/${github.owner}/${github.repo}/commit/${sha}`}
         className="group space-x-1.5"

--- a/packages/docs/src/components/changelog/commit-line.tsx
+++ b/packages/docs/src/components/changelog/commit-line.tsx
@@ -1,7 +1,7 @@
 import { BreakingChangeMarker } from '@/src/components/changelog/breaking-change-marker'
+import { ChangeDescription } from '@/src/components/changelog/change-description'
 import { cn, github } from '@/src/lib/utils'
 import type { ComponentProps } from 'react'
-import { parseCodeSpans } from 'scripts/lib/changelog-dto'
 
 export type CommitLineProps = Omit<ComponentProps<'li'>, 'children'> & {
   sha: string
@@ -40,15 +40,7 @@ export function CommitLine({
         <span className="text-muted-foreground" role="presentation">
           ·
         </span>
-        <span className="font-medium group-hover:underline">
-          {parseCodeSpans(description).map((segment, index) =>
-            segment.code ? (
-              <code key={index}>{segment.value}</code>
-            ) : (
-              <span key={index}>{segment.value}</span>
-            )
-          )}
-        </span>
+        <ChangeDescription description={description} />
       </a>
       <span className="text-muted-foreground" role="presentation">
         ·

--- a/packages/docs/src/components/changelog/commit-line.tsx
+++ b/packages/docs/src/components/changelog/commit-line.tsx
@@ -1,0 +1,51 @@
+import { cn, github } from '@/src/lib/utils'
+import type { ComponentProps } from 'react'
+import { parseCodeSpans } from 'scripts/lib/changelog-dto'
+
+export type CommitLineProps = Omit<ComponentProps<'li'>, 'children'> & {
+  sha: string
+  description: string
+  author: string
+}
+
+// Presentational, fetch-free changelog line for a direct-commit change (a commit
+// landed with no PR — a hotfix or revert). The counterpart to `PullRequestLine`:
+// the commit link is derived from its SHA, the title from the raw `description`
+// (code spans via the shared span-parser, identical to the GitHub notes), and the
+// author is the git author *name* rendered as plain text — not a GitHub login, so
+// no avatar and no profile link (unlike a squashed PR's `GitHubProfile`). Renders
+// the direct commits that the old markdown-reparsing page silently dropped.
+export function CommitLine({
+  sha,
+  description,
+  author,
+  className,
+  ...props
+}: CommitLineProps) {
+  return (
+    <li className={cn('not-prose space-x-2', className)} {...props}>
+      <a
+        href={`https://github.com/${github.owner}/${github.repo}/commit/${sha}`}
+        className="group space-x-1.5"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className="font-mono text-sm text-gray-500 sm:text-base sm:font-medium">
+          {sha}
+        </span>
+        <span className="font-medium group-hover:underline">
+          {parseCodeSpans(description).map((segment, index) =>
+            segment.code ? (
+              <code key={index}>{segment.value}</code>
+            ) : (
+              <span key={index}>{segment.value}</span>
+            )
+          )}
+        </span>
+      </a>{' '}
+      <span className="text-sm whitespace-nowrap text-gray-500">
+        <span className="sr-only">by</span> {author}
+      </span>
+    </li>
+  )
+}

--- a/packages/docs/src/components/changelog/contributors-footer.tsx
+++ b/packages/docs/src/components/changelog/contributors-footer.tsx
@@ -13,9 +13,7 @@ const formatter = new Intl.ListFormat('en-US', { type: 'conjunction' })
 
 // Build the human-readable contributors summary purely from GitHub logins (no
 // API call). Lists everyone when the count is small, otherwise names the first
-// few and collapses the rest: "a, b, c and 4 other contributors". Returns null
-// for an empty list, the single "no footer" signal the component branches on.
-// Pure and exported so it can be unit-tested directly once docs has a runner.
+// few and collapses the rest as "a, b, c, and 4 other contributors".
 export function formatContributorsSummary(
   contributors: readonly string[]
 ): string | null {
@@ -48,7 +46,12 @@ export function ContributorsFooter({ contributors }: ContributorsFooterProps) {
     <footer className="not-prose mt-6 flex flex-wrap items-center gap-x-3 gap-y-2">
       <ul className="flex items-center pl-0">
         {shown.map((login, index) => (
-          <li key={login} className={cn('list-none', index > 0 && '-ml-2')}>
+          // Key by index too to handle hand-edited non-unique logins
+          // (not enforced by the DTO schema)
+          <li
+            key={`${login}-${index}`}
+            className={cn('list-none', index > 0 && '-ml-2')}
+          >
             <a
               href={`https://github.com/${login}`}
               target="_blank"

--- a/packages/docs/src/components/changelog/contributors-footer.tsx
+++ b/packages/docs/src/components/changelog/contributors-footer.tsx
@@ -1,8 +1,5 @@
 import { cn } from '@/src/lib/utils'
 
-// The locale used across the docs site for `Intl` formatting (mirrors stats).
-const LOCALE = 'en-GB'
-
 // Name at most this many contributors before collapsing the rest into an
 // "N other contributors" tail.
 const MAX_NAMED_CONTRIBUTORS = 3
@@ -10,6 +7,9 @@ const MAX_NAMED_CONTRIBUTORS = 3
 // Show at most this many overlapping avatars before a "+N" bubble; avatars are a
 // denser surface than the named summary, so this cap is higher.
 const MAX_AVATARS = 8
+
+// Needs en-US for the Oxford comma, seriously??
+const formatter = new Intl.ListFormat('en-US', { type: 'conjunction' })
 
 // Build the human-readable contributors summary purely from GitHub logins (no
 // API call). Lists everyone when the count is small, otherwise names the first
@@ -20,7 +20,6 @@ export function formatContributorsSummary(
   contributors: readonly string[]
 ): string | null {
   if (contributors.length === 0) return null
-  const formatter = new Intl.ListFormat(LOCALE, { type: 'conjunction' })
   // Collapsing is only worth it past a single hidden name — "and 1 other
   // contributor" reads longer than just naming them.
   if (contributors.length <= MAX_NAMED_CONTRIBUTORS + 1) {
@@ -75,7 +74,7 @@ export function ContributorsFooter({ contributors }: ContributorsFooterProps) {
           </li>
         )}
       </ul>
-      <p className="text-fd-muted-foreground text-sm">{summary}</p>
+      <p className="text-md">{summary}</p>
     </footer>
   )
 }

--- a/packages/docs/src/components/changelog/contributors-footer.tsx
+++ b/packages/docs/src/components/changelog/contributors-footer.tsx
@@ -1,0 +1,81 @@
+import { cn } from '@/src/lib/utils'
+
+// The locale used across the docs site for `Intl` formatting (mirrors stats).
+const LOCALE = 'en-GB'
+
+// Name at most this many contributors before collapsing the rest into an
+// "N other contributors" tail.
+const MAX_NAMED_CONTRIBUTORS = 3
+
+// Show at most this many overlapping avatars before a "+N" bubble; avatars are a
+// denser surface than the named summary, so this cap is higher.
+const MAX_AVATARS = 8
+
+// Build the human-readable contributors summary purely from GitHub logins (no
+// API call). Lists everyone when the count is small, otherwise names the first
+// few and collapses the rest: "a, b, c and 4 other contributors". Returns null
+// for an empty list, the single "no footer" signal the component branches on.
+// Pure and exported so it can be unit-tested directly once docs has a runner.
+export function formatContributorsSummary(
+  contributors: readonly string[]
+): string | null {
+  if (contributors.length === 0) return null
+  const formatter = new Intl.ListFormat(LOCALE, { type: 'conjunction' })
+  // Collapsing is only worth it past a single hidden name — "and 1 other
+  // contributor" reads longer than just naming them.
+  if (contributors.length <= MAX_NAMED_CONTRIBUTORS + 1) {
+    return formatter.format(contributors)
+  }
+  const named = contributors.slice(0, MAX_NAMED_CONTRIBUTORS)
+  const others = contributors.length - MAX_NAMED_CONTRIBUTORS
+  return formatter.format([...named, `${others} other contributors`])
+}
+
+export type ContributorsFooterProps = {
+  contributors: readonly string[]
+}
+
+// Per-release contributors credit: a GitHub-style row of overlapping avatars
+// (linking to each profile) plus an `Intl.ListFormat` summary, built entirely
+// from the DTO's `contributors` logins — zero GitHub API calls (avatars come
+// straight from `github.com/{login}.png`). Renders nothing when the release
+// credits no one.
+export function ContributorsFooter({ contributors }: ContributorsFooterProps) {
+  const summary = formatContributorsSummary(contributors)
+  if (summary === null) return null
+  const shown = contributors.slice(0, MAX_AVATARS)
+  const overflow = contributors.length - shown.length
+  return (
+    <footer className="not-prose mt-6 flex flex-wrap items-center gap-x-3 gap-y-2">
+      <ul className="flex items-center pl-0">
+        {shown.map((login, index) => (
+          <li key={login} className={cn('list-none', index > 0 && '-ml-2')}>
+            <a
+              href={`https://github.com/${login}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={login}
+            >
+              <img
+                src={`https://github.com/${login}.png`}
+                alt={`${login}'s GitHub profile`}
+                width={24}
+                height={24}
+                loading="lazy"
+                className="ring-fd-background block size-6 rounded-full ring-2"
+              />
+            </a>
+          </li>
+        ))}
+        {overflow > 0 && (
+          <li className="-ml-2 list-none">
+            <span className="ring-fd-background bg-fd-muted text-fd-muted-foreground flex size-6 items-center justify-center rounded-full text-xs font-medium ring-2">
+              +{overflow}
+            </span>
+          </li>
+        )}
+      </ul>
+      <p className="text-fd-muted-foreground text-sm">{summary}</p>
+    </footer>
+  )
+}

--- a/packages/docs/src/components/changelog/pr-line.tsx
+++ b/packages/docs/src/components/changelog/pr-line.tsx
@@ -35,10 +35,11 @@ export function PullRequestLine({
         target="_blank"
         rel="noopener noreferrer"
       >
-        <span className="text-sm text-gray-500 tabular-nums sm:text-base sm:font-medium">
+        <span className="text-sm text-blue-500 tabular-nums sm:text-base">
           <span aria-label="number">#</span>
           {prNumber}
         </span>
+        <span className="text-muted-foreground">·</span>
         <span className="font-medium group-hover:underline">
           {parseCodeSpans(description).map((segment, index) =>
             segment.code ? (
@@ -51,7 +52,10 @@ export function PullRequestLine({
       </a>
       {author && (
         <>
-          {' '}
+          <span className="text-muted-foreground" role="presentation">
+            ·
+          </span>
+          <span className="sr-only">by </span>
           <GitHubProfile handle={author} />
         </>
       )}

--- a/packages/docs/src/components/changelog/pr-line.tsx
+++ b/packages/docs/src/components/changelog/pr-line.tsx
@@ -1,3 +1,4 @@
+import { BreakingChangeMarker } from '@/src/components/changelog/breaking-change-marker'
 import { GitHubProfile } from '@/src/components/github-profile'
 import { cn, github } from '@/src/lib/utils'
 import type { ComponentProps } from 'react'
@@ -7,6 +8,7 @@ export type PullRequestLineProps = Omit<ComponentProps<'li'>, 'children'> & {
   prNumber: number
   description: string
   author: string | null
+  breaking: boolean
 }
 
 // Presentational, fetch-free changelog line for a squashed-PR change. Every
@@ -20,11 +22,13 @@ export function PullRequestLine({
   prNumber,
   description,
   author,
+  breaking,
   className,
   ...props
 }: PullRequestLineProps) {
   return (
     <li className={cn('not-prose space-x-2', className)} {...props}>
+      {breaking && <BreakingChangeMarker />}
       <a
         href={`https://github.com/${github.owner}/${github.repo}/pull/${prNumber}`}
         className="group space-x-1.5"

--- a/packages/docs/src/components/changelog/pr-line.tsx
+++ b/packages/docs/src/components/changelog/pr-line.tsx
@@ -1,8 +1,8 @@
 import { BreakingChangeMarker } from '@/src/components/changelog/breaking-change-marker'
+import { ChangeDescription } from '@/src/components/changelog/change-description'
 import { GitHubProfile } from '@/src/components/github-profile'
 import { cn, github } from '@/src/lib/utils'
 import type { ComponentProps } from 'react'
-import { parseCodeSpans } from 'scripts/lib/changelog-dto'
 
 export type PullRequestLineProps = Omit<ComponentProps<'li'>, 'children'> & {
   prNumber: number
@@ -40,15 +40,7 @@ export function PullRequestLine({
           {prNumber}
         </span>
         <span className="text-muted-foreground">·</span>
-        <span className="font-medium group-hover:underline">
-          {parseCodeSpans(description).map((segment, index) =>
-            segment.code ? (
-              <code key={index}>{segment.value}</code>
-            ) : (
-              <span key={index}>{segment.value}</span>
-            )
-          )}
-        </span>
+        <ChangeDescription description={description} />
       </a>
       {author && (
         <>

--- a/packages/docs/src/components/changelog/pr-line.tsx
+++ b/packages/docs/src/components/changelog/pr-line.tsx
@@ -1,0 +1,56 @@
+import { GitHubProfile } from '@/src/components/github-profile'
+import { cn, github } from '@/src/lib/utils'
+import type { ComponentProps } from 'react'
+import { parseCodeSpans } from 'scripts/lib/changelog-dto'
+
+export type PullRequestLineProps = Omit<ComponentProps<'li'>, 'children'> & {
+  prNumber: number
+  description: string
+  author: string | null
+}
+
+// Presentational, fetch-free changelog line for a squashed-PR change. Every
+// value is derived statically from the DTO — the PR link from its number, the
+// title from the raw `description` (code spans rendered via the shared
+// span-parser, identical to the GitHub notes), the author from `GitHubProfile`
+// (avatar from `github.com/{login}.png`, no API call). Distinct from the
+// self-fetching `ui/pr-line` still used by the blog: the changelog page makes
+// zero GitHub API calls.
+export function PullRequestLine({
+  prNumber,
+  description,
+  author,
+  className,
+  ...props
+}: PullRequestLineProps) {
+  return (
+    <li className={cn('not-prose space-x-2', className)} {...props}>
+      <a
+        href={`https://github.com/${github.owner}/${github.repo}/pull/${prNumber}`}
+        className="group space-x-1.5"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className="text-sm text-gray-500 tabular-nums sm:text-base sm:font-medium">
+          <span aria-label="number">#</span>
+          {prNumber}
+        </span>
+        <span className="font-medium group-hover:underline">
+          {parseCodeSpans(description).map((segment, index) =>
+            segment.code ? (
+              <code key={index}>{segment.value}</code>
+            ) : (
+              <span key={index}>{segment.value}</span>
+            )
+          )}
+        </span>
+      </a>
+      {author && (
+        <>
+          {' '}
+          <GitHubProfile handle={author} />
+        </>
+      )}
+    </li>
+  )
+}

--- a/packages/docs/src/components/changelog/preamble.tsx
+++ b/packages/docs/src/components/changelog/preamble.tsx
@@ -1,0 +1,30 @@
+import { useMDXComponents } from '@/mdx-components'
+import { rehypeCodeOptions } from '@/rehype-code.config'
+import { Markdown } from 'fumadocs-core/content'
+import { rehypeCode, remarkHeading } from 'fumadocs-core/mdx-plugins'
+import remarkSmartypants from 'remark-smartypants'
+
+export type PreambleProps = {
+  markdown: string
+}
+
+// The docs-only preamble: maintainer-authored markdown carried in the release
+// body's hidden `<changelog:preamble>` block, surfaced above the change list.
+// Rendered through the same remark → hast → jsx pipeline (fumadocs' `Markdown`)
+// and MDX component set as the rest of the docs, so links, code fences and
+// callouts look identical to authored docs prose — and, unlike the change list,
+// it keeps the surrounding `DocsBody` prose styles (no `not-prose`). This is the
+// ONLY body content docs renders: the visible GitHub notes prose is never shown
+// here. The caller renders nothing when the preamble is empty/whitespace (the
+// codec already resolves that to null).
+export function Preamble({ markdown }: PreambleProps) {
+  return (
+    <Markdown
+      components={useMDXComponents()}
+      remarkPlugins={[remarkSmartypants, remarkHeading]}
+      rehypePlugins={[[rehypeCode, rehypeCodeOptions]]}
+    >
+      {markdown}
+    </Markdown>
+  )
+}

--- a/packages/docs/src/components/github-profile.tsx
+++ b/packages/docs/src/components/github-profile.tsx
@@ -1,4 +1,6 @@
-type GitHubProfileProps = {
+import type { ComponentProps } from 'react'
+
+type GitHubProfileProps = ComponentProps<'span'> & {
   handle: string
   name?: string
   url?: string
@@ -7,10 +9,11 @@ type GitHubProfileProps = {
 export function GitHubProfile({
   handle,
   name = handle,
-  url = `https://github.com/${handle}`
+  url = `https://github.com/${handle}`,
+  ...props
 }: GitHubProfileProps) {
   return (
-    <span>
+    <span {...props}>
       <img
         src={`https://github.com/${handle}.png`}
         alt={`${name}'s avatar`}

--- a/packages/docs/src/schemas/changelog-dto.artifact.ts
+++ b/packages/docs/src/schemas/changelog-dto.artifact.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from 'node:url'
+import { CHANGELOG_DTO_SCHEMA_URL } from 'scripts/lib/changelog-dto'
+
+// Absolute path of the committed JSON Schema artifact, shared by the generator
+// that writes it and the drift test that guards it so the two can't disagree
+// about where it lives. It is served as a static file at its own `$schema` URL:
+// Next serves `public/` at the site root, so the URL pathname maps 1:1 to a
+// file under `public/`. Deriving the path from the URL ties the served file,
+// the generator, and the test together — change the URL and the path follows.
+export const CHANGELOG_SCHEMA_ARTIFACT_PATH = fileURLToPath(
+  new URL(
+    `../../public${new URL(CHANGELOG_DTO_SCHEMA_URL).pathname}`,
+    import.meta.url
+  )
+)

--- a/packages/docs/src/schemas/changelog-dto.gen.ts
+++ b/packages/docs/src/schemas/changelog-dto.gen.ts
@@ -1,0 +1,20 @@
+#! /usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { styleText } from 'node:util'
+import { changelogJsonSchema } from 'scripts/lib/changelog-dto'
+import { CHANGELOG_SCHEMA_ARTIFACT_PATH } from './changelog-dto.artifact.ts'
+
+// Regenerate the committed JSON Schema artifact from the Zod SSOT. Throwaway by
+// design: run by hand only when the changelog DTO schema changes
+// (`pnpm --filter docs gen:schema`). The drift test fails the build until it is
+// re-run, so the published schema and the codec can never silently diverge.
+
+await mkdir(dirname(CHANGELOG_SCHEMA_ARTIFACT_PATH), { recursive: true })
+await writeFile(
+  CHANGELOG_SCHEMA_ARTIFACT_PATH,
+  JSON.stringify(changelogJsonSchema(), null, 2) + '\n'
+)
+
+console.log(styleText('green', `Wrote ${CHANGELOG_SCHEMA_ARTIFACT_PATH}`))

--- a/packages/docs/src/schemas/changelog-dto.test.ts
+++ b/packages/docs/src/schemas/changelog-dto.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { changelogJsonSchema } from 'scripts/lib/changelog-dto'
+import { describe, expect, it } from 'vitest'
+import { CHANGELOG_SCHEMA_ARTIFACT_PATH } from './changelog-dto.artifact.ts'
+
+describe('changelog DTO JSON Schema artifact', () => {
+  // Drift guard: the committed artifact must equal what the Zod SSOT generates
+  // right now. Any schema change not re-exported (via `pnpm --filter docs
+  // gen:schema`) fails here, so the published schema can never silently
+  // disagree with the codec that serializes and parses the DTO.
+  it('matches the schema generated from the Zod SSOT', () => {
+    const committed: unknown = JSON.parse(
+      readFileSync(CHANGELOG_SCHEMA_ARTIFACT_PATH, 'utf8')
+    )
+    expect(changelogJsonSchema()).toEqual(committed)
+  })
+})

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Scope to source tests only. Vitest's defaults don't exclude `.next/`, and
+    // the registry generates `.ts` items — restricting the glob keeps the runner
+    // off build output and codegen.
+    include: ['src/**/*.test.ts']
+  }
+})

--- a/packages/scripts/lib/change.ts
+++ b/packages/scripts/lib/change.ts
@@ -1,0 +1,55 @@
+// The `change` domain — the single source of truth for the atomic unit of a
+// release, shared by the discovery engine (which produces changes), the release
+// notes (which render them), and the changelog codec (which serializes them to
+// the DTO and parses them back). The Zod schema is authoritative; the types are
+// inferred from it, so a field added here flows to every surface.
+//
+// Pure and IO-free (only `zod`): the codec imports it without dragging in
+// git/octokit, so any consumer of the codec stays IO-free too. Keep it that way.
+
+import { z } from 'zod'
+
+// A change sourced from a squashed pull request (the common case)
+// identity is the PR number, `description` is the PR title as prose,
+// `author` is the GitHub login (or null for a deleted account), and it
+// carries the issue numbers it closes. Rendered as `#123 - …, by @login`.
+export const squashedPRChangeSchema = z.object({
+  source: z.literal('squashedPR'),
+  prNumber: z.number().int().positive(),
+  type: z.string().nullable(), // conventional-commit type, or null when none
+  breaking: z.boolean(),
+  description: z.string(), // the PR title, not the commit message's description
+  author: z.string().nullable(), // GitHub login, or null for a deleted account
+  closingIssues: z.array(z.number().int().positive())
+})
+
+// A change sourced from a direct commit with no PR (rare: a hotfix, a revert) —
+// identity is the 8-char commit SHA, `description` is the commit subject as
+// prose, `author` is the git author name as prose (not a GitHub login).
+// Rendered as `abcd1234 - …, by Name`.
+export const directCommitChangeSchema = z.object({
+  source: z.literal('directCommit'),
+  sha: z.string(),
+  type: z.string().nullable(),
+  breaking: z.boolean(),
+  description: z.string(), // the commit subject
+  author: z.string()
+})
+
+// In both, `type` and `breaking` come from the commit message, never a PR title:
+// the source decides only identity, prose, credited author, and closing issues.
+export const changeSchema = z.discriminatedUnion('source', [
+  squashedPRChangeSchema,
+  directCommitChangeSchema
+])
+
+// A release's full change list plus the humans to credit (GitHub logins.
+export const releaseChangesSchema = z.object({
+  changes: z.array(changeSchema),
+  contributors: z.array(z.string())
+})
+
+export type SquashedPRChange = z.infer<typeof squashedPRChangeSchema>
+export type DirectCommitChange = z.infer<typeof directCommitChangeSchema>
+export type Change = z.infer<typeof changeSchema>
+export type ReleaseChanges = z.infer<typeof releaseChangesSchema>

--- a/packages/scripts/lib/change.ts
+++ b/packages/scripts/lib/change.ts
@@ -9,31 +9,37 @@
 
 import { z } from 'zod'
 
-// A change sourced from a squashed pull request (the common case)
+const githubLoginSchema = z
+  .string()
+  .regex(/^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$/)
+
+// A change description (a PR title or a commit subject): non-empty and bounded.
+const descriptionSchema = z.string().min(1).max(500)
+
+const shaSchema = z.string().regex(/^[0-9a-f]{7,40}$/)
+
+// A change sourced from a squashed pull request (the common case):
 // identity is the PR number, `description` is the PR title as prose,
 // `author` is the GitHub login (or null for a deleted account), and it
 // carries the issue numbers it closes. Rendered as `#123 - …, by @login`.
-export const squashedPRChangeSchema = z.object({
+export const squashedPRChangeSchema = z.strictObject({
   source: z.literal('squashedPR'),
   prNumber: z.number().int().positive(),
   type: z.string().nullable(), // conventional-commit type, or null when none
   breaking: z.boolean(),
-  description: z.string(), // the PR title, not the commit message's description
-  author: z.string().nullable(), // GitHub login, or null for a deleted account
+  description: descriptionSchema, // the PR title
+  author: githubLoginSchema.nullable(), // null for a deleted account
   closingIssues: z.array(z.number().int().positive())
 })
 
-// A change sourced from a direct commit with no PR (rare: a hotfix, a revert) —
-// identity is the 8-char commit SHA, `description` is the commit subject as
-// prose, `author` is the git author name as prose (not a GitHub login).
-// Rendered as `abcd1234 - …, by Name`.
-export const directCommitChangeSchema = z.object({
+// A change sourced from a direct commit with no PR (rare: a hotfix, a revert)
+export const directCommitChangeSchema = z.strictObject({
   source: z.literal('directCommit'),
-  sha: z.string(),
+  sha: shaSchema,
   type: z.string().nullable(),
   breaking: z.boolean(),
-  description: z.string(), // the commit subject
-  author: z.string()
+  description: descriptionSchema, // the commit subject
+  author: z.string().min(1) // git author name (free prose, not a login)
 })
 
 // In both, `type` and `breaking` come from the commit message, never a PR title:
@@ -43,10 +49,10 @@ export const changeSchema = z.discriminatedUnion('source', [
   directCommitChangeSchema
 ])
 
-// A release's full change list plus the humans to credit (GitHub logins.
-export const releaseChangesSchema = z.object({
+// A release's full change list plus the humans to credit (GitHub logins).
+export const releaseChangesSchema = z.strictObject({
   changes: z.array(changeSchema),
-  contributors: z.array(z.string())
+  contributors: z.array(githubLoginSchema)
 })
 
 export type SquashedPRChange = z.infer<typeof squashedPRChangeSchema>

--- a/packages/scripts/lib/changelog-dto.test.ts
+++ b/packages/scripts/lib/changelog-dto.test.ts
@@ -242,6 +242,31 @@ describe('preamble extraction', () => {
       'See the [migration guide](/docs/migrations/v2.9).'
     )
   })
+
+  // Slice 5: the maintainer authors a filled preamble (multi-line markdown with
+  // a code fence) in the draft; docs renders it above the change list. The raw
+  // markdown — newlines, blank lines and the ``` fence intact — must come back
+  // verbatim (trimmed), since the page renders exactly this string.
+  it('extracts a multi-line preamble with a code fence verbatim', () => {
+    const preamble = [
+      'nuqs v2.9 changes parser error handling — see the [migration guide](/docs/migrations/v2.9).',
+      '',
+      '```ts',
+      'const value = parseAsInteger.parse(input) // null on bad input, no longer throws',
+      '```'
+    ].join('\n')
+    const body = [
+      '<!--',
+      '<changelog:preamble>',
+      preamble,
+      '</changelog:preamble>',
+      '<changelog:dto>',
+      JSON.stringify(expectedDto),
+      '</changelog:dto>',
+      '-->'
+    ].join('\n')
+    expect(parseChangelogComment(body)?.preamble).toBe(preamble)
+  })
 })
 
 describe('groupChangesByCategory', () => {

--- a/packages/scripts/lib/changelog-dto.test.ts
+++ b/packages/scripts/lib/changelog-dto.test.ts
@@ -281,6 +281,71 @@ describe('groupChangesByCategory', () => {
       'untyped commit'
     ])
   })
+
+  // Slice 2: a squashed PR and a direct commit sharing a category must coexist
+  // in one section, PRs first (ascending number), then commits in their given
+  // (discovery oldest-first) order — the ordering the page now renders directly.
+  it('coexists squashed PRs and direct commits in one category, in the correct order', () => {
+    const changes: Change[] = [
+      {
+        source: 'directCommit',
+        sha: 'aaaa1111',
+        type: 'fix',
+        breaking: false,
+        description: 'first commit',
+        author: 'Alice'
+      },
+      {
+        source: 'squashedPR',
+        prNumber: 9,
+        type: 'fix',
+        breaking: false,
+        description: 'pr nine',
+        author: null,
+        closingIssues: []
+      },
+      {
+        source: 'directCommit',
+        sha: 'bbbb2222',
+        type: 'fix',
+        breaking: false,
+        description: 'second commit',
+        author: 'Bob'
+      },
+      {
+        source: 'squashedPR',
+        prNumber: 3,
+        type: 'fix',
+        breaking: false,
+        description: 'pr three',
+        author: null,
+        closingIssues: []
+      }
+    ]
+    expect(
+      groupChangesByCategory(changes)['Bug fixes'].map(c => c.description)
+    ).toEqual(['pr three', 'pr nine', 'first commit', 'second commit'])
+  })
+
+  // Grouping must preserve every direct commit by identity (no dedup/collapse),
+  // so the page can render each — keyed on its distinct `sha` — instead of
+  // dropping any (the v2.8.10-beta.1 class of seven untyped direct commits).
+  it('preserves every direct commit by distinct sha when grouping', () => {
+    const shas = Array.from({ length: 7 }, (_, index) => `c0ffee0${index}`)
+    const changes: Change[] = shas.map(sha => ({
+      source: 'directCommit',
+      sha,
+      type: null,
+      breaking: false,
+      description: `direct commit ${sha}`,
+      author: 'François Best'
+    }))
+    expect(
+      groupChangesByCategory(changes)['Other changes'].map(c =>
+        c.source === 'directCommit' ? c.sha : c.prNumber
+      )
+    ).toEqual(shas)
+  })
 })
 
 describe('stripChangelogComment', () => {

--- a/packages/scripts/lib/changelog-dto.test.ts
+++ b/packages/scripts/lib/changelog-dto.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHANGELOG_DTO_SCHEMA_URL,
+  type Change,
+  type ChangelogDTO,
+  type ReleaseChanges,
+  groupChangesByCategory,
+  parseChangelogComment,
+  parseCodeSpans,
+  renderChangelogComment,
+  stripChangelogComment,
+  toChangelogDTO
+} from './changelog-dto.ts'
+
+// A full release payload exercising both change variants. The DTO is this exact
+// shape plus a `$schema` tag — domain and wire no longer diverge.
+const release: ReleaseChanges = {
+  changes: [
+    {
+      source: 'squashedPR',
+      prNumber: 1450,
+      type: 'feat',
+      breaking: true,
+      description: 'return null on invalid parser input',
+      author: 'franky47',
+      closingIssues: [1442, 1443]
+    },
+    {
+      source: 'directCommit',
+      sha: 'a1b2c3d4',
+      type: null,
+      breaking: false,
+      description: 'fix typo in funding link',
+      author: 'François Best'
+    }
+  ],
+  contributors: ['contributorA', 'contributorB']
+}
+
+const expectedDto: ChangelogDTO = {
+  $schema: CHANGELOG_DTO_SCHEMA_URL,
+  ...release
+}
+
+describe('parseCodeSpans', () => {
+  it('returns no segments for an empty string', () => {
+    expect(parseCodeSpans('')).toEqual([])
+  })
+
+  it('returns a single text segment when there are no backticks', () => {
+    expect(parseCodeSpans('plain title')).toEqual([
+      { code: false, value: 'plain title' }
+    ])
+  })
+
+  it('splits a balanced backtick pair into a code segment', () => {
+    expect(parseCodeSpans('Add `useQueryState` hook')).toEqual([
+      { code: false, value: 'Add ' },
+      { code: true, value: 'useQueryState' },
+      { code: false, value: ' hook' }
+    ])
+  })
+
+  it('handles multiple code spans', () => {
+    expect(parseCodeSpans('Replace `foo` with `bar`')).toEqual([
+      { code: false, value: 'Replace ' },
+      { code: true, value: 'foo' },
+      { code: false, value: ' with ' },
+      { code: true, value: 'bar' }
+    ])
+  })
+
+  it('handles code at the start and end', () => {
+    expect(parseCodeSpans('`nuqs` rocks `hard`')).toEqual([
+      { code: true, value: 'nuqs' },
+      { code: false, value: ' rocks ' },
+      { code: true, value: 'hard' }
+    ])
+  })
+
+  it('leaves a lone (unbalanced) backtick as literal text', () => {
+    expect(parseCodeSpans('a lone ` backtick')).toEqual([
+      { code: false, value: 'a lone ` backtick' }
+    ])
+  })
+})
+
+describe('toChangelogDTO', () => {
+  it('wraps a ReleaseChanges with the $schema tag (no per-change projection)', () => {
+    expect(toChangelogDTO(release)).toEqual(expectedDto)
+  })
+})
+
+describe('renderChangelogComment / parseChangelogComment round-trip', () => {
+  it('serializes to one HTML comment and parses back to an equal DTO', () => {
+    const comment = renderChangelogComment(release)
+    expect(comment.startsWith('<!--')).toBe(true)
+    expect(comment.trimEnd().endsWith('-->')).toBe(true)
+    const parsed = parseChangelogComment(comment)
+    expect(parsed).toEqual({ preamble: null, dto: expectedDto })
+  })
+
+  it('round-trips when the comment is embedded in a larger release body', () => {
+    const body = `## Features\n\n- #1450 - return null\n\n${renderChangelogComment(release)}`
+    expect(parseChangelogComment(body)).toEqual({
+      preamble: null,
+      dto: expectedDto
+    })
+  })
+
+  it('emits an empty preamble stub with the guiding hint line', () => {
+    const comment = renderChangelogComment(release)
+    expect(comment).toContain('<changelog:preamble></changelog:preamble>')
+    expect(comment).toContain("docs' changelog page")
+  })
+})
+
+describe('escaping', () => {
+  it('round-trips a description containing the comment terminator without producing a literal "-->"', () => {
+    const evil: ReleaseChanges = {
+      changes: [
+        {
+          source: 'directCommit',
+          sha: 'deadbeef',
+          type: null,
+          breaking: false,
+          description: 'guard against `-->` early termination',
+          author: 'Tester'
+        }
+      ],
+      contributors: []
+    }
+    const comment = renderChangelogComment(evil)
+    // The only "-->" in the whole comment is the closing terminator (last 3 chars).
+    expect(comment.indexOf('-->')).toBe(comment.length - 3)
+    const parsed = parseChangelogComment(comment)
+    expect(parsed?.dto.changes[0]).toMatchObject({
+      description: 'guard against `-->` early termination'
+    })
+  })
+
+  it('round-trips a description containing a literal closing DTO tag', () => {
+    const evil: ReleaseChanges = {
+      changes: [
+        {
+          source: 'directCommit',
+          sha: 'cafed00d',
+          type: null,
+          breaking: false,
+          description: 'parser must survive </changelog:dto> in prose',
+          author: 'Tester'
+        }
+      ],
+      contributors: []
+    }
+    const parsed = parseChangelogComment(renderChangelogComment(evil))
+    expect(parsed?.dto.changes[0]).toMatchObject({
+      description: 'parser must survive </changelog:dto> in prose'
+    })
+  })
+
+  it('keeps backticks literal (raw) in the DTO, never rendering presentation HTML', () => {
+    const withCode: ReleaseChanges = {
+      changes: [
+        {
+          source: 'directCommit',
+          sha: '0badf00d',
+          type: null,
+          breaking: false,
+          description: 'backticks `demo` stay raw',
+          author: 'Tester'
+        }
+      ],
+      contributors: []
+    }
+    const comment = renderChangelogComment(withCode)
+    expect(comment).not.toContain('<code>')
+    const parsed = parseChangelogComment(comment)
+    expect(parsed?.dto.changes[0]).toMatchObject({
+      description: 'backticks `demo` stay raw'
+    })
+  })
+})
+
+describe('parseChangelogComment degrade signals', () => {
+  it('returns null for a null body', () => {
+    expect(parseChangelogComment(null)).toBeNull()
+  })
+
+  it('returns null when there is no changelog comment', () => {
+    expect(parseChangelogComment('## Features\n\n- #1 - a feature')).toBeNull()
+  })
+
+  it('returns null for malformed JSON inside the dto tags', () => {
+    const body = '<!--\n<changelog:dto>\n{ not json ]\n</changelog:dto>\n-->'
+    expect(parseChangelogComment(body)).toBeNull()
+  })
+
+  it('returns null for schema-invalid JSON (missing required field)', () => {
+    const body = `<!--\n<changelog:dto>\n${JSON.stringify({
+      $schema: CHANGELOG_DTO_SCHEMA_URL,
+      changes: [{ source: 'squashedPR', prNumber: 1 }]
+    })}\n</changelog:dto>\n-->`
+    expect(parseChangelogComment(body)).toBeNull()
+  })
+
+  it('returns null for an unrecognized ($schema v2) URL', () => {
+    const body = `<!--\n<changelog:dto>\n${JSON.stringify({
+      $schema: 'https://nuqs.dev/schemas/changelog-dto.v2.json',
+      changes: [],
+      contributors: []
+    })}\n</changelog:dto>\n-->`
+    expect(parseChangelogComment(body)).toBeNull()
+  })
+})
+
+describe('preamble extraction', () => {
+  it('resolves an empty/whitespace preamble to null', () => {
+    const body = [
+      '<!--',
+      '<changelog:preamble>   </changelog:preamble>',
+      '<changelog:dto>',
+      JSON.stringify(expectedDto),
+      '</changelog:dto>',
+      '-->'
+    ].join('\n')
+    expect(parseChangelogComment(body)?.preamble).toBeNull()
+  })
+
+  it('returns the trimmed markdown of a non-empty preamble', () => {
+    const body = [
+      '<!--',
+      '<changelog:preamble>',
+      'See the [migration guide](/docs/migrations/v2.9).',
+      '</changelog:preamble>',
+      '<changelog:dto>',
+      JSON.stringify(expectedDto),
+      '</changelog:dto>',
+      '-->'
+    ].join('\n')
+    expect(parseChangelogComment(body)?.preamble).toBe(
+      'See the [migration guide](/docs/migrations/v2.9).'
+    )
+  })
+})
+
+describe('groupChangesByCategory', () => {
+  it('groups changes by their derived category', () => {
+    const changes: Change[] = [
+      {
+        source: 'squashedPR',
+        prNumber: 2,
+        type: 'fix',
+        breaking: false,
+        description: 'a fix',
+        author: null,
+        closingIssues: []
+      },
+      {
+        source: 'squashedPR',
+        prNumber: 1,
+        type: 'feat',
+        breaking: false,
+        description: 'a feature',
+        author: null,
+        closingIssues: []
+      },
+      {
+        source: 'directCommit',
+        sha: 'abcd1234',
+        type: null,
+        breaking: false,
+        description: 'untyped commit',
+        author: 'Someone'
+      }
+    ]
+    const grouped = groupChangesByCategory(changes)
+    expect(grouped.Features.map(c => c.description)).toEqual(['a feature'])
+    expect(grouped['Bug fixes'].map(c => c.description)).toEqual(['a fix'])
+    expect(grouped['Other changes'].map(c => c.description)).toEqual([
+      'untyped commit'
+    ])
+  })
+})
+
+describe('stripChangelogComment', () => {
+  it('removes the appended changelog comment from a notes body', () => {
+    const notes = '## Features\n\n- #1450 - return null'
+    const body = `${notes}\n\n${renderChangelogComment(release)}`
+    expect(stripChangelogComment(body)).toBe(notes)
+  })
+
+  it('leaves a body without the comment untouched', () => {
+    const notes = '## Features\n\n- #1 - a feature'
+    expect(stripChangelogComment(notes)).toBe(notes)
+  })
+
+  it('strips the comment regardless of CRLF line endings, and past an earlier migration comment', () => {
+    const notes =
+      '## Breaking changes\n\n<!-- todo: Add migration steps -->\n\n## Features\n\n- #1450 - return null'
+    const body = `${notes}\n\n${renderChangelogComment(release)}`.replace(
+      /\n/g,
+      '\r\n'
+    )
+    expect(stripChangelogComment(body)).toBe(notes.replace(/\n/g, '\r\n'))
+  })
+})

--- a/packages/scripts/lib/changelog-dto.test.ts
+++ b/packages/scripts/lib/changelog-dto.test.ts
@@ -42,6 +42,16 @@ const expectedDto: ChangelogDTO = {
   ...release
 }
 
+// Parse and assert the happy path, narrowing to the `ok` variant so a test can
+// reach `.dto`/`.preamble` without re-checking the discriminant each time.
+function parseOk(body: string) {
+  const result = parseChangelogComment(body)
+  if (result.status !== 'ok') {
+    throw new Error(`expected a valid DTO, got status "${result.status}"`)
+  }
+  return result
+}
+
 describe('parseCodeSpans', () => {
   it('returns no segments for an empty string', () => {
     expect(parseCodeSpans('')).toEqual([])
@@ -97,12 +107,13 @@ describe('renderChangelogComment / parseChangelogComment round-trip', () => {
     expect(comment.startsWith('<!--')).toBe(true)
     expect(comment.trimEnd().endsWith('-->')).toBe(true)
     const parsed = parseChangelogComment(comment)
-    expect(parsed).toEqual({ preamble: null, dto: expectedDto })
+    expect(parsed).toEqual({ status: 'ok', preamble: null, dto: expectedDto })
   })
 
   it('round-trips when the comment is embedded in a larger release body', () => {
     const body = `## Features\n\n- #1450 - return null\n\n${renderChangelogComment(release)}`
     expect(parseChangelogComment(body)).toEqual({
+      status: 'ok',
       preamble: null,
       dto: expectedDto
     })
@@ -111,7 +122,7 @@ describe('renderChangelogComment / parseChangelogComment round-trip', () => {
   it('emits an empty preamble stub with the guiding hint line', () => {
     const comment = renderChangelogComment(release)
     expect(comment).toContain('<changelog:preamble></changelog:preamble>')
-    expect(comment).toContain("docs' changelog page")
+    expect(comment).toContain('rendered on the changelog page')
   })
 })
 
@@ -133,8 +144,7 @@ describe('escaping', () => {
     const comment = renderChangelogComment(evil)
     // The only "-->" in the whole comment is the closing terminator (last 3 chars).
     expect(comment.indexOf('-->')).toBe(comment.length - 3)
-    const parsed = parseChangelogComment(comment)
-    expect(parsed?.dto.changes[0]).toMatchObject({
+    expect(parseOk(comment).dto.changes[0]).toMatchObject({
       description: 'guard against `-->` early termination'
     })
   })
@@ -153,8 +163,7 @@ describe('escaping', () => {
       ],
       contributors: []
     }
-    const parsed = parseChangelogComment(renderChangelogComment(evil))
-    expect(parsed?.dto.changes[0]).toMatchObject({
+    expect(parseOk(renderChangelogComment(evil)).dto.changes[0]).toMatchObject({
       description: 'parser must survive </changelog:dto> in prose'
     })
   })
@@ -175,42 +184,113 @@ describe('escaping', () => {
     }
     const comment = renderChangelogComment(withCode)
     expect(comment).not.toContain('<code>')
-    const parsed = parseChangelogComment(comment)
-    expect(parsed?.dto.changes[0]).toMatchObject({
+    expect(parseOk(comment).dto.changes[0]).toMatchObject({
       description: 'backticks `demo` stay raw'
     })
   })
 })
 
 describe('parseChangelogComment degrade signals', () => {
-  it('returns null for a null body', () => {
-    expect(parseChangelogComment(null)).toBeNull()
+  // `absent` (no DTO block — a pre-DTO/hand-written release) is degraded
+  // quietly; `invalid` (a present-but-broken block — tamper/drift) is degraded
+  // loudly. The two are distinct so a renderer/gate can tell them apart.
+  it('reports absent for a null body', () => {
+    expect(parseChangelogComment(null)).toEqual({ status: 'absent' })
   })
 
-  it('returns null when there is no changelog comment', () => {
-    expect(parseChangelogComment('## Features\n\n- #1 - a feature')).toBeNull()
+  it('reports absent when there is no changelog comment', () => {
+    expect(parseChangelogComment('## Features\n\n- #1 - a feature')).toEqual({
+      status: 'absent'
+    })
   })
 
-  it('returns null for malformed JSON inside the dto tags', () => {
+  it('reports invalid for malformed JSON inside the dto tags', () => {
     const body = '<!--\n<changelog:dto>\n{ not json ]\n</changelog:dto>\n-->'
-    expect(parseChangelogComment(body)).toBeNull()
+    expect(parseChangelogComment(body).status).toBe('invalid')
   })
 
-  it('returns null for schema-invalid JSON (missing required field)', () => {
+  it('reports invalid for schema-invalid JSON (missing required field)', () => {
     const body = `<!--\n<changelog:dto>\n${JSON.stringify({
       $schema: CHANGELOG_DTO_SCHEMA_URL,
       changes: [{ source: 'squashedPR', prNumber: 1 }]
     })}\n</changelog:dto>\n-->`
-    expect(parseChangelogComment(body)).toBeNull()
+    expect(parseChangelogComment(body).status).toBe('invalid')
   })
 
-  it('returns null for an unrecognized ($schema v2) URL', () => {
+  it('reports invalid for an unrecognized ($schema v2) URL', () => {
     const body = `<!--\n<changelog:dto>\n${JSON.stringify({
       $schema: 'https://nuqs.dev/schemas/changelog-dto.v2.json',
       changes: [],
       contributors: []
     })}\n</changelog:dto>\n-->`
-    expect(parseChangelogComment(body)).toBeNull()
+    expect(parseChangelogComment(body).status).toBe('invalid')
+  })
+
+  // Runtime must reject unknown keys, so the parse agrees with the published
+  // JSON Schema's `additionalProperties: false` rather than silently stripping.
+  it('reports invalid for a body carrying an unknown key', () => {
+    const body = `<!--\n<changelog:dto>\n${JSON.stringify({
+      ...expectedDto,
+      unexpected: 'extra'
+    })}\n</changelog:dto>\n-->`
+    expect(parseChangelogComment(body).status).toBe('invalid')
+  })
+})
+
+describe('parseChangelogComment v1 back-compat', () => {
+  // A hand-frozen, real-world-shaped v1 body (NOT generated from the current
+  // schema): if a future change adds a *required* field without bumping the
+  // `$schema` URL, this body stops parsing and this test goes red — forcing the
+  // field to be optional, or the version to bump, instead of silently degrading
+  // every already-published release to a bare title+link.
+  const FROZEN_V1_BODY = [
+    '## Features',
+    '',
+    '- #100 - add something',
+    '',
+    '<!--',
+    'Any Markdown between the preamble tags is rendered on the changelog page:',
+    '<changelog:preamble></changelog:preamble>',
+    '<changelog:dto>',
+    JSON.stringify(
+      {
+        $schema: 'https://nuqs.dev/schemas/changelog-dto.v1.json',
+        changes: [
+          {
+            source: 'squashedPR',
+            prNumber: 100,
+            type: 'feat',
+            breaking: false,
+            description: 'add something',
+            author: 'octocat',
+            closingIssues: [42]
+          },
+          {
+            source: 'directCommit',
+            sha: 'a1b2c3d4',
+            type: null,
+            breaking: false,
+            description: 'fix a typo',
+            author: 'Jane Doe'
+          }
+        ],
+        contributors: ['octocat']
+      },
+      null,
+      2
+    ),
+    '</changelog:dto>',
+    '-->'
+  ].join('\n')
+
+  it('still parses the frozen v1 body', () => {
+    const parsed = parseOk(FROZEN_V1_BODY)
+    expect(parsed.dto.changes).toHaveLength(2)
+    expect(parsed.dto.changes[0]).toMatchObject({
+      source: 'squashedPR',
+      prNumber: 100
+    })
+    expect(parsed.dto.contributors).toEqual(['octocat'])
   })
 })
 
@@ -224,7 +304,7 @@ describe('preamble extraction', () => {
       '</changelog:dto>',
       '-->'
     ].join('\n')
-    expect(parseChangelogComment(body)?.preamble).toBeNull()
+    expect(parseOk(body).preamble).toBeNull()
   })
 
   it('returns the trimmed markdown of a non-empty preamble', () => {
@@ -238,13 +318,13 @@ describe('preamble extraction', () => {
       '</changelog:dto>',
       '-->'
     ].join('\n')
-    expect(parseChangelogComment(body)?.preamble).toBe(
+    expect(parseOk(body).preamble).toBe(
       'See the [migration guide](/docs/migrations/v2.9).'
     )
   })
 
   // Slice 5: the maintainer authors a filled preamble (multi-line markdown with
-  // a code fence) in the draft; docs renders it above the change list. The raw
+  // a code fence) in the draft; the page renders it above the change list. The raw
   // markdown — newlines, blank lines and the ``` fence intact — must come back
   // verbatim (trimmed), since the page renders exactly this string.
   it('extracts a multi-line preamble with a code fence verbatim', () => {
@@ -265,7 +345,7 @@ describe('preamble extraction', () => {
       '</changelog:dto>',
       '-->'
     ].join('\n')
-    expect(parseChangelogComment(body)?.preamble).toBe(preamble)
+    expect(parseOk(body).preamble).toBe(preamble)
   })
 })
 

--- a/packages/scripts/lib/changelog-dto.ts
+++ b/packages/scripts/lib/changelog-dto.ts
@@ -47,6 +47,16 @@ export function toChangelogDTO(release: ReleaseChanges): ChangelogDTO {
   return { $schema: CHANGELOG_DTO_SCHEMA_URL, ...release }
 }
 
+// The JSON Schema artifact (Draft 2020-12) derived from the Zod SSOT. Served
+// out-of-band at `CHANGELOG_DTO_SCHEMA_URL` for editor/tooling validation —
+// consumers never fetch it and validate at runtime with Zod, never this. The
+// derivation lives here, beside the schema, so the throwaway generator (which
+// writes the committed artifact) and the drift test (which guards it) share one
+// source and cannot disagree about what the artifact should contain.
+export function changelogJsonSchema() {
+  return z.toJSONSchema(changelogDtoSchema)
+}
+
 // --- Embedding: the HTML comment block --------------------------------------
 
 const HINT =

--- a/packages/scripts/lib/changelog-dto.ts
+++ b/packages/scripts/lib/changelog-dto.ts
@@ -1,9 +1,7 @@
 // Shared changelog codec — the single source of truth for the machine-readable
 // DTO embedded in each GitHub release body (inside an HTML comment) and parsed
 // back out of it. The release pipeline (`release-notes-automation.ts`) serializes
-// a `ReleaseChanges`; whatever renders the changelog parses it back. Both go
-// through the very same Zod schema, so serializer and parser cannot drift — the
-// bug class this replaces.
+// a `ReleaseChanges`; whatever renders the changelog parses it back.
 //
 // Pure and IO-free by contract: it touches only `zod` and the `change.ts` schema
 // SSOT, never the git/octokit IO in `commit-graph.ts`, so it can be imported from
@@ -60,7 +58,7 @@ export function changelogJsonSchema() {
 // --- Embedding: the HTML comment block --------------------------------------
 
 const HINT =
-  "Any Markdown between the preamble tags shows up in the docs' changelog page:"
+  'Any Markdown between the preamble tags is rendered on the changelog page:'
 const PREAMBLE_OPEN = '<changelog:preamble>'
 const PREAMBLE_CLOSE = '</changelog:preamble>'
 const DTO_OPEN = '<changelog:dto>'
@@ -80,7 +78,7 @@ function escapeForComment(json: string): string {
 // Serialize a release's changes into the one HTML comment block carried by the
 // release body: a guiding hint line, an (empty) preamble stub, and the DTO as
 // pretty-printed, `<`/`>`-escaped JSON. The hint sits outside the preamble tags,
-// so GitHub hides the whole comment and docs ignores the hint.
+// so GitHub hides the whole comment and the renderer ignores the hint.
 export function renderChangelogComment(release: ReleaseChanges): string {
   const json = escapeForComment(
     JSON.stringify(toChangelogDTO(release), null, 2)
@@ -112,27 +110,48 @@ function extractBetween(
   return body.slice(from, end)
 }
 
+// The outcome of parsing a release body, distinguishing the two cases the old
+// single `null` conflated:
+//   - `absent`  — no `<changelog:dto>` block at all (a legitimate pre-DTO or
+//     hand-written release): degrade quietly.
+//   - `invalid` — the block is present but its JSON is malformed or fails the
+//     schema (incl. an unrecognized `$schema`): the signature of a tampered body
+//     or a pipeline schema drift. Degrade too, but loudly, carrying the `reason`.
+export type ParsedChangelog =
+  | { status: 'ok'; preamble: string | null; dto: ChangelogDTO }
+  | { status: 'absent' }
+  | { status: 'invalid'; reason: string }
+
 // Extract + Zod-validate the DTO (and optional preamble) from a release body.
-// Returns null whenever the comment is absent, the JSON is malformed, or the
-// payload fails validation (incl. an unrecognized `$schema`) — the single
-// "degrade this release" signal the caller branches on. Never throws.
-export function parseChangelogComment(
-  body: string | null
-): { preamble: string | null; dto: ChangelogDTO } | null {
-  if (!body) return null
+// Never throws: every parse/validation failure is reported as `absent`/`invalid`
+// so a renderer can always degrade a single release rather than fail the build.
+export function parseChangelogComment(body: string | null): ParsedChangelog {
+  if (!body) return { status: 'absent' }
   const dtoText = extractBetween(body, DTO_OPEN, DTO_CLOSE)
-  if (dtoText === null) return null
+  if (dtoText === null) return { status: 'absent' }
   let json: unknown
   try {
     json = JSON.parse(dtoText)
-  } catch {
-    return null
+  } catch (error) {
+    return {
+      status: 'invalid',
+      reason: `malformed JSON: ${(error as Error).message}`
+    }
   }
   const result = changelogDtoSchema.safeParse(json)
-  if (!result.success) return null
+  if (!result.success) {
+    const reason = result.error.issues
+      .map(issue => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('; ')
+    return { status: 'invalid', reason }
+  }
   const rawPreamble = extractBetween(body, PREAMBLE_OPEN, PREAMBLE_CLOSE)
   const trimmed = rawPreamble?.trim() ?? ''
-  return { preamble: trimmed.length > 0 ? trimmed : null, dto: result.data }
+  return {
+    status: 'ok',
+    preamble: trimmed.length > 0 ? trimmed : null,
+    dto: result.data
+  }
 }
 
 // Remove the appended changelog comment from a release body — for surfaces that

--- a/packages/scripts/lib/changelog-dto.ts
+++ b/packages/scripts/lib/changelog-dto.ts
@@ -1,0 +1,236 @@
+// Shared changelog codec — the single source of truth for the machine-readable
+// DTO embedded in each GitHub release body (inside an HTML comment) and parsed
+// back out of it. The release pipeline (`release-notes-automation.ts`) serializes
+// a `ReleaseChanges`; whatever renders the changelog parses it back. Both go
+// through the very same Zod schema, so serializer and parser cannot drift — the
+// bug class this replaces.
+//
+// Pure and IO-free by contract: it touches only `zod` and the `change.ts` schema
+// SSOT, never the git/octokit IO in `commit-graph.ts`, so it can be imported from
+// anywhere. Keep it that way — a value import from `commit-graph.ts`/`git.ts`
+// here would pull `node:child_process` and octokit into every consumer.
+
+import { z } from 'zod'
+import {
+  type Change,
+  type ReleaseChanges,
+  releaseChangesSchema
+} from './change.ts'
+
+// Re-export the change-domain types so consumers have a single import site for
+// the changelog shapes.
+export type { Change, ReleaseChanges } from './change.ts'
+
+// Branded, stable, versioned identity for the DTO. A `z.literal`, so a future
+// breaking `v2` URL simply fails `parse` → the consumer degrades that release,
+// with no version branching anywhere. The matching JSON Schema artifact served
+// at this URL (for out-of-band/editor validation) is generated in a later slice;
+// runtime validation is always Zod, never a fetch of this URL.
+export const CHANGELOG_DTO_SCHEMA_URL =
+  'https://nuqs.dev/schemas/changelog-dto.v1.json'
+
+// --- DTO schema -------------------------------------------------------------
+
+// The DTO is a release's changes plus a `$schema` tag — the serialized form is
+// the exact `ReleaseChanges` shape, so wire and domain can't drift. `category`
+// is intentionally never stored: it is derived from each change's `type` at
+// render via `categoryForType`, so a future mapping change re-buckets every
+// release consistently.
+export const changelogDtoSchema = releaseChangesSchema.extend({
+  $schema: z.literal(CHANGELOG_DTO_SCHEMA_URL)
+})
+
+export type ChangelogDTO = z.infer<typeof changelogDtoSchema>
+
+// Serialize a release into the DTO: its changes verbatim, tagged with `$schema`.
+export function toChangelogDTO(release: ReleaseChanges): ChangelogDTO {
+  return { $schema: CHANGELOG_DTO_SCHEMA_URL, ...release }
+}
+
+// --- Embedding: the HTML comment block --------------------------------------
+
+const HINT =
+  "Any Markdown between the preamble tags shows up in the docs' changelog page:"
+const PREAMBLE_OPEN = '<changelog:preamble>'
+const PREAMBLE_CLOSE = '</changelog:preamble>'
+const DTO_OPEN = '<changelog:dto>'
+const DTO_CLOSE = '</changelog:dto>'
+const COMMENT_OPEN = '<!--'
+const COMMENT_END = '-->'
+
+// Neutralize every `<` and `>` in the embedded JSON so it can neither close the
+// HTML comment (`-->`) nor the `</changelog:dto>` tag, nor smuggle any other
+// markup into the body. Both are valid JSON escapes that `JSON.parse` decodes
+// back to the exact characters, so the round-trip needs no custom unescape — the
+// escaping is invisible to every consumer except the raw comment text.
+function escapeForComment(json: string): string {
+  return json.replace(/</g, '\\u003c').replace(/>/g, '\\u003e')
+}
+
+// Serialize a release's changes into the one HTML comment block carried by the
+// release body: a guiding hint line, an (empty) preamble stub, and the DTO as
+// pretty-printed, `<`/`>`-escaped JSON. The hint sits outside the preamble tags,
+// so GitHub hides the whole comment and docs ignores the hint.
+export function renderChangelogComment(release: ReleaseChanges): string {
+  const json = escapeForComment(
+    JSON.stringify(toChangelogDTO(release), null, 2)
+  )
+  return [
+    COMMENT_OPEN,
+    HINT,
+    `${PREAMBLE_OPEN}${PREAMBLE_CLOSE}`,
+    DTO_OPEN,
+    json,
+    DTO_CLOSE,
+    COMMENT_END
+  ].join('\n')
+}
+
+// The substring between the first `open` and the next `close` after it, or null
+// when either marker is absent. The escaped JSON contains no `<`/`>`, so the
+// `</changelog:dto>` match is unambiguous regardless of the change descriptions.
+function extractBetween(
+  body: string,
+  open: string,
+  close: string
+): string | null {
+  const start = body.indexOf(open)
+  if (start === -1) return null
+  const from = start + open.length
+  const end = body.indexOf(close, from)
+  if (end === -1) return null
+  return body.slice(from, end)
+}
+
+// Extract + Zod-validate the DTO (and optional preamble) from a release body.
+// Returns null whenever the comment is absent, the JSON is malformed, or the
+// payload fails validation (incl. an unrecognized `$schema`) — the single
+// "degrade this release" signal the caller branches on. Never throws.
+export function parseChangelogComment(
+  body: string | null
+): { preamble: string | null; dto: ChangelogDTO } | null {
+  if (!body) return null
+  const dtoText = extractBetween(body, DTO_OPEN, DTO_CLOSE)
+  if (dtoText === null) return null
+  let json: unknown
+  try {
+    json = JSON.parse(dtoText)
+  } catch {
+    return null
+  }
+  const result = changelogDtoSchema.safeParse(json)
+  if (!result.success) return null
+  const rawPreamble = extractBetween(body, PREAMBLE_OPEN, PREAMBLE_CLOSE)
+  const trimmed = rawPreamble?.trim() ?? ''
+  return { preamble: trimmed.length > 0 ? trimmed : null, dto: result.data }
+}
+
+// Remove the appended changelog comment from a release body — for surfaces that
+// render the human-readable notes verbatim and must not leak the machine DTO.
+// A no-op when the comment is absent. Anchors on the
+// single-line `<changelog:dto>` tag (not a multi-line literal), so it is
+// line-ending agnostic: the enclosing comment is the nearest `<!--` before the
+// tag and the next `-->` after it (the escaped DTO contains no `-->`), which
+// also skips any earlier `<!-- … -->` in the human notes (e.g. a migration stub).
+export function stripChangelogComment(body: string): string {
+  const dtoIndex = body.indexOf(DTO_OPEN)
+  if (dtoIndex === -1) return body
+  const start = body.lastIndexOf(COMMENT_OPEN, dtoIndex)
+  const end = body.indexOf(COMMENT_END, dtoIndex)
+  if (start === -1 || end === -1) return body
+  return (body.slice(0, start) + body.slice(end + COMMENT_END.length)).trimEnd()
+}
+
+// --- Shared span-parser -----------------------------------------------------
+
+// One segment of a change description: plain text, or an inline-code run.
+type DescriptionSegment = { code: boolean; value: string }
+
+// Split a description into plain-text and inline-code segments on *balanced*
+// backtick pairs (a lone backtick stays literal text). This is the single
+// primitive both renderers build on — the GitHub notes' `<code>` HTML
+// (`formatTitle`) and any consumer rendering inline code as nodes — so a
+// description stored raw in the DTO can't diverge between surfaces.
+export function parseCodeSpans(text: string): DescriptionSegment[] {
+  const segments: DescriptionSegment[] = []
+  const pattern = /`([^`]+)`/g
+  let lastIndex = 0
+  for (const match of text.matchAll(pattern)) {
+    const start = match.index ?? 0
+    if (start > lastIndex) {
+      segments.push({ code: false, value: text.slice(lastIndex, start) })
+    }
+    segments.push({ code: true, value: match[1]! })
+    lastIndex = start + match[0].length
+  }
+  if (lastIndex < text.length) {
+    segments.push({ code: false, value: text.slice(lastIndex) })
+  }
+  return segments
+}
+
+// --- Shared category derivation + grouping ----------------------------------
+
+export const CATEGORIES = [
+  'Features',
+  'Bug fixes',
+  'Documentation',
+  'Other changes'
+] as const
+export type Category = (typeof CATEGORIES)[number]
+
+// Derive a change's changelog category from its commit `type` — never a PR
+// title, whose prefix is irrelevant prose. `null` (a non-conventional commit)
+// falls through to "Other changes". (Also tolerates `undefined` for callers
+// holding a not-yet-encoded parse result.)
+export function categoryForType(type: string | null | undefined): Category {
+  switch (type) {
+    case 'feat':
+      return 'Features'
+    case 'fix':
+      return 'Bug fixes'
+    case 'doc':
+    case 'docs':
+      return 'Documentation'
+    default:
+      return 'Other changes'
+  }
+}
+
+// Order within a section: PR-sourced changes first (ascending PR number), then
+// direct-commit changes in their given order (discovery supplies them
+// oldest-first). Relies on a stable sort to preserve that commit order.
+function compareChanges(a: Change, b: Change): number {
+  if (a.source !== b.source) return a.source === 'squashedPR' ? -1 : 1
+  if (a.source === 'squashedPR' && b.source === 'squashedPR') {
+    return a.prNumber - b.prNumber
+  }
+  return 0
+}
+
+// Group changes into their changelog categories. The category is the bucket key,
+// not a field on the change, so the two can't drift.
+export function groupChangesByCategory(
+  changes: readonly Change[]
+): Record<Category, Change[]> {
+  const categories: Record<Category, Change[]> = {
+    Features: [],
+    'Bug fixes': [],
+    Documentation: [],
+    'Other changes': []
+  }
+  for (const change of changes) {
+    categories[categoryForType(change.type)].push(change)
+  }
+  for (const category of CATEGORIES) {
+    categories[category].sort(compareChanges)
+  }
+  return categories
+}
+
+// The breaking-changes cross-cut: every change flagged `breaking`, in the same
+// PR-first / commit-oldest order. A filter over `breaking`, NOT a category — a
+// `feat!` stays in its type section and also appears here.
+export function breakingChanges(changes: readonly Change[]): Change[] {
+  return changes.filter(change => change.breaking).sort(compareChanges)
+}

--- a/packages/scripts/lib/commit-graph.test.ts
+++ b/packages/scripts/lib/commit-graph.test.ts
@@ -1,9 +1,9 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { http, HttpResponse } from 'msw'
-import { setupServer } from 'msw/node'
 import {
   afterAll,
   afterEach,
@@ -14,8 +14,8 @@ import {
   vi
 } from 'vitest'
 import { z } from 'zod'
+import type { Change } from './change'
 import {
-  type Change,
   collectContributors,
   collectIssues,
   type CommitRecord,
@@ -416,7 +416,7 @@ describe('collectIssues', () => {
         }
       })
     ]
-    expect(collectIssues(prs)).toEqual([{ number: 10 }, { number: 11 }])
+    expect(collectIssues(prs)).toEqual([10, 11])
   })
 
   it('deduplicates an issue closed by more than one PR', () => {
@@ -435,7 +435,7 @@ describe('collectIssues', () => {
         closingIssuesReferences: closes100
       })
     ]
-    expect(collectIssues(prs)).toEqual([{ number: 100 }])
+    expect(collectIssues(prs)).toEqual([100])
   })
 })
 
@@ -539,7 +539,7 @@ describe('discoverChanges', () => {
           breaking: false,
           description: 'first',
           author: null,
-          closingIssues: [{ number: 100 }]
+          closingIssues: [100]
         },
         {
           source: 'squashedPR',
@@ -558,11 +558,11 @@ describe('discoverChanges', () => {
     expect(reader.fetchClosingIssues).not.toHaveBeenCalled()
   })
 
-  it('keeps the first-seen classification and warns when a PR number recurs with a divergent type', async () => {
+  it('keeps the first-seen type/breaking and warns when a PR number recurs with a divergent type', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const reader: ReleaseGraphReader = {
       readTags: () => [],
-      // PR #1's squash commit classifies it `feat`; a later commit re-uses the
+      // PR #1's squash commit types it `feat`; a later commit re-uses the
       // (#1) suffix with a divergent `fix`. First-seen wins; the conflict warns.
       readCommits: () => records('feat: kept (#1)', 'fix: divergent (#1)'),
       fetchChangeDetails: vi.fn(async () => [
@@ -733,7 +733,7 @@ describe('discoverTargets', () => {
     ).resolves.toEqual({
       changes: [{ prNumber: 1 }, { prNumber: 2 }],
       // #100 is closed by both PRs but listed once.
-      issues: [{ number: 100 }, { number: 101 }]
+      issues: [100, 101]
     })
     // Finalize fetches the closing issues only; the change details are untouched.
     expect(reader.fetchClosingIssues).toHaveBeenCalledExactlyOnceWith([1, 2])
@@ -802,7 +802,9 @@ function issuesOf(changes: Change[]) {
         ? [
             {
               closingIssuesReferences: {
-                edges: change.closingIssues.map(node => ({ node }))
+                edges: change.closingIssues.map(number => ({
+                  node: { number }
+                }))
               }
             }
           ]
@@ -864,7 +866,7 @@ describe('discovery (history scenarios)', () => {
     )
     expect(finalize.issues).toEqual(issuesOf(draft.changes))
     expect(prNumbersOf(draft.changes)).toEqual([2, 3])
-    expect(finalize.issues).toEqual([{ number: 100 }])
+    expect(finalize.issues).toEqual([100])
     expect(draft.contributors).toEqual(['alice', 'bob'])
   })
 
@@ -985,7 +987,7 @@ describe('discovery (history scenarios)', () => {
       await discoverTargets({ channel: 'beta', currentRef: 'HEAD', reader })
     ).toEqual({
       changes: [{ prNumber: 2 }],
-      issues: [{ number: 50 }]
+      issues: [50]
     })
   })
 })

--- a/packages/scripts/lib/commit-graph.ts
+++ b/packages/scripts/lib/commit-graph.ts
@@ -23,6 +23,11 @@
 
 import { z } from 'zod'
 import type { Channel } from '../compute-version.ts'
+import type {
+  DirectCommitChange,
+  ReleaseChanges,
+  SquashedPRChange
+} from './change.ts'
 import {
   parseCommit,
   parseSubject,
@@ -173,59 +178,19 @@ export const prClosingIssuesSchema = z.object({
 
 export type PRClosingIssues = z.infer<typeof prClosingIssuesSchema>
 
-// A closing-issue reference: the GitHub issue number a PR closes.
-export type IssueRef = { readonly number: number }
-
-// A change: the atomic unit of a release. It is sourced either from a squashed
-// pull request (the common case) or from a direct commit with no PR:
-//   - `squashedPR`   → identity is the PR number, `description` is the PR title
-//                       as prose, `author` is the GitHub login, and it carries
-//                       closing issues. Rendered as `#123 - …, by @login`.
-//   - `directCommit` → identity is the 8-char commit SHA, `description` is the
-//                       commit subject as prose, `author` is the git author
-//                       name. Rendered as `abcd1234 - …, by Name`.
-// In both, the `type`/`breaking` classification comes from the commit message,
-// never a PR title. Finalize comments only on `squashedPR` changes (a direct
-// commit has no PR/issue).
-export type SquashedPRChange = {
-  readonly source: 'squashedPR'
-  readonly prNumber: number
-  readonly type: string | undefined
-  readonly breaking: boolean
-  readonly description: string
-  readonly author: string | null
-  readonly closingIssues: readonly IssueRef[]
-}
-export type DirectCommitChange = {
-  readonly source: 'directCommit'
-  readonly sha: string
-  readonly type: string | undefined
-  readonly breaking: boolean
-  readonly description: string
-  readonly author: string
-}
-export type Change = SquashedPRChange | DirectCommitChange
-
-// The notes-path output: the full `changes` driving the changelog, plus the
-// release `contributors` feeding the "Thanks" section.
-export type ReleaseChanges = {
-  changes: Change[]
-  contributors: string[]
-}
-
 // The finalize-path output: the comment targets, split into the release's PRs
-// (`changes`, by number) and their deduplicated closing `issues`. Finalize
-// comments on both.
+// (`changes`, by number) and their deduplicated closing `issues` (issue
+// numbers). Finalize comments on both.
 export type ReleaseTargets = {
   changes: Array<{ prNumber: number }>
-  issues: IssueRef[]
+  issues: number[]
 }
 
 // --- Reader port -----------------------------------------------------------
 
 // One commit as read from git: its SHA, author name (no email), and full
 // message. SHA and author hydrate a direct (no-PR) change; the message yields
-// the classification and, for direct changes, the description.
+// the type/breaking and, for direct changes, the description.
 export type CommitRecord = {
   sha: string
   author: string
@@ -408,19 +373,19 @@ function fetchClosingIssues(
 // The closing-issues facet shared by `PR` and `PRClosingIssues`, so
 // `collectIssues` serves both discovery paths from the same field.
 type WithClosingIssues = {
-  closingIssuesReferences: { edges: Array<{ node: IssueRef }> }
+  closingIssuesReferences: { edges: Array<{ node: { number: number } }> }
 }
 
-// Deduplicate closing issues across all PRs (a single issue can be closed by
-// more than one PR across the range).
-export function collectIssues(prs: WithClosingIssues[]): IssueRef[] {
+// Deduplicate the closing issue numbers across all PRs (a single issue can be
+// closed by more than one PR across the range).
+export function collectIssues(prs: WithClosingIssues[]): number[] {
   const numbers = new Set<number>()
   for (const pr of prs) {
     for (const { node } of pr.closingIssuesReferences.edges) {
       numbers.add(node.number)
     }
   }
-  return [...numbers].map(number => ({ number }))
+  return Array.from(numbers).sort((a, b) => a - b)
 }
 
 // Stage 1 of discovery: everything the git log alone yields for one commit in
@@ -467,10 +432,10 @@ function parseCommits(records: CommitRecord[]): ParsedCommit[] {
       seen.set(prNumber, commit)
       parsed.push(commit)
     } else if (existing.type !== type || existing.breaking !== breaking) {
-      // A `(#N)` recurring with a divergent classification (rare under
+      // A `(#N)` recurring with a divergent type/breaking (rare under
       // squash-merge). Keep the first-seen (authoritative) entry, but warn.
       console.warn(
-        `commit-graph: PR #${prNumber} recurs with a conflicting classification; keeping the first-seen one.`
+        `commit-graph: PR #${prNumber} recurs with a conflicting type/breaking; keeping the first-seen one.`
       )
     }
   }
@@ -479,7 +444,8 @@ function parseCommits(records: CommitRecord[]): ParsedCommit[] {
 
 // Project a fetched PR into a PR-sourced change: `type`/`breaking` from the
 // squash commit (via `byNumber`), `description` from the PR title as prose (its
-// type prefix stripped for display, never classified).
+// type prefix stripped for display only). A non-conventional commit has no
+// `type` (`undefined` from the parser), encoded as `null` on the change.
 function toSquashedPRChange(
   pr: PR,
   byNumber: Map<number, ParsedCommit>
@@ -487,22 +453,22 @@ function toSquashedPRChange(
   const parsed = byNumber.get(pr.number)
   if (parsed === undefined) {
     // Fetched PRs are exactly the keys of `byNumber`, so a miss is an invariant
-    // violation, not a data condition — fail loud rather than silently
-    // classifying the change as untyped (which would drop its bump/category).
+    // violation, not a data condition — fail loud rather than silently treating
+    // the change as untyped (which would drop its bump/category).
     throw new Error(
-      `commit-graph: no squash-commit classification for PR #${pr.number}`
+      `commit-graph: no squash-commit type/breaking for PR #${pr.number}`
     )
   }
   return {
     source: 'squashedPR',
     prNumber: pr.number,
-    type: parsed.type,
+    type: parsed.type ?? null,
     breaking: parsed.breaking,
     description: parseSubject(pr.title).description,
     author: pr.author?.login ?? null,
-    closingIssues: pr.closingIssuesReferences.edges.map(edge => ({
-      number: edge.node.number
-    }))
+    closingIssues: pr.closingIssuesReferences.edges.map(
+      edge => edge.node.number
+    )
   }
 }
 
@@ -512,7 +478,7 @@ function toDirectCommitChange(commit: ParsedCommit): DirectCommitChange {
   return {
     source: 'directCommit',
     sha: commit.sha.slice(0, 8),
-    type: commit.type,
+    type: commit.type ?? null,
     breaking: commit.breaking,
     description: commit.description,
     author: commit.author
@@ -520,7 +486,7 @@ function toDirectCommitChange(commit: ParsedCommit): DirectCommitChange {
 }
 
 // The shared range → parsed-commits core both phases build on. Resolve the
-// channel-asymmetric range, read its commits (the classification authority), and
+// channel-asymmetric range, read its commits (the type/breaking authority), and
 // parse them into the uniform stage-1 form. The PR-linked entries' numbers are
 // the SSOT both phase-specific fetches key off.
 export function parseRange(args: {
@@ -534,7 +500,7 @@ export function parseRange(args: {
 }
 
 // Notes-path discovery: the shared core + `fetchChangeDetails`, projected into
-// the full change list — the PR-sourced changes (classification from the commit,
+// the full change list — the PR-sourced changes (type/breaking from the commit,
 // the rest hydrated from the PR) followed by the direct-commit changes — plus the
 // release contributors (from the PRs only; commit authors are not GitHub
 // handles). `fetchClosingIssues` is never touched.

--- a/packages/scripts/lib/commit-graph.ts
+++ b/packages/scripts/lib/commit-graph.ts
@@ -376,8 +376,8 @@ type WithClosingIssues = {
   closingIssuesReferences: { edges: Array<{ node: { number: number } }> }
 }
 
-// Deduplicate the closing issue numbers across all PRs (a single issue can be
-// closed by more than one PR across the range).
+// Deduplicate (and sort asc) the closing issue numbers across all PRs.
+// (a single issue can be closed by more than one PR across the range)
 export function collectIssues(prs: WithClosingIssues[]): number[] {
   const numbers = new Set<number>()
   for (const pr of prs) {
@@ -415,20 +415,20 @@ function parseCommits(records: CommitRecord[]): ParsedCommit[] {
     const firstLine = message.split('\n')[0] ?? ''
     const prNumber = extractPRNumber(firstLine)
     const { type, breaking, description } = parseCommit(message)
+    const commit: ParsedCommit = {
+      sha,
+      author,
+      prNumber,
+      type,
+      breaking,
+      description
+    }
     if (prNumber === null) {
-      parsed.push({ sha, author, prNumber, type, breaking, description })
+      parsed.push(commit)
       continue
     }
     const existing = seen.get(prNumber)
     if (existing === undefined) {
-      const commit: ParsedCommit = {
-        sha,
-        author,
-        prNumber,
-        type,
-        breaking,
-        description
-      }
       seen.set(prNumber, commit)
       parsed.push(commit)
     } else if (existing.type !== type || existing.breaking !== breaking) {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0-internal",
   "type": "module",
+  "exports": {
+    "./lib/changelog-dto": "./lib/changelog-dto.ts"
+  },
   "scripts": {
     "test": "pnpm run --stream '/^test:/'",
     "test:unit": "vitest run",

--- a/packages/scripts/release-finalize.test.ts
+++ b/packages/scripts/release-finalize.test.ts
@@ -426,8 +426,12 @@ describe('commentAndLabel', () => {
     ).resolves.toBeUndefined()
   })
 
-  it('skips a 404 REST write (target deleted) without failing the job', async () => {
-    const { writer } = makeFakeWriter({
+  it('fails loud when a label write fails after a successful comment (target proven writable, not deleted)', async () => {
+    // Edge case: the comment landed, so #1 is reachable and writable:
+    // a 404/403 on the follow-up label is a real fault (e.g. a missing label),
+    // not a deleted target. It must fail the job (→ red, re-run applies the label)
+    // rather than leave #1 silently commented-but-unlabelled on a green run.
+    const { writer, commentSpy, addLabelSpy } = makeFakeWriter({
       failOn: { 1: { op: 'addLabel', status: 404 } }
     })
     await expect(
@@ -437,7 +441,9 @@ describe('commentAndLabel', () => {
         info: gaInfo,
         targets: [{ number: 1, kind: 'PR' }]
       })
-    ).resolves.toBeUndefined()
+    ).rejects.toThrow(/re-run/)
+    expect(commentSpy).toHaveBeenCalledOnce()
+    expect(addLabelSpy).toHaveBeenCalledOnce()
   })
 
   it('skips a FORBIDDEN thread read on a single target without failing', async () => {

--- a/packages/scripts/release-finalize.ts
+++ b/packages/scripts/release-finalize.ts
@@ -241,13 +241,13 @@ export async function commentAndLabel(args: {
 // are unique across issues and PRs in one repo, so the two lists never collide.
 function collectTargets(
   changes: Array<{ prNumber: number }>,
-  issues: Array<{ number: number }>
+  issues: number[]
 ): Target[] {
   return [
     ...changes.map(
       ({ prNumber }): Target => ({ number: prNumber, kind: 'PR' })
     ),
-    ...issues.map(({ number }): Target => ({ number, kind: 'issue' }))
+    ...issues.map((number): Target => ({ number, kind: 'issue' }))
   ]
 }
 

--- a/packages/scripts/release-finalize.ts
+++ b/packages/scripts/release-finalize.ts
@@ -191,6 +191,13 @@ export async function commentAndLabel(args: {
   const errors: unknown[] = []
   let unrecoverable = 0
   for (const { number, kind } of targets) {
+    // Hoisted out of the try: a non-empty `did` means we already wrote to this
+    // target this run, which proves it is reachable and writable — so a later
+    // failure (e.g. the label after a successful comment) is a real fault, not a
+    // deleted/forbidden target. Collect it (→ red run, re-run completes the
+    // missing side) rather than swallowing it as unrecoverable, which would
+    // leave the target silently commented-but-unlabelled on a green run.
+    const did: string[] = []
     try {
       const { labels, comments } = await writer.getThread(number)
       const needsComment = !hasReleaseComment(comments, marker)
@@ -199,7 +206,6 @@ export async function commentAndLabel(args: {
         console.log(`#${number}: already finalized, skipping`)
         continue
       }
-      const did: string[] = []
       if (needsComment) {
         await writer.comment(number, renderComment({ tag, kind }))
         did.push('commented')
@@ -210,7 +216,7 @@ export async function commentAndLabel(args: {
       }
       console.log(`#${number}: ${did.join(' + ')}`)
     } catch (error) {
-      if (isUnrecoverable(error)) {
+      if (did.length === 0 && isUnrecoverable(error)) {
         unrecoverable++
         console.warn(`#${number}: skipped (unrecoverable):`, error)
         continue

--- a/packages/scripts/release-notes-automation.test.ts
+++ b/packages/scripts/release-notes-automation.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type {
-  Change,
-  DirectCommitChange,
-  SquashedPRChange
-} from './lib/commit-graph'
+import type { Change, DirectCommitChange, SquashedPRChange } from './lib/change'
 import {
   breakingChanges,
   formatChangeLine,
@@ -20,7 +16,7 @@ function createChange(
 ): SquashedPRChange {
   return {
     source: 'squashedPR',
-    type: undefined,
+    type: null,
     breaking: false,
     description: '',
     author: null,
@@ -35,7 +31,7 @@ function createDirectCommitChange(
 ): DirectCommitChange {
   return {
     source: 'directCommit',
-    type: undefined,
+    type: null,
     breaking: false,
     description: '',
     author: 'Author Name',
@@ -69,7 +65,7 @@ describe('groupChangesByCategory', () => {
       createChange({ prNumber: 3, type: 'doc', description: 'update docs' }),
       createChange({ prNumber: 4, type: 'docs', description: 'more docs' }),
       createChange({ prNumber: 5, type: 'chore', description: 'maintenance' }),
-      createChange({ prNumber: 6, type: undefined, description: 'no type' })
+      createChange({ prNumber: 6, type: null, description: 'no type' })
     ]
 
     const result = groupChangesByCategory(changes)
@@ -143,15 +139,14 @@ describe('groupChangesByCategory', () => {
       createChange({
         prNumber: 1,
         type: 'fix',
-        closingIssues: [{ number: 100 }, { number: 101 }]
+        closingIssues: [100, 101]
       })
     ]
 
     const result = groupChangesByCategory(changes)
     const change = result['Bug fixes'][0]!
     expect(change.source === 'squashedPR' ? change.closingIssues : []).toEqual([
-      { number: 100 },
-      { number: 101 }
+      100, 101
     ])
   })
 })
@@ -193,7 +188,7 @@ describe('renderReleaseNotes', () => {
         breaking: false,
         description: 'fix bug',
         author: 'bob',
-        closingIssues: [{ number: 9 }]
+        closingIssues: [9]
       })
     ]
     expect(renderReleaseNotes(changes, ['alice', 'bob'])).toBe(
@@ -300,7 +295,7 @@ describe('formatChangeLine', () => {
     type: 'feat',
     description: 'add `useQueryState`',
     author: 'alice',
-    closingIssues: [{ number: 5 }],
+    closingIssues: [5],
     breaking: true
   }
 
@@ -371,13 +366,11 @@ describe('formatClosingIssues', () => {
   })
 
   it('formats single issue', () => {
-    expect(formatClosingIssues([{ number: 123 }])).toBe(' (closes #123)')
+    expect(formatClosingIssues([123])).toBe(' (closes #123)')
   })
 
   it('formats multiple issues', () => {
-    expect(formatClosingIssues([{ number: 123 }, { number: 456 }])).toBe(
-      ' (closes #123, #456)'
-    )
+    expect(formatClosingIssues([123, 456])).toBe(' (closes #123, #456)')
   })
 })
 

--- a/packages/scripts/release-notes-automation.ts
+++ b/packages/scripts/release-notes-automation.ts
@@ -13,9 +13,9 @@ import {
 import { discoverChanges, makeGitHubGraphReader } from './lib/commit-graph.ts'
 
 // The category vocabulary and the change grouping/breaking cross-cut now live in
-// the IO-free codec (`lib/changelog-dto.ts`), the SSOT shared with the docs
-// changelog page. Re-exported here so existing importers (and the test suite)
-// keep their entry point.
+// the IO-free codec (`lib/changelog-dto.ts`), the SSOT shared with the changelog
+// renderer. Re-exported here so existing importers (and the test suite) keep
+// their entry point.
 export {
   breakingChanges,
   CATEGORIES,
@@ -63,8 +63,8 @@ export function formatChangeLine(
 
 export function formatTitle(title: string): string {
   // Convert backtick code spans to <code> tags for GitHub release notes, via the
-  // shared span-parser — so the GitHub notes and the docs page render the (raw)
-  // description identically and cannot drift.
+  // shared span-parser — so the GitHub notes and the changelog page render the
+  // (raw) description identically and cannot drift.
   return parseCodeSpans(title)
     .map(segment =>
       segment.code ? `<code>${segment.value}</code>` : segment.value
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
     reader: makeGitHubGraphReader(env.GITHUB_TOKEN)
   })
   // The human-readable notes, followed by the machine-readable DTO comment the
-  // docs changelog page reads back (hidden on GitHub + in subscriber emails).
+  // changelog page reads back (hidden on GitHub + in subscriber emails).
   const notes = renderReleaseNotes(release.changes, release.contributors)
   console.log(`${notes}\n\n${renderChangelogComment(release)}`)
 }

--- a/packages/scripts/release-notes-automation.ts
+++ b/packages/scripts/release-notes-automation.ts
@@ -2,78 +2,30 @@
 
 import { createEnv } from '@t3-oss/env-core'
 import { z } from 'zod'
+import type { Change } from './lib/change.ts'
 import {
-  type Change,
-  discoverChanges,
-  type IssueRef,
-  makeGitHubGraphReader
-} from './lib/commit-graph.ts'
+  breakingChanges,
+  CATEGORIES,
+  groupChangesByCategory,
+  parseCodeSpans,
+  renderChangelogComment
+} from './lib/changelog-dto.ts'
+import { discoverChanges, makeGitHubGraphReader } from './lib/commit-graph.ts'
 
-export const CATEGORIES = [
-  'Features',
-  'Bug fixes',
-  'Documentation',
-  'Other changes'
-] as const
-export type Category = (typeof CATEGORIES)[number]
+// The category vocabulary and the change grouping/breaking cross-cut now live in
+// the IO-free codec (`lib/changelog-dto.ts`), the SSOT shared with the docs
+// changelog page. Re-exported here so existing importers (and the test suite)
+// keep their entry point.
+export {
+  breakingChanges,
+  CATEGORIES,
+  groupChangesByCategory
+} from './lib/changelog-dto.ts'
+export type { Category } from './lib/changelog-dto.ts'
 
-function categoryForType(type: string | undefined): Category {
-  switch (type) {
-    case 'feat':
-      return 'Features'
-    case 'fix':
-      return 'Bug fixes'
-    case 'doc':
-    case 'docs':
-      return 'Documentation'
-    default:
-      return 'Other changes'
-  }
-}
-
-// Order within a section: PR-sourced changes first (ascending PR number), then
-// direct-commit changes in their given order (discovery supplies them
-// oldest-first). Relies on a stable sort to preserve that commit order.
-function compareChanges(a: Change, b: Change): number {
-  if (a.source !== b.source) return a.source === 'squashedPR' ? -1 : 1
-  if (a.source === 'squashedPR' && b.source === 'squashedPR')
-    return a.prNumber - b.prNumber
-  return 0
-}
-
-// Group changes into their changelog categories. The category is derived from
-// the change's `type` (the commit's classification) — never a PR title, whose
-// prefix is irrelevant prose. The category is the bucket key, not a field on the
-// change, so the two can't drift.
-export function groupChangesByCategory(
-  changes: Change[]
-): Record<Category, Change[]> {
-  const categories: Record<Category, Change[]> = {
-    Features: [],
-    'Bug fixes': [],
-    Documentation: [],
-    'Other changes': []
-  }
-  for (const change of changes) {
-    categories[categoryForType(change.type)].push(change)
-  }
-  for (const category of CATEGORIES) {
-    categories[category].sort(compareChanges)
-  }
-  return categories
-}
-
-// The breaking-changes cross-cut: every change flagged `breaking`, in the same
-// PR-first / commit-oldest order. A filter over `breaking`, NOT a category — a
-// `feat!` stays in its type section and also appears here. Drives the top
-// "Breaking changes" section, the maintainer's editing surface for the guide.
-export function breakingChanges(changes: Change[]): Change[] {
-  return changes.filter(change => change.breaking).sort(compareChanges)
-}
-
-export function formatClosingIssues(issues: readonly IssueRef[]): string {
+export function formatClosingIssues(issues: readonly number[]): string {
   if (issues.length === 0) return ''
-  const issueNumbers = issues.map(i => `#${i.number}`).join(', ')
+  const issueNumbers = issues.map(number => `#${number}`).join(', ')
   return ` (closes ${issueNumbers})`
 }
 
@@ -110,8 +62,14 @@ export function formatChangeLine(
 }
 
 export function formatTitle(title: string): string {
-  // Convert backtick code blocks to <code> tags for better rendering in GitHub release notes
-  return title.replace(/`([^`]+)`/g, '<code>$1</code>')
+  // Convert backtick code spans to <code> tags for GitHub release notes, via the
+  // shared span-parser — so the GitHub notes and the docs page render the (raw)
+  // description identically and cannot drift.
+  return parseCodeSpans(title)
+    .map(segment =>
+      segment.code ? `<code>${segment.value}</code>` : segment.value
+    )
+    .join('')
 }
 
 export function formatThanksSection(contributors: string[]): string | null {
@@ -182,12 +140,15 @@ async function main(): Promise<void> {
     isServer: true,
     runtimeEnv: process.env
   })
-  const { changes, contributors } = await discoverChanges({
+  const release = await discoverChanges({
     channel: env.CHANNEL,
     currentRef: 'HEAD',
     reader: makeGitHubGraphReader(env.GITHUB_TOKEN)
   })
-  console.log(renderReleaseNotes(changes, contributors))
+  // The human-readable notes, followed by the machine-readable DTO comment the
+  // docs changelog page reads back (hidden on GitHub + in subscriber emails).
+  const notes = renderReleaseNotes(release.changes, release.contributors)
+  console.log(`${notes}\n\n${renderChangelogComment(release)}`)
 }
 
 if (import.meta.main) {

--- a/packages/scripts/validate-changelog-dto.ts
+++ b/packages/scripts/validate-changelog-dto.ts
@@ -1,20 +1,30 @@
 #!/usr/bin/env node
 
-// Exit 0 iff the release body on $RELEASE_BODY carries a changelog DTO that
-// parses through the shared codec (a well-formed, schema-valid `<changelog:dto>`
-// comment); exit 1 otherwise. This is `parseChangelogComment` — the very parse a
-// renderer runs — exposed as a process gate, so a caller that renders *only* the
-// parsed DTO can tell, before doing expensive work, whether a body would render
-// at all (a body with no valid DTO degrades to a bare entry, or renders nothing
-// new). Running the same codec keeps this gate from drifting from the renderer.
-//
-// The body is read from the environment, never an argument, so a `-->`-laden or
-// otherwise hostile body is only ever data to a pure parser, never shell input.
+// Gate for the release-edited ISR bust: runs the shared codec against
+// $RELEASE_BODY (env, never an argument — a hostile body is only ever parser
+// data, never shell input) and signals the result through three exit codes so a
+// codec regression can't masquerade as an expected "no DTO":
+//   0 — a valid DTO (bust the cache)
+//   1 — expected: no DTO present (skip busting)
+//   2 - an invalid DTO: the caller should fail the job loud
+//   3 - the codec threw (import/regression): the caller should fail the job loud
 
-import { parseChangelogComment } from './lib/changelog-dto.ts'
-
-if (parseChangelogComment(process.env.RELEASE_BODY ?? null) === null) {
-  console.error('No valid changelog DTO found in the release body.')
+try {
+  const { parseChangelogComment } = await import('./lib/changelog-dto.ts')
+  const result = parseChangelogComment(process.env.RELEASE_BODY ?? null)
+  if (result.status === 'ok') {
+    console.log('Release body carries a valid changelog DTO.')
+    process.exit(0)
+  }
+  if (result.status === 'invalid') {
+    console.error(
+      `Release body carries an INVALID changelog DTO: ${result.reason}`
+    )
+    process.exit(2)
+  }
+  console.info('No changelog DTO found in the release body')
   process.exit(1)
+} catch (error) {
+  console.error('validate-changelog-dto crashed (codec regression?):', error)
+  process.exit(3)
 }
-console.log('Release body carries a valid changelog DTO.')

--- a/packages/scripts/validate-changelog-dto.ts
+++ b/packages/scripts/validate-changelog-dto.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// Exit 0 iff the release body on $RELEASE_BODY carries a changelog DTO that
+// parses through the shared codec (a well-formed, schema-valid `<changelog:dto>`
+// comment); exit 1 otherwise. This is `parseChangelogComment` — the very parse a
+// renderer runs — exposed as a process gate, so a caller that renders *only* the
+// parsed DTO can tell, before doing expensive work, whether a body would render
+// at all (a body with no valid DTO degrades to a bare entry, or renders nothing
+// new). Running the same codec keeps this gate from drifting from the renderer.
+//
+// The body is read from the environment, never an argument, so a `-->`-laden or
+// otherwise hostile body is only ever data to a pure parser, never shell input.
+
+import { parseChangelogComment } from './lib/changelog-dto.ts'
+
+if (parseChangelogComment(process.env.RELEASE_BODY ?? null) === null) {
+  console.error('No valid changelog DTO found in the release body.')
+  process.exit(1)
+}
+console.log('Release body carries a valid changelog DTO.')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       remark-smartypants:
         specifier: ^3.0.2
         version: 3.0.2
+      scripts:
+        specifier: workspace:*
+        version: link:../scripts
       server-only:
         specifier: ^0.0.1
         version: 0.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
         version: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-mdx:
         specifier: 13.0.2
-        version: 13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.4)(yaml@2.9.0))
+        version: 13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.0.4
         version: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -252,6 +252,9 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
 
   packages/e2e: {}
 
@@ -12592,7 +12595,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.5(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.4)(yaml@2.9.0)):
+  fumadocs-mdx@13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.0.0
@@ -12615,7 +12618,7 @@ snapshots:
     optionalDependencies:
       next: 16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      vite: 7.3.5(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
The docs changelog page reverse-engineered each release from its rendered GitHub markdown, then hit the GitHub API once per PR at build to recover titles, authors and avatars. That didn't scale and caused issues with our refactored release process (introducing a breaking changes section & special formatting, and direct commits references)

This embeds a machine-readable DTO instead. At draft time the pipeline writes the structured change list as JSON inside an HTML comment in the release body, invisible on GitHub and stripped from notification emails. The docs page reads only that comment, validates it with a shared Zod schema, and renders every change, breaking marker, contributor and optional preamble statically, with no GitHub API calls for changelog data.

The format lives in one codec in scripts that both writes and reads it, so the serializer and parser can't drift again. A JSON Schema generated from the same schema covers out-of-band validation, kept in sync by a CI test. A release with a missing or broken DTO renders degraded as a minimal entry linking to GitHub, so one bad body can't blank the page or fail the build.

Tasks:
- [x] Backfill GA releases (no need for betas, they are not listed on the changelog page)
- [x] Setup ISR invalidation on post-publish to regen the page

<details>
<summary>PRD</summary>

# Changelog DTO for the docs changelog page

> PRD — embed a machine-readable **DTO** in each GitHub release body so the docs changelog page renders statically (no GitHub API enrichment, no markdown re-parsing), correctly handling direct commits, breaking changes, contributors, and an optional docs-only preamble.
> Parent PRD: [[[Phasing out semantic-release](https://github.com/47ng/nuqs/pull/Phasing%20out%20semantic-release)]] — the two-phase, human-gated release pipeline this builds on. Consumes the discovery engine from [[[commit-graph-parsedcommit-refactor](https://github.com/47ng/nuqs/pull/commit-graph-parsedcommit-refactor)]] and the notes format from [[[release-notes-classification](https://github.com/47ng/nuqs/pull/release-notes-classification)]]; sibling to [[[release-finalize.prd](https://github.com/47ng/nuqs/pull/release-finalize.prd)]].
> Status: design agreed (brainstorm Q1–Q16). Ready for implementation. Backfill execution deferred.
> Date: 2026-06-15

## Problem Statement

The docs changelog page renders release notes by **reverse-engineering the rendered markdown** of each GitHub release body, then **re-fetching from the GitHub API at build time**:

- It extracts changes with an ad-hoc regex that only understands a bare `#1234` PR reference, keeping `{ number }` and nothing else.
- For each number it calls `GET /repos/47ng/nuqs/pulls/{number}` to recover the title, author, avatar, and status, once per change, at every docs build.

The in-house release-notes pipeline (`release-notes-automation.ts`) now emits shapes this model cannot represent:

- **Direct-commit lines** (`<sha> - title, by Name`) have no `#NNN`, so the regex drops them silently. This is already live — seven direct commits vanished from `v2.8.10-beta.1`.
- **A "Breaking changes" section + migration guide** is misclassified into "Other changes" (the heading-text classifier matches none of feature/bug/fix/doc) and double-counted, since the same change also appears in its real category section.

The root cause is structural: the page reverses a **lossy serialization**, and the serializer (in `scripts`) and the parser (in `docs`) are two independent implementations of one undocumented line format that have **already drifted**. On top of that, the page does N GitHub API calls at build for data the pipeline already computed once, at draft time — slow, flaky, and rate-limit-exposed.

## Solution

At draft time the release pipeline embeds a **machine-readable DTO** (JSON) inside an HTML comment in the release body. The comment is invisible in the rendered GitHub page **and** stripped from subscriber notification emails (verified empirically), so it sits silently beside the human-readable notes.

The docs changelog page reads **only** that comment — never the rendered markdown, never the GitHub API — validates the DTO with a **shared Zod schema**, and renders every category, direct commits, accessible breaking markers, contributors, and an optional docs-only preamble, entirely statically.

The format is defined **once**, as a single shared codec in `scripts` that both serializes (pipeline) and parses (docs). A `$schema`-referenced JSON Schema artifact, generated from the same Zod schema, provides out-of-band/editor validation; a CI drift test keeps the artifact in sync with the code. This eliminates the drift class of bug (the breaking-section misfile and the dropped direct commits are two instances of it) instead of patching the parser to limp alongside a serializer it can't see.

## User Stories

1. As a docs reader, I want every change in a release to appear — including direct commits with no PR — so the changelog is complete and not silently lossy.
2. As a docs reader, I want breaking changes marked with a clear, accessible indicator, so I can spot them at a glance.
3. As a docs reader, I want a short migration/announcement note at the top of a release when relevant, so I know how to react before reading the change list.
4. As a docs reader, I want each change to link to its PR or its commit, so I can dig into the detail.
5. As a docs reader, I want the changelog page to load reliably and fast, so a GitHub API hiccup at build never blanks or breaks it.
6. As a docs reader, I want to see who contributed to each release, so contributions are visible and credited.
7. As a docs reader, I want a release whose data is missing or malformed to still appear as a minimal entry linking to GitHub, so the page never silently drops a release or fails to build.
8. As a contributor, I want my work credited on the docs changelog (inline author and a contributors footer), so my involvement is recognized beyond the GitHub notes.
9. As the maintainer, I want the DTO emitted automatically when the draft notes are generated, so I add no manual step to the release.
10. As the maintainer, I want to author a docs-only preamble in the draft, separate from the visible GitHub prose, so the two surfaces can diverge when needed.
11. As the maintainer, I want to edit the visible GitHub release notes freely after publish without affecting the docs page, so the two are decoupled.
12. As the maintainer, I want an always-present, empty preamble stub with a usage hint in the generated draft, so I never have to remember the syntax.
13. As the maintainer, I want DTO/schema problems to never fail the draft or finalize pipeline, so a release is never left half-staged and hard to recover.
14. As the maintainer, I want a broken hand-edit to the body to degrade a single release on the docs page rather than crash the build, so one mistake can't take the site down.
15. As an external tool or editor, I want each DTO to reference a public JSON Schema, so I can validate or autocomplete it out of band.
16. As a developer, I want a single shared schema as the source of truth, so the serializer and the parser cannot drift.
17. As a developer, I want the DTO to be type-safe across `scripts` and `docs`, so a schema change surfaces as a type error at the call sites.
18. As a developer, I want schema/artifact drift caught at merge in CI, so the published JSON Schema can never silently disagree with the code.
19. As a developer, I want to add a field to the DTO additively without breaking already-published releases, so evolution doesn't require touching history.
20. As a developer, I want the docs build to make zero GitHub API calls for changelog data, so the build is deterministic and unthrottled.
21. As a developer, I want older (pre-DTO) releases backfilled from the discovery engine rather than from their drifted bodies, so backfilled data is accurate regardless of the era's note format.
22. As a developer, I want to render old releases via a one-time backfill instead of maintaining a permanent legacy parser, so the docs code has a single path.
23. As a developer, I want the breaking/migration prose to live on dedicated docs migration pages, linked from the preamble, rather than encoded in the DTO, so authored prose stays where it is authored.

## Implementation Decisions

### Scope of the DTO

- The DTO carries the **structured change list only** — the data that is lossy and painful to reparse — not free-form prose. Shape: `{ $schema, changes[], contributors[] }`.
- `changes` is a **flat** list (not pre-grouped). Each change mirrors the existing discovery `Change` union, a discriminated union on `source`:
  - `squashedPR`: `prNumber`, `type`, `breaking`, `description`, `author` (GitHub login or null), `closingIssues` (flattened to `number[]`).
  - `directCommit`: `sha` (8 chars), `type`, `breaking`, `description`, `author` (git name).
- `category` is **not stored** — docs derives it at render from `type` via the shared `categoryForType`, so a future mapping change reclassifies all releases consistently.
- `breaking` is a **per-change flag** only; there is no separate breaking list in the DTO.
- No redundant `tag`/`channel`/URL fields — docs already has the tag/date/URL from the release object, and PR/commit links and avatars are **derived statically** (`github.com/47ng/nuqs/pull/{n}`, `…/commit/{sha}`, `github.com/{login}.png`).

### Preamble — two independent channels

- The **visible** body prose is GitHub-only; the docs page never reads it.
- A hidden, optional `changelog:preamble` block (raw markdown) is **docs-only**; rendered when present, ignored when empty/whitespace.
- The draft generator **always emits an empty preamble stub** with a guiding hint line (the hint sits inside the comment but outside the preamble tags, so GitHub hides it and docs ignores it).
- Docs reads **exclusively** from the HTML comment (preamble + DTO); zero coupling to the rendered markdown.
- Breaking/migration narrative is **not** in the DTO: it lives on dedicated docs migration pages, surfaced via the preamble link; the per-change `breaking` flag only drives an inline accessible marker.

### Embedding

- DTO and preamble live in **one HTML comment** in the body. The DTO is pretty-printed JSON; the serializer **escapes any `-->`** in string values (e.g. as `-->`) so the comment can't terminate early.
- The hidden preamble is raw markdown, so a literal `-->` there is a footgun that cannot be auto-escaped; it surfaces at docs build (parse fails → that release degrades), since finalize is body-blind by design.

### Shared codec + type safety

- A single **pure, IO-free codec module** in `scripts` is the SSOT: the Zod schema, inferred TS types (aligned with the discovery `Change`/`ReleaseChanges`), `serialize`, `parse`, and the `$schema` URL constant. No git/octokit in its import graph, so `docs` can import it without dragging IO into the Next bundle.
- `docs` takes a workspace dependency on `scripts` (and `transpilePackages: ['scripts']`) to import the Zod schema and codec. Runtime validation in docs is **Zod**, never the JSON Schema.

### `$schema` reference + JSON Schema artifact

- Each DTO includes `"$schema": "https://nuqs.dev/schemas/changelog-dto.v1.json"` — identity, editor support, and out-of-band validation. Docs **never fetches** it and **never branches** on it.
- The JSON Schema file is generated from the Zod SSOT via `z.toJSONSchema()` as a **throwaway export** (`node -e`/small script), committed under the docs `public/schemas/` directory, and served as a static file. Regenerated by hand only when the schema changes.
- Version is in the path (`v1`); it is expected to stay `v1` indefinitely because the schema evolves **additively** (new fields optional). A genuinely breaking change (deferred) would bump to `v2` and be absorbed by a one-time backfill of the in-window releases — docs never carries two parsers.

### Docs rendering

- `docs` makes **zero GitHub API calls** for the changelog. `PullRequestLine` is rewritten as a presentational component (no fetch); a new `CommitLine` renders direct commits; `GitHubProfile` is reused for inline author attribution (login authors only; direct-commit git names render as plain text).
- Changes are grouped/ordered via the shared `groupChangesByCategory` and the breaking cross-cut via the shared `breakingChanges`; breaking items get an **inline accessible icon** (a real icon with `aria-label`, not an emoji) — there is no separate breaking section on the page (that role is the preamble's).
- A **contributors footer** (new component, GitHub-style overlapping avatars + an `Intl.ListFormat` summary) renders per release from `contributors`.
- The preamble markdown is rendered with the existing remark → `hast-util-to-jsx-runtime` pipeline (no new dependency).
- The releases fetch makes a **single** list call (the newest 100), filtered to GA. It deliberately does **not** paginate the whole history: older GA releases beyond that page are surfaced by a **"See more releases on GitHub"** link at the end of the list, keeping the page bounded rather than dumping every release. (A single 50-item window previously showed only ~23 GA because betas consumed it; 100 captures the current GA set with headroom.)
- A change `description` is stored **raw** in the DTO (literal backticks, no presentation HTML). Docs renders **backtick code spans as `<code>`** and leaves everything else as escaped text — mirroring the existing `formatTitle` scope (balanced pairs only; a lone backtick stays literal). To guarantee GitHub notes and the docs page render identically, `formatTitle`'s transform is extracted into a **shared pure span-parser** in the codec module: `formatTitle` builds an HTML string from it (GitHub), docs builds React `<code>` nodes from it (page). Descriptions are never rendered as raw HTML.

### Failure / evolution policy

- **Degrade, never crash.** A missing, invalid, or unrecognized-version DTO renders a **degraded entry** (title + date + "View on GitHub") and logs a build warning; the page still builds and the release still appears.
- Schema evolves **additively**; the single current Zod parser reads old and new DTOs. Validation is a plain Zod `parse`: success → render, failure → degrade. No tripwire, no registry.

### Pipeline integration

- The DTO is written at **draft time** by `release-notes-automation.ts` (it already holds `changes` and `contributors` from `discoverChanges`); the codec's comment is appended to the generated notes body.
- **No fatal DTO validation in the release runtime.** The serializer is pure and tested; the draft path only serializes with tested code. All assertions (round-trip, drift) live in the test suites / PR CI, so a DTO concern can never abort a draft after the npm package is staged, nor a finalize.
- **Finalize stays body-blind** (reads only `tag_name`), so the maintainer's body edits never affect who gets commented, and the DTO needs no finalize-time handling.

### ISR caching and on-publish invalidation

- The changelog page is **statically generated at build and revalidated by tag**, not on a timer: it keeps `revalidate = false` and fetches releases under the `releases` cache tag (both already in place). After the redesign it makes a **single GitHub call** (the releases list, newest 100, under the same tag) and **zero per-PR enrichment calls**.
- The build typically runs **before** the release is published (the docs prod deploy is advanced just ahead of finalize), so the new release is picked up by an **on-publish tag bust**, not the build.
- The finalize workflow busts the `releases` tag (alongside the existing `contributors` bust), GA-only, gated on success — the same mechanism already used for the landing-page contributors. This requires allowlisting `releases` in the `/api/isr` route (today it accepts only `github`, `github-actions-status`, `npm-stats`, `contributors`).
- **Known race (accepted):** if the bust lands before the promoted Vercel deployment is live, it invalidates the outgoing deployment and the incoming one serves build-time (pre-release) data until the next bust/build. This is the *same* race the existing `contributors` bust already has in the same step, deemed acceptable; it self-heals, and the changelog data is fetched from the GitHub API at ISR time independent of the code deploy. A future hardening (out of scope) would fire the bust from a Vercel deploy-success webhook so it always targets the promoted deployment.
- **Post-publish edits:** a separate, minimal workflow triggers on `release: [edited]`, filtered to published releases (`!release.draft`), and busts the `releases` tag — so fixing a docs-only preamble or a broken DTO on an already-published release refreshes the page without waiting for the next release. It must NOT be added to the finalize workflow (which stays `published`-only; re-running its comment/label loop on a content edit would re-notify issues) — it only calls `/api/isr`. It is sequenced **after** the backfill (slice 8 → blocked by slice 7) so the backfill's ~23 body PATCHes don't each fire a bust.

### Backfill (deferred execution)

- Older releases are **backfilled** rather than served by a permanent fallback parser: a one-off script iterates GA tags from **v2.0.0** onward, regenerates each DTO via `discoverChanges` (format-agnostic, accurate), and **appends** the comment to each release body via the API (purely additive; editing notes is permitted under immutable releases, which lock only tags and assets).
- Pre-squash-era releases (v1.x, early v2.0.x) lack `(#N)` suffixes, so discovery renders them as bare direct commits with no PR links/logins/contributors; these need **manual curation** or are accepted as degraded. Releases earlier than v2.0.0 are out of the displayed window and skipped if not cleanly linkable.
- Backfill DTOs are to be generated and reviewed before scripting the body updates deterministically.

## Testing Decisions

A good test here asserts **external behavior** through a module's public interface, not its internals — mirroring the repo's established "pure core tested, IO shell untested by design" stance (see `lib/commit-graph.ts` and its `commit-graph.test.ts`, and `release-notes-automation.test.ts`).

- **The codec (primary target).** Round-trip property (`serialize` → `parse` → deep-equal) over both change variants; `-->` escaping (a value containing `-->` round-trips and never produces a literal terminator); a `description` containing backticks round-trips **raw** (no presentation HTML in the DTO); `parse` of a body with no comment, a malformed comment, or schema-invalid JSON returns the degrade signal; the empty/whitespace preamble resolves to "none"; Zod accepts each `squashedPR`/`directCommit` shape and rejects malformed ones. Prior art: `release-notes-automation.test.ts`, `commit-graph.test.ts`.
- **The shared span-parser.** Balanced backtick pairs become code segments, a lone backtick stays literal text, and the same segments drive both `formatTitle`'s HTML (GitHub) and the docs `<code>` rendering — so a description can't render differently on the two surfaces. Prior art: `release-notes-automation.test.ts` (which already tests `formatTitle`).
- **The schema drift test (docs).** Regenerate `toJSONSchema(zodSchema)` and deep-equal the committed `public/schemas/changelog-dto.v1.json`; any schema change that isn't re-exported fails CI. This requires adding vitest to `docs` (none today — its `test` script is typecheck-only); use the repo's `catalog:vitest`, as `scripts` does.
- **The docs pure transform.** If the parse-and-group step is extracted as a pure function (release body → render model, with degrade), test it directly: direct commits surface, categories group correctly, breaking flags map through, a broken DTO yields a degraded entry.
- **Untested by design.** The IO shells (docs releases fetch, backfill API PATCH) and the React presentational components — consistent with the repo convention; correctness there is covered by `tsc` and manual verification.

## Out of Scope

- Rendering the full breaking-changes/migration **prose** on the changelog page — it stays on dedicated migration pages, linked via the preamble.
- A **v2** schema and any multi-version parser registry — deferred; the additive-only policy keeps a single parser, and a future hard break is handled by backfill.
- **Executing** the backfill — this PRD specifies the mechanism; the sweep (and any manual curation of pre-squash releases) is a separate, later task.
- Changing the GitHub release **notes format** itself (the human-readable markdown) beyond appending the comment.
- Restyling the changelog page beyond what the new data model requires (direct commits, breaking markers, contributors footer, preamble).
- Backfilling or displaying releases **earlier than v2.0.0**.

## Further Notes

- **Email/visibility verified.** A test release confirmed HTML comments (DTO and sentinel markers) are stripped from subscriber notification emails while fenced visible prose and code render normally — so hiding the DTO and the preamble in a comment is safe on every surface.
- **REST verbatim-body verified.** The releases REST API returns `body` verbatim, including every HTML comment and its contents (`changelog:preamble`/`changelog:dto` tags and inner code fences) — checked against `franky47/actions-laboratory@testing-html-comments-2`. So the docs build reads exactly what the pipeline wrote, even though render and email show none of it; the parser locates the `<changelog:dto>`/`<changelog:preamble>` tags directly in `body`.
- **Immutable releases** lock only tags and assets; titles and notes remain editable after publish — which is why the inline-in-body DTO (editable, hand-tweakable) is a better fit than a release **asset** (which immutability would freeze).
- **`$schema` URL form** chosen: a branded, stable, versioned URL served by the docs site, over tag-/SHA-pinned raw GitHub URLs — simplest tripwire-free identity, with integrity guaranteed by the append-only artifact plus the CI drift test rather than per-release byte-pinning.
- **Numbers behind the decisions (as of 2026-06-15):** 60 GA releases, 40 betas; the most-recent-50 fetch window contains only ~23 GA (betas consume the rest) and spans ~17 months — which is why a transitional fallback parser would live ~17 months, tipping the decision toward backfill.
- The DTO is essentially `discoverChanges`' `ReleaseChanges` output plus a `$schema` field, so serialization is near-free and the codec's Zod schema can become the typed home of the `Change`/`ReleaseChanges` shapes.

---

## Implementation Slices

Tracer-bullet vertical slices. Slice 1 is the spine (the codec exercised end-to-end); slices 2–6 each add one capability on top and are blocked only by slice 1; slice 7 (backfill) is the deferred, human-gated tail; slice 8 (post-publish edit invalidation) follows the backfill so the backfill doesn't trigger it. Only slice 7 is HITL. Until slice 7 runs, the ~23 historical in-window releases render as degraded entries (title + date + link) — the page is correct and builds; new releases are full-fidelity immediately.

### Slice 1 — Tracer bullet: DTO round-trips pipeline → docs (PR changes) · AFK

Blocked by: —

**What to build**

The thinnest end-to-end path proving the whole pipe. The shared pure codec in `scripts` (Zod schema for the full DTO, `serialize`, `parse`, the `$schema` URL constant, `-->` escaping). The release pipeline appends the DTO comment to the generated draft notes. The docs changelog takes a workspace dependency on `scripts` (+ `transpilePackages`), fetches a single page of the newest 100 releases and filters to GA (a "See more releases on GitHub" link at the end covers older ones), parses the DTO via the codec, and renders **PR-sourced (`squashedPR`) changes grouped by category with zero GitHub API calls** — reusing `GitHubProfile` for author lines and replacing the `PullRequestLine` fetch. Missing/invalid DTO → degraded entry. See PRD "Shared codec + type safety", "Docs rendering", "Failure / evolution policy", "Pipeline integration".

The **embedded comment block** — one HTML comment carrying a hint line, an (empty until slice 5) preamble region, and the DTO. The hint sits outside the preamble tags, so GitHub hides it and docs ignores it:

```text
<!--
Any Markdown between the preamble tags shows up in the docs' changelog page:
<changelog:preamble></changelog:preamble>
<changelog:dto>
{
  "$schema": "https://nuqs.dev/schemas/changelog-dto.v1.json",
  "changes": [
    {
      "source": "squashedPR",
      "prNumber": 1450,
      "type": "feat",
      "breaking": true,
      "description": "return null on invalid parser input",
      "author": "franky47",
      "closingIssues": [1442]
    },
    {
      "source": "directCommit",
      "sha": "a1b2c3d4",
      "type": null,
      "breaking": false,
      "description": "fix typo in funding link",
      "author": "François Best"
    }
  ],
  "contributors": ["contributorA", "contributorB"]
}
</changelog:dto>
-->
```

The **DTO schema** (Zod is the SSOT; types inferred from it; `$schema` is a literal, so a future breaking `v2` URL simply fails `parse` → degrade, no version branching):

```ts
export const CHANGELOG_DTO_SCHEMA_URL =
  'https://nuqs.dev/schemas/changelog-dto.v1.json'

const change = z.discriminatedUnion('source', [
  z.object({
    source: z.literal('squashedPR'),
    prNumber: z.number().int().positive(),
    type: z.string().nullable(),       // conventional-commit type, or null
    breaking: z.boolean(),
    description: z.string(),           // PR title prose, cosmetic prefix stripped
    author: z.string().nullable(),     // GitHub login, or null (deleted account)
    closingIssues: z.array(z.number().int().positive())
  }),
  z.object({
    source: z.literal('directCommit'),
    sha: z.string(),                   // 8-char short hash
    type: z.string().nullable(),
    breaking: z.boolean(),
    description: z.string(),           // commit subject
    author: z.string()                 // git author name (not a login)
  })
])

export const changelogDtoSchema = z.object({
  $schema: z.literal(CHANGELOG_DTO_SCHEMA_URL),
  changes: z.array(change),
  contributors: z.array(z.string())    // GitHub logins; bots + maintainer excluded
})

export type ChangelogDTO = z.infer<typeof changelogDtoSchema>
```

The **codec surface** (pure, IO-free — the only interface the pipeline and docs consume):

```ts
// ReleaseChanges → the full HTML comment block (DTO + empty preamble stub),
// escaping any "-->" inside string values so the comment can't terminate early.
export function renderChangelogComment(release: ReleaseChanges): string

// Extract + Zod-validate from a release body.
// null when the comment is absent or invalid (→ docs degrades that release).
export function parseChangelogComment(
  body: string | null
): { preamble: string | null; dto: ChangelogDTO } | null
```

**Acceptance criteria**

- [x] Codec serializes a `ReleaseChanges` payload into one HTML comment (pretty JSON, escaped `-->`) and parses it back to an equal value (round-trip).
- [x] The draft notes generated by the pipeline contain the DTO comment.
- [x] The docs changelog renders a freshly drafted release's PR changes, grouped by category, making no GitHub API calls.
- [x] A release with no/invalid DTO renders a degraded entry and logs a build warning; the build does not fail.
- [x] `docs` imports the codec from `scripts` without pulling git/octokit into the bundle.
- [x] The page is tag-revalidated (`revalidate = false`, `releases` tag) and makes a single releases-list call (newest 100, filtered to GA; a "See more releases on GitHub" link covers older releases) with no per-PR enrichment; `releases` is allowlisted in the `/api/isr` route and busted by the finalize workflow (alongside `contributors`), so publishing a release refreshes the page. See PRD "ISR caching and on-publish invalidation".
- [x] A description with backticks (e.g. ``backticks `demo` ``) round-trips raw in the DTO and renders as inline `<code>` on the page, matching the GitHub notes via the shared span-parser.

**User stories addressed**: 1 (partial), 4, 5, 7 (basic), 9, 16, 17, 20, 22

### Slice 2 — Direct-commit changes · AFK

Blocked by: Slice 1

**What to build**

Render the `directCommit` entries the codec already carries: a new `CommitLine` (derived commit link, plain-text git author, no avatar). Fixes the live bug where direct-commit lines were silently dropped. See PRD "Scope of the DTO", "Docs rendering".

**Acceptance criteria**

- [x] A release whose DTO contains a `directCommit` change renders it with a commit link and the author name.
- [x] The seven direct commits dropped from `v2.8.10-beta.1` render (verified against its regenerated DTO).
- [x] `squashedPR` and `directCommit` entries coexist in the same category section in the correct order.

**User stories addressed**: 1 (complete), 6

### Slice 3 — Breaking-change marker · AFK

Blocked by: Slice 1

**What to build**

Render an inline accessible icon (lucide `TriangleAlert` with `aria-label`) on changes whose DTO `breaking` flag is set, within their category section. No standalone breaking section (that role is the preamble's). See PRD "Preamble — two independent channels", "Docs rendering".

**Acceptance criteria**

- [x] A breaking change shows the icon inline with an accessible label; a non-breaking one does not.
- [x] No standalone "Breaking changes" section is rendered on the page.

**User stories addressed**: 2

### Slice 4 — Contributors footer · AFK

Blocked by: Slice 1

**What to build**

A new per-release contributors component: overlapping GitHub avatars (`github.com/{login}.png`) + an `Intl.ListFormat` summary, from the DTO `contributors`. See PRD "Docs rendering".

**Acceptance criteria**

- [x] A release with contributors shows the avatar row + "X, Y, and N other contributors" summary.
- [x] A release with no contributors shows no footer.
- [x] No GitHub API calls are made for avatars or names.

**User stories addressed**: 8

### Slice 5 — Docs-only preamble · AFK

Blocked by: Slice 1

**What to build**

The pipeline emits the always-present empty preamble stub + guiding hint inside the comment; the codec extracts the preamble block; docs renders its markdown (existing remark → hast pipeline) when non-empty, nothing when empty/whitespace. The visible body stays GitHub-only. See PRD "Preamble — two independent channels", "Embedding".

A **filled preamble** (multi-line markdown, code fences allowed) the maintainer authors in the draft — docs renders it above the change list; an empty/whitespace region renders nothing:

````md
<!--
Any Markdown between the preamble tags shows up in the docs' changelog page:
<changelog:preamble>
nuqs v2.9 changes parser error handling — see the [migration guide](/docs/migrations/v2.9).

```ts
const value = parseAsInteger.parse(input) // null on bad input, no longer throws
```
</changelog:preamble>
<changelog:dto> { /* … */ } </changelog:dto>
-->
````

**Acceptance criteria**

- [x] Generated draft notes contain an empty `changelog:preamble` stub with the hint line (hidden on GitHub).
- [x] A non-empty preamble renders as markdown above the release's change list on the docs page.
- [x] An empty/whitespace preamble renders nothing.
- [x] The visible GitHub body prose is never rendered by docs.

**User stories addressed**: 10, 11, 12, 23

### Slice 6 — JSON Schema artifact + drift test · AFK

Blocked by: Slice 1

**What to build**

A throwaway export generates the JSON Schema from the Zod SSOT (`z.toJSONSchema`) into the committed `docs/public/schemas/changelog-dto.v1.json`, served at the `$schema` URL. Add vitest to `docs` plus a drift test that regenerates and deep-equals the committed file. See PRD "$schema reference + JSON Schema artifact", "Testing Decisions".

**Acceptance criteria**

- [x] The committed JSON Schema is served at the `$schema` URL.
- [x] A vitest drift test fails when the Zod schema changes without re-exporting the artifact.
- [x] vitest runs in the docs CI.

**User stories addressed**: 15, 18, 19

### Slice 7 — Backfill in-window releases from v2.0.0 · HITL (deferred)

Blocked by: Slices 1–5

**What to build**

A one-off script that, for each GA tag ≥ v2.0.0, regenerates the DTO via `discoverChanges` and appends the comment to the release body via the API (additive; permitted under immutable releases). Pre-squash-era entries are manually curated/reviewed before the deterministic sweep; releases earlier than v2.0.0 are skipped. Generation + review precede any body update. See PRD "Backfill (deferred execution)".

**Acceptance criteria**

- [x] DTOs are generated for GA tags ≥ v2.0.0 and reviewed before any body is edited.
- [x] Each targeted release body gains the DTO comment without altering its visible content.
- [x] After the sweep, in-window historical releases render full-fidelity (no degraded entries) on the docs page.
- [x] Pre-squash entries are curated or accepted as degraded per review.

**User stories addressed**: 21 (+ history fidelity for 1, 4, 6, 8)

### Slice 8 — Post-publish edit → ISR invalidation · AFK

Blocked by: Slice 7

**What to build**

A separate, minimal workflow on `release: [edited]`, filtered to published releases (`!release.draft`), that busts the `releases` ISR tag via `/api/isr` — so a post-publish fix to a docs-only preamble or a broken DTO refreshes the changelog page without waiting for the next release. Sequenced after the backfill so the backfill's body PATCHes don't each fire a bust. See PRD "ISR caching and on-publish invalidation".

**Acceptance criteria**

- [x] Editing a published release's body refreshes the changelog page (the `releases` tag is busted).
- [x] The workflow is separate from finalize and does not run any comment/label logic.
- [x] Draft edits do not trigger a bust.

**User stories addressed**: 11, 14

</details>