### PR TITLE
ref: scope nullable useSearchParams defence to Next.js specific adapter

### DIFF
--- a/packages/nuqs/src/adapters/next/impl.app.browser.test.tsx
+++ b/packages/nuqs/src/adapters/next/impl.app.browser.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from 'vitest-browser-react'
+import { useNuqsNextAppRouterAdapter } from './impl.app'
+
+// `useSearchParams()` returns `null` when rendered outside a SearchParamsContext
+// provider (e.g. `app/global-error` before Next 15.2, or isolated mounts/tests).
+// nuqs builds without a `pages/` dir, so it only sees the non-null app-router
+// overload — this null path can't surface from types, only by forcing it here.
+// The adapter must still expose a non-null `searchParams` (AdapterInterface).
+vi.mock('next/navigation.js', () => ({
+  default: {},
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => null
+}))
+
+describe('Next App Router Adapter', () => {
+  it('coalesces a null `useSearchParams()` into a non-null URLSearchParams', async () => {
+    const { result } = await renderHook(() => useNuqsNextAppRouterAdapter())
+    expect(result.current.searchParams).toBeInstanceOf(URLSearchParams)
+    expect(result.current.searchParams.size).toBe(0)
+  })
+})

--- a/packages/nuqs/src/adapters/next/impl.app.ts
+++ b/packages/nuqs/src/adapters/next/impl.app.ts
@@ -109,7 +109,11 @@ export function NavigationSpy() {
 
 export function useNuqsNextAppRouterAdapter(): AdapterInterface {
   const router = useRouter()
-  const searchParams = useSearchParams()
+  // `useSearchParams` is typed `ReadonlyURLSearchParams | null` for consumer
+  // apps that have a `pages/` directory (Next injects that compat overload
+  // through next-env.d.ts). Only truly null when rendered outside a
+  // SearchParamsContext provider: tests/mocks, or `app/global-error` (pre-15.2).
+  const searchParams = useSearchParams() ?? new URLSearchParams()
   const [optimisticSearchParams, setOptimisticSearchParams] =
     useOptimistic<URLSearchParams>(searchParams)
   const updateUrl: UpdateUrlFunction = useCallback((search, options) => {

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -125,10 +125,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const queuedQueries = debounceController.useQueuedQueries(
     Object.values(resolvedUrlKeys)
   )
-  const [internalState, setInternalState] = useState<V>(() => {
-    const source = initialSearchParams ?? new URLSearchParams()
-    return parseMap(keyMap, urlKeys, source, queuedQueries).state
-  })
+  const [internalState, setInternalState] = useState<V>(
+    () => parseMap(keyMap, urlKeys, initialSearchParams, queuedQueries).state
+  )
 
   const stateRef = useRef(internalState)
 
@@ -138,7 +137,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // (optimistic) updates which don't immediately alter the URL source.
   const searchParamsSyncKey =
     Object.values(resolvedUrlKeys)
-      .map(key => `${key}=${initialSearchParams?.getAll(key)}`)
+      .map(key => `${key}=${initialSearchParams.getAll(key)}`)
       .join('&') + JSON.stringify(queuedQueries)
   // Adopts the current URL value into the internal state when it has changed.
   // Used both during render (below) and from the effect backstop further down.
@@ -190,8 +189,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           return [
             urlKey,
             parser?.type === 'multi'
-              ? initialSearchParams?.getAll(urlKey)
-              : (initialSearchParams?.get(urlKey) ?? null)
+              ? initialSearchParams.getAll(urlKey)
+              : (initialSearchParams.get(urlKey) ?? null)
           ]
         })
       )
@@ -430,8 +429,8 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
     const query =
       queuedQuery === undefined
         ? ((parser.type === 'multi'
-            ? searchParams?.getAll(urlKey)
-            : searchParams?.get(urlKey)) ?? fallbackValue)
+            ? searchParams.getAll(urlKey)
+            : searchParams.get(urlKey)) ?? fallbackValue)
         : queuedQuery
     if (
       cachedQuery &&


### PR DESCRIPTION
There was some leftover null defence in useQueryStates from the time we called useSearchParams directly (pre-2.0.0), which can be moved into the app router adapter, so we enforce the searchParams adapter property non-nullable as a contract.