### PR TITLE
chore: replace MailPace SDK with minimal implementation

### DIFF
--- a/packages/scripts/lib/mailpace.test.ts
+++ b/packages/scripts/lib/mailpace.test.ts
@@ -1,0 +1,54 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { sendEmail } from './mailpace.ts'
+
+const endpoint = 'https://app.mailpace.com/api/v1/send'
+
+const email = {
+  from: 'release-bot@example.com',
+  to: 'maintainer@example.com',
+  subject: '[nuqs] test',
+  textbody: 'Body of the email',
+  tags: ['nuqs']
+}
+
+describe('sendEmail', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('posts the email to the MailPace API with the auth token in the header', async () => {
+    let captured:
+      | { token: string | null; contentType: string | null; body: unknown }
+      | undefined
+    server.use(
+      http.post(endpoint, async ({ request }) => {
+        captured = {
+          token: request.headers.get('MailPace-Server-Token'),
+          contentType: request.headers.get('Content-Type'),
+          body: await request.json()
+        }
+        return HttpResponse.json({ id: 1, status: 'pending' })
+      })
+    )
+    await sendEmail('api-token-123', email)
+    expect(captured).toEqual({
+      token: 'api-token-123',
+      contentType: 'application/json',
+      body: email
+    })
+  })
+
+  it('throws with the status and error detail when the API rejects the request', async () => {
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json({ error: 'Invalid API Token' }, { status: 400 })
+      )
+    )
+    await expect(sendEmail('bad-token', email)).rejects.toThrow(
+      /400.*Invalid API Token/
+    )
+  })
+})

--- a/packages/scripts/lib/mailpace.ts
+++ b/packages/scripts/lib/mailpace.ts
@@ -1,0 +1,33 @@
+// Minimal MailPace client: the official SDK is unmaintained and pulled in a
+// vulnerable, ancient axios. We only send a couple of plaintext emails from the
+// release pipeline, so a thin fetch wrapper around the one endpoint is enough.
+// https://docs.mailpace.com/reference/send
+
+const SEND_ENDPOINT = 'https://app.mailpace.com/api/v1/send'
+
+export type MailPaceEmail = {
+  from: string
+  to: string
+  subject: string
+  textbody: string
+  tags?: string[]
+}
+
+export async function sendEmail(
+  apiToken: string,
+  email: MailPaceEmail
+): Promise<void> {
+  const response = await fetch(SEND_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'MailPace-Server-Token': apiToken
+    },
+    body: JSON.stringify(email)
+  })
+  if (!response.ok) {
+    const detail = await response.text()
+    throw new Error(`MailPace API error ${response.status}: ${detail}`)
+  }
+}

--- a/packages/scripts/next-release-analyser.ts
+++ b/packages/scripts/next-release-analyser.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import MailPace from '@mailpace/mailpace.js'
 import { createEnv } from '@t3-oss/env-core'
 import minimist from 'minimist'
 import { z } from 'zod'
+import { sendEmail } from './lib/mailpace.ts'
 
 const gaRegexp = /^\d+\.\d+\.\d+$/
 const canaryRegexp = /^(\d+)\.(\d+)\.(\d+)-canary\.(\d+)$/
@@ -74,7 +74,6 @@ function getPreviousVersion(version: string) {
 }
 
 async function sendNotificationEmail(thisVersion: string, files: File[]) {
-  const client = new MailPace.DomainClient(env.MAILPACE_API_TOKEN)
   const release = await fetch(
     `https://api.github.com/repos/vercel/next.js/releases/tags/v${thisVersion}`
   ).then(res => res.json())
@@ -104,7 +103,7 @@ ${patchSection}
   if (!env.CI) {
     return
   }
-  return client.sendEmail({
+  return sendEmail(env.MAILPACE_API_TOKEN, {
     from: env.EMAIL_ADDRESS_FROM,
     to: env.EMAIL_ADDRESS_TO,
     subject,
@@ -114,7 +113,6 @@ ${patchSection}
 }
 
 function sendGAEmail(thisVersion: string) {
-  const client = new MailPace.DomainClient(env.MAILPACE_API_TOKEN)
   const subject = `[nuqs] Next.js ${thisVersion} was published to GA`
   const body = `https://github.com/vercel/next.js/releases/tag/v${thisVersion}`
   console.info('Sending email:', subject)
@@ -122,7 +120,7 @@ function sendGAEmail(thisVersion: string) {
   if (!env.CI) {
     return
   }
-  return client.sendEmail({
+  return sendEmail(env.MAILPACE_API_TOKEN, {
     from: env.EMAIL_ADDRESS_FROM,
     to: env.EMAIL_ADDRESS_TO,
     subject,

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -12,7 +12,6 @@
     "test:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@mailpace/mailpace.js": "^0.1.3",
     "@t3-oss/env-core": "^0.13.10",
     "minimist": "^1.2.8",
     "octokit": "^5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,7 +510,7 @@ importers:
         version: 1.58.1
       '@remix-run/dev':
         specifier: ^2.17.4
-        version: 2.17.4(@remix-run/react@2.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@remix-run/serve@2.17.4(typescript@5.9.3))(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(ts-node@9.1.1(typescript@5.9.3))(tsx@4.20.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(yaml@2.9.0)
+        version: 2.17.4(@remix-run/react@2.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@remix-run/serve@2.17.4(typescript@5.9.3))(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(yaml@2.9.0)
       '@types/react':
         specifier: catalog:react19
         version: 19.2.10
@@ -801,9 +801,6 @@ importers:
 
   packages/scripts:
     dependencies:
-      '@mailpace/mailpace.js':
-        specifier: ^0.1.3
-        version: 0.1.3(typescript@5.9.3)
       '@t3-oss/env-core':
         specifier: ^0.13.10
         version: 0.13.10(arktype@2.1.29)(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6)
@@ -2022,10 +2019,6 @@ packages:
 
   '@jspm/core@2.1.0':
     resolution: {integrity: sha512-3sRl+pkyFY/kLmHl0cgHiFp2xEqErA8N3ECjMs7serSUBmoJ70lBa0PG5t0IM6WJgdZNyyI0R8YFfi5wM8+mzg==}
-
-  '@mailpace/mailpace.js@0.1.3':
-    resolution: {integrity: sha512-egh8at5vGozWdofvmZMzKdFKDEILWqi4HTGq9fb6zzfgEzvd4IU+mB+2vFbmgSzRudyDHrD3rXhEKOhgsVx5ww==}
-    engines: {node: '>=10'}
 
   '@mdx-js/mdx@2.3.0':
     resolution: {integrity: sha512-jLuwRlz8DQfQNiUCJR50Y09CGPq3fLtmtUQfVrj79E0JWu3dvsVcxVIcfhR5h0iXu+/z++zDrYeiJqifRynJkA==}
@@ -4016,9 +4009,6 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@14.18.63':
-    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
-
   '@types/node@24.10.10':
     resolution: {integrity: sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==}
 
@@ -4198,9 +4188,6 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
-
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -4248,9 +4235,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -4563,9 +4547,6 @@ packages:
       typescript:
         optional: true
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
@@ -4730,10 +4711,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -5077,15 +5054,6 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
-
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -5958,9 +5926,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   markdown-extensions@1.1.1:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
@@ -7756,13 +7721,6 @@ packages:
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
-  ts-node@9.1.1:
-    resolution: {integrity: sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.7'
-
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -8342,10 +8300,6 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -9278,15 +9232,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jspm/core@2.1.0': {}
-
-  '@mailpace/mailpace.js@0.1.3(typescript@5.9.3)':
-    dependencies:
-      '@types/node': 14.18.63
-      axios: 0.21.4
-      ts-node: 9.1.1(typescript@5.9.3)
-    transitivePeerDependencies:
-      - debug
-      - typescript
 
   '@mdx-js/mdx@2.3.0':
     dependencies:
@@ -10442,7 +10387,7 @@ snapshots:
       react: 19.2.4
       react-redux: 9.2.0(@types/react@19.2.10)(react@19.2.4)(redux@5.0.1)
 
-  '@remix-run/dev@2.17.4(@remix-run/react@2.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@remix-run/serve@2.17.4(typescript@5.9.3))(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(ts-node@9.1.1(typescript@5.9.3))(tsx@4.20.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(yaml@2.9.0)':
+  '@remix-run/dev@2.17.4(@remix-run/react@2.17.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@remix-run/serve@2.17.4(typescript@5.9.3))(@types/node@24.10.10)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.20.4)(typescript@5.9.3)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.17.6)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.0
@@ -10487,7 +10432,7 @@ snapshots:
       pidtree: 0.6.0
       postcss: 8.5.15
       postcss-discard-duplicates: 5.1.0(postcss@8.5.15)
-      postcss-load-config: 4.0.2(postcss@8.5.15)(ts-node@9.1.1(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.15)
       postcss-modules: 6.0.1(postcss@8.5.15)
       prettier: 2.8.8
       pretty-ms: 7.0.1
@@ -11238,8 +11183,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@14.18.63': {}
-
   '@types/node@24.10.10':
     dependencies:
       undici-types: 7.16.0
@@ -11498,8 +11441,6 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  arg@4.1.3: {}
-
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -11547,12 +11488,6 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-
-  axios@0.21.4:
-    dependencies:
-      follow-redirects: 1.15.11
-    transitivePeerDependencies:
-      - debug
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -11874,8 +11809,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-require@1.1.1: {}
-
   cross-env@10.1.0:
     dependencies:
       '@epic-web/invariant': 1.0.0
@@ -11995,8 +11928,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  diff@4.0.2: {}
 
   diff@5.2.0: {}
 
@@ -12509,8 +12440,6 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-
-  follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
     dependencies:
@@ -13329,8 +13258,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
-
-  make-error@1.3.6: {}
 
   markdown-extensions@1.1.1: {}
 
@@ -14667,13 +14594,12 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  postcss-load-config@4.0.2(postcss@8.5.15)(ts-node@9.1.1(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.15):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.9.0
     optionalDependencies:
       postcss: 8.5.15
-      ts-node: 9.1.1(typescript@5.9.3)
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.15):
     dependencies:
@@ -15821,16 +15747,6 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  ts-node@9.1.1(typescript@5.9.3):
-    dependencies:
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      source-map-support: 0.5.21
-      typescript: 5.9.3
-      yn: 3.1.1
-
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -16407,8 +16323,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Allows dropping axios as a sub-dependency and keeps things lean.