### PR TITLE
doc: add Deno & other package managers to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Read the complete documentation at [nuqs.dev](https://nuqs.dev).
 ## Installation
 
 ```shell
+npm install nuqs
+```
+
+```shell
 pnpm add nuqs
 ```
 
@@ -34,15 +38,11 @@ yarn add nuqs
 ```
 
 ```shell
-npm install nuqs
+bun add nuqs
 ```
 
 ```shell
 deno add nuqs
-```
-
-```shell
-bun add nuqs
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ yarn add nuqs
 npm install nuqs
 ```
 
+```shell
+deno add nuqs
+```
+
 ## Adapters
 
 You will need to wrap your React component tree with an adapter for your framework. _(expand the appropriate section below)_

--- a/README.md
+++ b/README.md
@@ -46,11 +46,7 @@ deno add nuqs
 ```
 
 ```shell
-vlt add nuqs
-```
-
-```shell
-nub add nuqs
+vlt install nuqs
 ```
 
 ## Adapters

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ npm install nuqs
 deno add nuqs
 ```
 
+```shell
+bun add nuqs
+```
+
+```shell
+vlt add nuqs
+```
+
+```shell
+nub add nuqs
+```
+
 ## Adapters
 
 You will need to wrap your React component tree with an adapter for your framework. _(expand the appropriate section below)_

--- a/packages/docs/source.config.ts
+++ b/packages/docs/source.config.ts
@@ -13,7 +13,18 @@ export default defineConfig({
   lastModifiedTime: 'git',
   mdxOptions: {
     remarkPlugins: [remarkSmartypants, remarkAudience],
-    rehypeCodeOptions
+    rehypeCodeOptions,
+    remarkNpmOptions: {
+      packageManagers: [
+        { name: 'npm', command: () => 'npm i nuqs' },
+        { name: 'pnpm', command: () => 'pnpm add nuqs' },
+        { name: 'yarn', command: () => 'yarn add nuqs' },
+        { name: 'bun', command: () => 'bun add nuqs' },
+        { name: 'deno', command: () => 'deno add nuqs' },
+        { name: 'vlt', command: () => 'vlt add nuqs' },
+        { name: 'nub', command: () => 'nub add nuqs' }
+      ]
+    }
   }
 })
 

--- a/packages/docs/source.config.ts
+++ b/packages/docs/source.config.ts
@@ -21,8 +21,7 @@ export default defineConfig({
         { name: 'yarn', command: () => 'yarn add nuqs' },
         { name: 'bun', command: () => 'bun add nuqs' },
         { name: 'deno', command: () => 'deno add nuqs' },
-        { name: 'vlt', command: () => 'vlt add nuqs' },
-        { name: 'nub', command: () => 'nub add nuqs' }
+        { name: 'vlt', command: () => 'vlt install nuqs' }
       ]
     }
   }


### PR DESCRIPTION
👋 Bartek from the Deno team here. Thanks for nuqs.

The Installation section lists pnpm / yarn / npm. Since Deno is a drop-in replacement for npm these days, this adds a Deno line in parity, using `deno add` to match the others:

```shell
deno add nuqs
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
