### PR TITLE
chore: emit the release-notes multiline output from TypeScript

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -83,8 +83,7 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # The script appends the `notes` multiline output to $GITHUB_OUTPUT
-        # itself (heredoc envelope + unguessable delimiter live in the tested
-        # TypeScript, not in shell).
+        # itself; the envelope construction lives in the tested TypeScript.
         run: ./release-notes-automation.ts
 
   ci:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -82,20 +82,10 @@ jobs:
         env:
           CHANNEL: ${{ inputs.channel }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          ./release-notes-automation.ts > "$RUNNER_TEMP/notes.md"
-          # Multiline job output. The notes are built from untrusted text, so a
-          # fixed `EOF` could be closed early by crafted note content to inject
-          # extra outputs — use an unguessable delimiter.
-          # The leading \n keeps the closing delimiter on its own
-          # line even when notes.md has no trailing newline.
-          DELIM="NOTES_EOF_$(openssl rand -hex 16)"
-          {
-            printf 'notes<<%s\n' "$DELIM"
-            cat "$RUNNER_TEMP/notes.md"
-            printf '\n%s\n' "$DELIM"
-          } >> "$GITHUB_OUTPUT"
+        # The script appends the `notes` multiline output to $GITHUB_OUTPUT
+        # itself (heredoc envelope + unguessable delimiter live in the tested
+        # TypeScript, not in shell).
+        run: ./release-notes-automation.ts
 
   ci:
     name: CI gate

--- a/packages/scripts/release-notes-automation.test.ts
+++ b/packages/scripts/release-notes-automation.test.ts
@@ -4,6 +4,7 @@ import {
   breakingChanges,
   formatChangeLine,
   formatClosingIssues,
+  formatMultilineOutput,
   formatThanksSection,
   formatTitle,
   groupChangesByCategory,
@@ -394,6 +395,26 @@ describe('formatThanksSection', () => {
   it('formats three+ contributors with oxford comma', () => {
     expect(formatThanksSection(['alice', 'bob', 'charlie'])).toBe(
       'Huge thanks to @alice, @bob, and @charlie for helping!'
+    )
+  })
+})
+
+describe('formatMultilineOutput', () => {
+  it('wraps the value in a heredoc envelope on its own lines', () => {
+    expect(formatMultilineOutput('notes', 'line one\nline two', 'EOF')).toBe(
+      'notes<<EOF\nline one\nline two\nEOF\n'
+    )
+  })
+
+  it('keeps the closing delimiter on its own line when the value already ends in a newline', () => {
+    expect(formatMultilineOutput('notes', 'ends with newline\n', 'EOF')).toBe(
+      'notes<<EOF\nends with newline\n\nEOF\n'
+    )
+  })
+
+  it('throws rather than emit when the value contains the delimiter', () => {
+    expect(() => formatMultilineOutput('notes', 'a\nEOF\nb', 'EOF')).toThrow(
+      /delimiter/
     )
   })
 })

--- a/packages/scripts/release-notes-automation.ts
+++ b/packages/scripts/release-notes-automation.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { randomBytes } from 'node:crypto'
+import { appendFileSync } from 'node:fs'
 import { createEnv } from '@t3-oss/env-core'
 import { z } from 'zod'
 import type { Change } from './lib/change.ts'
@@ -127,6 +129,25 @@ export function renderReleaseNotes(
   return blocks.join('\n\n')
 }
 
+// Wrap a value in the heredoc envelope GitHub Actions uses for multiline job
+// outputs: `name<<DELIM`, the value, then `DELIM` alone on the last line. The
+// caller passes an unguessable delimiter because the notes are untrusted text —
+// a predictable one could be closed early by a crafted note line to inject
+// extra outputs. The collision check turns the (astronomically unlikely) case
+// of the value containing the delimiter into a loud failure rather than a
+// silent injection. Emitting this from here keeps the `<<` operator out of the
+// workflow's shell, where GitHub's blob highlighter mis-reads it as a heredoc.
+export function formatMultilineOutput(
+  name: string,
+  value: string,
+  delimiter: string
+): string {
+  if (value.includes(delimiter)) {
+    throw new Error('Refusing to emit output: value contains the delimiter')
+  }
+  return `${name}<<${delimiter}\n${value}\n${delimiter}\n`
+}
+
 async function main(): Promise<void> {
   // Draft phase: the tag does not exist yet, so the range is resolved from
   // HEAD. The channel selects the asymmetric range (incremental beta vs
@@ -135,7 +156,8 @@ async function main(): Promise<void> {
   const env = createEnv({
     server: {
       CHANNEL: z.enum(['stable', 'beta']),
-      GITHUB_TOKEN: z.string().min(1)
+      GITHUB_TOKEN: z.string().min(1),
+      GITHUB_OUTPUT: z.string().optional()
     },
     isServer: true,
     runtimeEnv: process.env
@@ -148,7 +170,18 @@ async function main(): Promise<void> {
   // The human-readable notes, followed by the machine-readable DTO comment the
   // changelog page reads back (hidden on GitHub + in subscriber emails).
   const notes = renderReleaseNotes(release.changes, release.contributors)
-  console.log(`${notes}\n\n${renderChangelogComment(release)}`)
+  const body = `${notes}\n\n${renderChangelogComment(release)}`
+  // In CI, hand the notes to the draft job as a multiline output; locally,
+  // print them for inspection.
+  if (env.GITHUB_OUTPUT) {
+    const delimiter = `NOTES_EOF_${randomBytes(16).toString('hex')}`
+    appendFileSync(
+      env.GITHUB_OUTPUT,
+      formatMultilineOutput('notes', body, delimiter)
+    )
+  } else {
+    console.log(body)
+  }
 }
 
 if (import.meta.main) {

--- a/packages/scripts/release-notes-automation.ts
+++ b/packages/scripts/release-notes-automation.ts
@@ -130,20 +130,23 @@ export function renderReleaseNotes(
 }
 
 // Wrap a value in the heredoc envelope GitHub Actions uses for multiline job
-// outputs: `name<<DELIM`, the value, then `DELIM` alone on the last line. The
-// caller passes an unguessable delimiter because the notes are untrusted text —
+// outputs: `name<<DELIM`, the value, then `DELIM` alone on the last line.
+// The caller passes an unguessable delimiter because the notes are untrusted:
 // a predictable one could be closed early by a crafted note line to inject
 // extra outputs. The collision check turns the (astronomically unlikely) case
-// of the value containing the delimiter into a loud failure rather than a
-// silent injection. Emitting this from here keeps the `<<` operator out of the
-// workflow's shell, where GitHub's blob highlighter mis-reads it as a heredoc.
+// of the value containing the delimiter into a loud failure instead of a
+// silent injection. Building the envelope here rather than in the workflow's
+// `run:` shell also keeps the `<<` token out of YAML-embedded shell, where
+// GitHub's highlighter parses it as a heredoc and mangles the file's rendering.
 export function formatMultilineOutput(
   name: string,
   value: string,
   delimiter: string
 ): string {
   if (value.includes(delimiter)) {
-    throw new Error('Refusing to emit output: value contains the delimiter')
+    throw new Error(
+      `Refusing to emit "${name}" output: value contains the delimiter`
+    )
   }
   return `${name}<<${delimiter}\n${value}\n${delimiter}\n`
 }
@@ -157,7 +160,9 @@ async function main(): Promise<void> {
     server: {
       CHANNEL: z.enum(['stable', 'beta']),
       GITHUB_TOKEN: z.string().min(1),
-      GITHUB_OUTPUT: z.string().optional()
+      // Optional so the script also runs locally; min(1) makes an empty value
+      // (set but blank) fail loudly rather than silently print to stdout.
+      GITHUB_OUTPUT: z.string().min(1).optional()
     },
     isServer: true,
     runtimeEnv: process.env


### PR DESCRIPTION
The shell step in `release-draft.yml` built the multiline job output by hand with `printf 'notes<<%s\n'`. That literal `<<` reads as a heredoc operator to GitHub's blob highlighter, which then mis-colours the rest of the file.

GitHub Actions has a single multiline output format, the `key<<DELIM ... DELIM` envelope, so the `<<` has to live somewhere. This moves it out of the YAML shell and into the script that already produces the notes.

`release-notes-automation.ts` now appends the `notes` output to `$GITHUB_OUTPUT` itself, gated on the env var (it still prints to stdout when run locally). The `<<` sits in a TypeScript string, where the highlighter treats it as plain text, and the workflow step collapses to a single `run: ./release-notes-automation.ts`.

It follows the pattern already in the repo: `compute-version.ts` emits its own outputs, and `validate-pr-title.ts` writes to `$GITHUB_STEP_SUMMARY` the same way.

## Security

The notes come from untrusted text (commit messages, PR titles), so the delimiter stays an unguessable random token to block output injection. The envelope builder gained a collision guard that throws if the value ever contains the delimiter, turning a near-impossible collision into a loud failure rather than a silent injection. The shell version had no such check.

## Testing

`formatMultilineOutput` is now a pure, exported function with unit tests for the envelope shape, the trailing-newline edge, and the injection guard. `tsc`, prettier and actionlint pass, full suite green (35 tests).

Note: `pr-lint.yml` carries the same `printf 'files<<%s\n'` pattern but is left as-is. It passes data step to step within one job, where a temp file would suit it better.
