### PR TITLE
chore: don't run Lint PR Title on merged PRs and body-only edits

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   lint-pr-title:
     name: Lint PR Title
+    # Skip merged PRs and body-only edits (we lint titles, not bodies).
+    if: >-
+      ${{ !github.event.pull_request.merged &&
+          (github.event.action != 'edited' || github.event.changes.title.from) }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
Editing a merged PR re-fired the check against an unfetchable squash-merged head SHA, and body edits triggered a title-only linter for no reason. on:-level filters can't see PR state or which field changed, so guard at the job level.