### PR TITLE
feat: add history to adapters `defaultOptions`

### DIFF
--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -404,6 +404,16 @@ adapter prop:
 </NuqsAdapter>
 ```
 
+<Callout title="Don't break the Back button" type="warn">
+Setting `history: 'push'{:ts}` globally will add a new entry to the navigation
+history for **every** search param update across your whole app, which is likely
+to pollute the Back/Forward history and degrade that experience.
+
+Prefer opting into `history: 'push'{:ts}` on a per-hook or per-call basis, only
+where the search params contribute to a navigation-like experience (eg: tabs,
+modals).
+</Callout>
+
 ### Processing `URLSearchParams`
 
 <FeatureSupportMatrix introducedInVersion='2.6.0' />

--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -393,6 +393,7 @@ adapter prop:
 // [!code word:defaultOptions]
 <NuqsAdapter
   defaultOptions={{
+    history: 'push',
     shallow: false,
     scroll: true,
     clearOnDefault: false,

--- a/packages/nuqs/src/adapters/lib/context.ts
+++ b/packages/nuqs/src/adapters/lib/context.ts
@@ -13,7 +13,10 @@ import type { AdapterInterface, UseAdapterHook } from './defs'
 
 export type AdapterProps = {
   defaultOptions?: Partial<
-    Pick<Options, 'shallow' | 'clearOnDefault' | 'scroll' | 'limitUrlUpdates'>
+    Pick<
+      Options,
+      'history' | 'shallow' | 'clearOnDefault' | 'scroll' | 'limitUrlUpdates'
+    >
   >
   processUrlSearchParams?: (search: URLSearchParams) => URLSearchParams
 }

--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -450,6 +450,34 @@ describe('useQueryState: adapter defaults', () => {
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?test=pass')
   })
+  it('should use adapter default value for `history` when provided', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(() => useQueryState('test'), {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          history: 'push'
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]('update'))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('push')
+  })
+  it('should let a call-level `history` override the adapter default', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(() => useQueryState('test'), {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          history: 'push'
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]('update', { history: 'replace' }))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('replace')
+  })
 })
 
 describe('useQueryState: edge cases & repros', () => {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -923,6 +923,56 @@ describe('useQueryStates: adapter defaults', () => {
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?test=pass')
   })
+  it('should use adapter default value for `history` when provided', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () => useQueryStates({ test: parseAsString })
+    const { result, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          history: 'push'
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]({ test: 'update' }))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('push')
+  })
+  it('should let a call-level `history` override the adapter default', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () => useQueryStates({ test: parseAsString })
+    const { result, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          history: 'push'
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() =>
+      result.current[1]({ test: 'update' }, { history: 'replace' })
+    )
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('replace')
+  })
+  it('should let a parser-level `history` override the adapter default', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () =>
+      useQueryStates({
+        test: parseAsString.withOptions({ history: 'replace' })
+      })
+    const { result, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          history: 'push'
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]({ test: 'update' }))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('replace')
+  })
 })
 
 describe('useQueryStates: process url search params', () => {

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -77,7 +77,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const processUrlSearchParams = useAdapterProcessUrlSearchParams()
 
   const {
-    history = 'replace',
+    history = defaultOptions?.history ?? 'replace',
     scroll = defaultOptions?.scroll ?? false,
     shallow = defaultOptions?.shallow ?? true,
     throttleMs = defaultRateLimit.timeMs,


### PR DESCRIPTION
Implements the feature in this discussion: https://github.com/47ng/nuqs/discussions/1448