### PR TITLE
fix: stale search params leaking across React Router navigation

### DIFF
--- a/packages/e2e/next/specs/shared/repro-1358.spec.ts
+++ b/packages/e2e/next/specs/shared/repro-1358.spec.ts
@@ -1,0 +1,11 @@
+import { testRepro1358 } from 'e2e-shared/specs/repro-1358.spec.ts'
+
+testRepro1358({
+  path: '/app/repro-1358',
+  router: 'next-app'
+})
+
+testRepro1358({
+  path: '/pages/repro-1358',
+  router: 'next-pages'
+})

--- a/packages/e2e/next/src/app/app/repro-1358/a/page.tsx
+++ b/packages/e2e/next/src/app/app/repro-1358/a/page.tsx
@@ -1,0 +1,10 @@
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Repro1358RouteA otherPageHref="/app/repro-1358/b" />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/app/app/repro-1358/b/page.tsx
+++ b/packages/e2e/next/src/app/app/repro-1358/b/page.tsx
@@ -1,0 +1,10 @@
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <Repro1358RouteB otherPageHref="/app/repro-1358/a" />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/pages/pages/repro-1358/a.tsx
+++ b/packages/e2e/next/src/pages/pages/repro-1358/a.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteA otherPageHref="/pages/repro-1358/b" />
+}

--- a/packages/e2e/next/src/pages/pages/repro-1358/b.tsx
+++ b/packages/e2e/next/src/pages/pages/repro-1358/b.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteB otherPageHref="/pages/repro-1358/a" />
+}

--- a/packages/e2e/react-router/v6/specs/shared/repro-1358.spec.ts
+++ b/packages/e2e/react-router/v6/specs/shared/repro-1358.spec.ts
@@ -1,0 +1,5 @@
+import { testRepro1358 } from 'e2e-shared/specs/repro-1358.spec.ts'
+
+testRepro1358({
+  path: '/repro-1358'
+})

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -83,6 +83,8 @@ const router = createBrowserRouter(
       <Route path="repro-1099/useQueryStates" lazy={load(import('./routes/repro-1099.useQueryStates'))} />
       <Route path="repro-1293/a"              lazy={load(import('./routes/repro-1293.a'))} />
       <Route path="repro-1293/b"              lazy={load(import('./routes/repro-1293.b'))} />
+      <Route path="repro-1358/a"              lazy={load(import('./routes/repro-1358.a'))} />
+      <Route path="repro-1358/b"              lazy={load(import('./routes/repro-1358.b'))} />
       <Route path="repro-1365"                lazy={load(import('./routes/repro-1365'))} />
       <Route path="repro-1444"                lazy={load(import('./routes/repro-1444'))} />
     </Route>

--- a/packages/e2e/react-router/v6/src/routes/repro-1358.a.tsx
+++ b/packages/e2e/react-router/v6/src/routes/repro-1358.a.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteA otherPageHref="/repro-1358/b" />
+}

--- a/packages/e2e/react-router/v6/src/routes/repro-1358.b.tsx
+++ b/packages/e2e/react-router/v6/src/routes/repro-1358.b.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteB otherPageHref="/repro-1358/a" />
+}

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -64,6 +64,8 @@ export default [
     route('/repro-1099/useQueryStates', './routes/repro-1099.useQueryStates.tsx'),
     route('/repro-1293/a',              './routes/repro-1293.a.tsx'),
     route('/repro-1293/b',              './routes/repro-1293.b.tsx'),
+    route('/repro-1358/a',              './routes/repro-1358.a.tsx'),
+    route('/repro-1358/b',              './routes/repro-1358.b.tsx'),
     route('/repro-1365',                './routes/repro-1365.tsx'),
     route('/repro-1444',                './routes/repro-1444.tsx'),
   ])

--- a/packages/e2e/react-router/v7/app/routes/repro-1358.a.tsx
+++ b/packages/e2e/react-router/v7/app/routes/repro-1358.a.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteA otherPageHref="/repro-1358/b" />
+}

--- a/packages/e2e/react-router/v7/app/routes/repro-1358.b.tsx
+++ b/packages/e2e/react-router/v7/app/routes/repro-1358.b.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteB otherPageHref="/repro-1358/a" />
+}

--- a/packages/e2e/react-router/v7/specs/shared/repro-1358.spec.ts
+++ b/packages/e2e/react-router/v7/specs/shared/repro-1358.spec.ts
@@ -1,0 +1,5 @@
+import { testRepro1358 } from 'e2e-shared/specs/repro-1358.spec.ts'
+
+testRepro1358({
+  path: '/repro-1358'
+})

--- a/packages/e2e/remix/app/routes/repro-1358.a.tsx
+++ b/packages/e2e/remix/app/routes/repro-1358.a.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteA otherPageHref="/repro-1358/b" />
+}

--- a/packages/e2e/remix/app/routes/repro-1358.b.tsx
+++ b/packages/e2e/remix/app/routes/repro-1358.b.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteB otherPageHref="/repro-1358/a" />
+}

--- a/packages/e2e/remix/specs/shared/repro-1358.spec.ts
+++ b/packages/e2e/remix/specs/shared/repro-1358.spec.ts
@@ -1,0 +1,5 @@
+import { testRepro1358 } from 'e2e-shared/specs/repro-1358.spec.ts'
+
+testRepro1358({
+  path: '/repro-1358'
+})

--- a/packages/e2e/shared/specs/repro-1358.spec.ts
+++ b/packages/e2e/shared/specs/repro-1358.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test as it } from '@playwright/test'
+import { defineTest } from '../define-test'
+import { expectSearch } from '../playwright/expect-url'
+import { navigateTo } from '../playwright/navigate'
+
+export const testRepro1358 = defineTest('repro-1358', ({ path }) => {
+  it('should use the correct derived value after navigating between routes', async ({
+    page
+  }) => {
+    // Navigate to Route A
+    await navigateTo(page, path + '/a')
+    // Wait for the render-time effect to have run (mode appears in URL)
+    await expectSearch(page, { mode: 'default' })
+    await expect(page.locator('#route-label').first()).toHaveText('Route A')
+    await expect(page.locator('#filter').first()).toHaveText('default - AAA')
+
+    // Navigate to Route B
+    await page.getByRole('link', { name: 'Go to Route B' }).click()
+    // Wait for Route B's render-time effect to have run
+    await expect(page).toHaveURL(
+      url =>
+        url.pathname.endsWith(`${path}/b`) &&
+        url.searchParams.get('mode') === 'default'
+    )
+    await expect(page.locator('#route-label').first()).toHaveText('Route B')
+    // The filter should be Route B's derived value, not Route A's
+    await expect(page.locator('#filter').first()).toHaveText('default - BBB')
+  })
+
+  it('should not leak state from Route A into Route B on navigation', async ({
+    page
+  }) => {
+    // Navigate to Route A, wait for effect
+    await navigateTo(page, path + '/a')
+    await expectSearch(page, { mode: 'default' })
+    await expect(page.locator('#filter').first()).toHaveText('default - AAA')
+
+    // Navigate to Route B
+    await page.getByRole('link', { name: 'Go to Route B' }).click()
+    await expect(page).toHaveURL(
+      url =>
+        url.pathname.endsWith(`${path}/b`) &&
+        url.searchParams.get('mode') === 'default'
+    )
+    await expect(page.locator('#route-label').first()).toHaveText('Route B')
+    // Route A's filter value should NOT appear on Route B
+    await expect(page.locator('#filter').first()).not.toHaveText(
+      'default - AAA'
+    )
+    await expect(page.locator('#filter').first()).toHaveText('default - BBB')
+  })
+
+  it('should not leak state from Route B into Route A on back navigation', async ({
+    page
+  }) => {
+    // Navigate to Route A, wait for effect
+    await navigateTo(page, path + '/a')
+    await expectSearch(page, { mode: 'default' })
+
+    // Navigate to Route B, wait for effect
+    await page.getByRole('link', { name: 'Go to Route B' }).click()
+    await expect(page).toHaveURL(
+      url =>
+        url.pathname.endsWith(`${path}/b`) &&
+        url.searchParams.get('mode') === 'default'
+    )
+    await expect(page.locator('#filter').first()).toHaveText('default - BBB')
+
+    // Navigate back to Route A
+    await page.goBack()
+    await expect(page).toHaveURL(
+      url => url.pathname.endsWith(`${path}/a`) // support basePath
+    )
+    await expect(page.locator('#route-label').first()).toHaveText('Route A')
+    await expect(page.locator('#filter').first()).not.toHaveText(
+      'default - BBB'
+    )
+    await expect(page.locator('#filter').first()).toHaveText('default - AAA')
+  })
+})

--- a/packages/e2e/shared/specs/repro-1358.tsx
+++ b/packages/e2e/shared/specs/repro-1358.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { parseAsString, useQueryState } from 'nuqs'
+import { useLink } from '../components/link'
+
+type Props = {
+  otherPageHref: string
+}
+
+export function Repro1358RouteA({ otherPageHref }: Props) {
+  const [filter, setFilter] = useQueryState(
+    'filter',
+    parseAsString.withDefault('AAA')
+  )
+  const [mode, setMode] = useQueryState('mode', parseAsString)
+  const Link = useLink()
+
+  if (typeof window !== 'undefined' && !mode) {
+    setMode('default')
+    setFilter('default - AAA')
+  }
+
+  return (
+    <>
+      <pre id="route-label">Route A</pre>
+      <pre id="filter">{filter}</pre>
+      <pre id="mode">{mode}</pre>
+      <Link href={otherPageHref}>Go to Route B</Link>
+    </>
+  )
+}
+
+export function Repro1358RouteB({ otherPageHref }: Props) {
+  const [filter, setFilter] = useQueryState(
+    'filter',
+    parseAsString.withDefault('BBB')
+  )
+  const [mode, setMode] = useQueryState('mode', parseAsString)
+  const Link = useLink()
+
+  if (typeof window !== 'undefined' && !mode) {
+    setMode('default')
+    setFilter('default - BBB')
+  }
+
+  return (
+    <>
+      <pre id="route-label">Route B</pre>
+      <pre id="filter">{filter}</pre>
+      <pre id="mode">{mode}</pre>
+      <Link href={otherPageHref}>Go to Route A</Link>
+    </>
+  )
+}

--- a/packages/e2e/tanstack-router/specs/shared/repro-1358.spec.ts
+++ b/packages/e2e/tanstack-router/specs/shared/repro-1358.spec.ts
@@ -1,0 +1,5 @@
+import { testRepro1358 } from 'e2e-shared/specs/repro-1358.spec.ts'
+
+testRepro1358({
+  path: '/repro-1358'
+})

--- a/packages/e2e/tanstack-router/src/routes/repro-1358.a.tsx
+++ b/packages/e2e/tanstack-router/src/routes/repro-1358.a.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+
+export const Route = createFileRoute('/repro-1358/a')({
+  component: () => <Repro1358RouteA otherPageHref="/repro-1358/b" />
+})

--- a/packages/e2e/tanstack-router/src/routes/repro-1358.b.tsx
+++ b/packages/e2e/tanstack-router/src/routes/repro-1358.b.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+
+export const Route = createFileRoute('/repro-1358/b')({
+  component: () => <Repro1358RouteB otherPageHref="/repro-1358/a" />
+})

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -133,6 +133,22 @@ export function createReactRouterBasedAdapter({
       }
       emitter.on('update', onEmitterUpdate)
       window.addEventListener('popstate', onPopState)
+      // Catch up with the URL as it stands now that we're subscribed. A hook
+      // mounting during a navigation transition subscribes after the emitter
+      // has fired (e.g. a sibling route's shallow update), so its state would
+      // otherwise stay stale — and an outgoing route could then re-run a
+      // render-phase update and leak its value onto the route we navigated to
+      // (#1358). Only commit when it actually moved, to avoid a no-op re-render.
+      const caughtUp = applyChange(
+        new URLSearchParams(location.search),
+        watchKeys,
+        false
+      )(searchParams)
+      // Compare by value: with no watched keys `applyChange` always returns a
+      // fresh instance, so a reference check would re-render on every mount.
+      if (caughtUp.toString() !== searchParams.toString()) {
+        setSearchParams(caughtUp)
+      }
       return () => {
         emitter.off('update', onEmitterUpdate)
         window.removeEventListener('popstate', onPopState)


### PR DESCRIPTION
## What was happening

Navigate between two routes that both use `useQueryState`, hit the browser Back button, and the destination route could show the search params from the page you just left.

The React Router adapter keeps an optimistic copy of the search params in React state and syncs it through an emitter it subscribes to inside an effect. A component that mounts during a navigation transition subscribes a beat too late: the sibling route's URL update has already fired on the emitter, so the freshly mounted component never receives it and its optimistic state stays empty.

On the back navigation, the outgoing route reads that empty state, re-runs an app-level render-phase update, and writes its own value onto the route you just landed on.

## The fix

Right after subscribing, the adapter reads `location.search` once and adopts it, but only when it actually differs from the current state. An unconditional `setState` would still cost a render, and the render-count tests catch that.

That one catch-up closes the race. The whole production change is a single block in `useOptimisticSearchParams`.

## Approaches that did not work

Noting these since the obvious ones fall short:

- Resetting the queue on popstate. The outgoing route re-pushes right after the reset.
- Gating the write on the committed pathname (the signal from #1273). A normally unmounting RR route still runs its effects during the transition, so that ref retargets to the new pathname and the gate lets the write through.
- Wrapping the app's render-phase setState in `startTransition`. It deprioritises the React render, not the queue push where the leak comes from.

Reading the URL back on subscribe avoids all of these and stays inside an effect. No render-phase side effects, no module globals, no pathname guards.

## Tests

Brings the e2e reproduction across every adapter: Next (app + pages), React Router v6 and v7, Remix, and TanStack Router. Each one passes the three cases (forward nav, no leak forward, no leak on back).

TanStack passes without a dedicated fix of its own, which confirms the bug was specific to the React Router adapter.

## Notes

Supersedes the fix from #1359: same reproduction, one file changed instead of five.

Closes #1358.