### PR TITLE
chore: require sha512 integrity as the primary release-verification gate

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -183,6 +183,17 @@ jobs:
               exit 1
             fi
           done
+          # Validate digest shapes at capture: a missing field (jq prints the
+          # literal "null") or garbage fails here, not just downstream in the
+          # verifier. integrity is now the primary gate, so reject a non-sha512.
+          case "$INTEGRITY" in
+            sha512-?*) ;;
+            *) echo "::error::stage integrity is not a sha512 integrity"; exit 1 ;;
+          esac
+          if ! printf '%s' "$SHASUM" | LC_ALL=C grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::stage shasum is not a 40-char sha1"
+            exit 1
+          fi
           # stage-id gates the draft; integrity + shasum are surfaced in the
           # job summary so a reviewer can match the staged tarball before 2FA.
           {

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -121,8 +121,8 @@ jobs:
       id-token: write # OIDC trusted publishing for `npm stage publish`
     outputs:
       stage-id: ${{ steps.stage.outputs.stage-id }}
-      shasum: ${{ steps.stage.outputs.shasum }}
       integrity: ${{ steps.stage.outputs.integrity }}
+      shasum: ${{ steps.stage.outputs.shasum }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -184,22 +184,22 @@ jobs:
             exit 1
           fi
           STAGE_ID=$(printf '%s' "$PKG" | jq -r '.stageId')
-          SHASUM=$(printf '%s' "$PKG" | jq -r '.shasum')
           INTEGRITY=$(printf '%s' "$PKG" | jq -r '.integrity')
+          SHASUM=$(printf '%s' "$PKG" | jq -r '.shasum')
           # Reject anything carrying control chars before writing: a newline
           # would let crafted npm output inject extra $GITHUB_OUTPUT lines.
-          for v in "$STAGE_ID" "$SHASUM" "$INTEGRITY"; do
+          for v in "$STAGE_ID" "$INTEGRITY" "$SHASUM"; do
             if [ -z "$v" ] || printf '%s' "$v" | LC_ALL=C grep -q '[^[:print:]]'; then
               echo "::error::Unexpected characters in npm stage metadata"
               exit 1
             fi
           done
-          # stage-id gates the draft; shasum + integrity are surfaced in the
+          # stage-id gates the draft; integrity + shasum are surfaced in the
           # job summary so a reviewer can match the staged tarball before 2FA.
           {
             echo "stage-id=$STAGE_ID"
-            echo "shasum=$SHASUM"
             echo "integrity=$INTEGRITY"
+            echo "shasum=$SHASUM"
           } >> "$GITHUB_OUTPUT"
 
   create-draft:
@@ -255,8 +255,8 @@ jobs:
             echo "| git tag | \`$TAG\` |"
             echo "| npm dist-tag | \`$DIST_TAG\` |"
             echo "| npm stage id | \`$STAGE_ID\` |"
-            echo "| shasum | \`$SHASUM\` |"
             echo "| integrity | \`$INTEGRITY\` |"
+            echo "| shasum | \`$SHASUM\` |"
             echo ""
             echo "## Next steps"
             echo ""
@@ -265,10 +265,10 @@ jobs:
             echo "packages/scripts/verify-release/verify.staged.ts \\"
             echo "  --package nuqs \\"
             echo "  --version '$VERSION' \\"
-            echo "  --sha '$GITHUB_SHA' \\"
-            echo "  --stage-id '$STAGE_ID' \\"
+            echo "  --integrity '$INTEGRITY' \\"
             echo "  --shasum '$SHASUM' \\"
-            echo "  --integrity '$INTEGRITY'"
+            echo "  --sha '$GITHUB_SHA' \\"
+            echo "  --stage-id '$STAGE_ID'"
             echo '```'
             echo "2. Review the [draft release notes]($RELEASE_DRAFT_URL)"
             echo "3. Approve the [staged package on npmjs.com](https://www.npmjs.com/settings/franky47/staged-packages/?page=0&perPage=10&filterPackage=nuqs) with 2FA"
@@ -279,7 +279,7 @@ jobs:
           TAG: ${{ needs.compute-version.outputs.tag }}
           DIST_TAG: ${{ needs.compute-version.outputs.dist-tag }}
           STAGE_ID: ${{ needs.stage.outputs.stage-id }}
-          SHASUM: ${{ needs.stage.outputs.shasum }}
           INTEGRITY: ${{ needs.stage.outputs.integrity }}
+          SHASUM: ${{ needs.stage.outputs.shasum }}
           RELEASE_DRAFT_URL: ${{ steps.create-release.outputs.draft-url }}
           RELEASE_EDIT_URL: ${{ steps.create-release.outputs.edit-url }}

--- a/packages/scripts/verify-release/verify.lib.test.ts
+++ b/packages/scripts/verify-release/verify.lib.test.ts
@@ -14,8 +14,8 @@ import {
 const PINS: Toolchain = { node: '24.11.0', npm: '11.16.0', pnpm: '11.0.9' }
 
 const REPRO: Reproduction = {
-  shasum: 'a'.repeat(40),
   integrity: 'sha512-AAAA',
+  shasum: 'a'.repeat(40),
   localTgz: '/out/local.tgz'
 }
 
@@ -39,15 +39,15 @@ describe('verifyReproducibility', () => {
         ref: 'v1.2.3',
         pkg: 'nuqs',
         version: '1.2.3',
-        shasum: 'a'.repeat(40),
-        integrity: 'sha512-AAAA'
+        integrity: 'sha512-AAAA',
+        shasum: 'a'.repeat(40)
       },
       verifier
     )
     expect(outcome).toEqual({
       kind: 'mismatch',
       reproduced: { ...REPRO, shasum: 'b'.repeat(40) },
-      expected: { shasum: 'a'.repeat(40), integrity: 'sha512-AAAA' }
+      expected: { integrity: 'sha512-AAAA', shasum: 'a'.repeat(40) }
     })
   })
 
@@ -58,15 +58,15 @@ describe('verifyReproducibility', () => {
         ref: 'v1.2.3',
         pkg: 'nuqs',
         version: '1.2.3',
-        shasum: REPRO.shasum,
-        integrity: REPRO.integrity
+        integrity: REPRO.integrity,
+        shasum: REPRO.shasum
       },
       fakeVerifier({ reproduce })
     )
     expect(outcome).toEqual({
       kind: 'match',
       reproduced: REPRO,
-      expected: { shasum: REPRO.shasum, integrity: REPRO.integrity }
+      expected: { integrity: REPRO.integrity, shasum: REPRO.shasum }
     })
     expect(reproduce).toHaveBeenCalledExactlyOnceWith({
       ref: 'v1.2.3',
@@ -75,28 +75,16 @@ describe('verifyReproducibility', () => {
     })
   })
 
-  it('matches on sha1 alone when no integrity is provided', async () => {
-    const outcome = await verifyReproducibility(
-      { ref: 'v1.2.3', pkg: 'nuqs', version: '1.2.3', shasum: REPRO.shasum },
-      fakeVerifier({
-        reproduce: async () => ({ ...REPRO, integrity: 'sha512-DIFFERENT' })
-      })
-    )
-    expect(outcome).toEqual({
-      kind: 'match',
-      reproduced: { ...REPRO, integrity: 'sha512-DIFFERENT' },
-      expected: { shasum: REPRO.shasum, integrity: undefined }
-    })
-  })
-
-  it('reports mismatch when integrity diverges even if sha1 agrees', async () => {
+  // integrity (sha512) is the required anchor: a sha1 that agrees while the
+  // sha512 diverges is exactly the shape of a collision attempt, and is rejected.
+  it('reports mismatch when integrity (the anchor) diverges even if sha1 agrees', async () => {
     const outcome = await verifyReproducibility(
       {
         ref: 'v1.2.3',
         pkg: 'nuqs',
         version: '1.2.3',
-        shasum: REPRO.shasum,
-        integrity: 'sha512-EXPECTED'
+        integrity: 'sha512-EXPECTED',
+        shasum: REPRO.shasum
       },
       fakeVerifier({
         reproduce: async () => ({ ...REPRO, integrity: 'sha512-ACTUAL' })
@@ -112,6 +100,7 @@ describe('verifyReproducibility', () => {
         ref: 'v1.2.3',
         pkg: 'nuqs',
         version: '1.2.3',
+        integrity: REPRO.integrity,
         shasum: REPRO.shasum
       },
       fakeVerifier({
@@ -219,8 +208,8 @@ describe('fetchRegistryMeta', () => {
     version: '2.8.9',
     gitHead: 'f3e2d176d549f38f00daa765e6cd1c83cc826174',
     dist: {
-      shasum: 'e2c27d87c0dd0e3b4412fe867bcd0947cc4c998f',
       integrity: 'sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC',
+      shasum: 'e2c27d87c0dd0e3b4412fe867bcd0947cc4c998f',
       tarball: 'https://registry.npmjs.org/nuqs/-/nuqs-2.8.9.tgz'
     }
   }
@@ -230,8 +219,8 @@ describe('fetchRegistryMeta', () => {
   it('reads digests + gitHead from the canonical registry URL', async () => {
     const fetchFn = okFetch(validBody)
     const meta = await fetchRegistryMeta('nuqs', '2.8.9', fetchFn)
-    expect(meta.dist.shasum).toBe(validBody.dist.shasum)
     expect(meta.dist.integrity).toBe(validBody.dist.integrity)
+    expect(meta.dist.shasum).toBe(validBody.dist.shasum)
     expect(meta.gitHead).toBe(validBody.gitHead)
     expect(fetchFn).toHaveBeenCalledExactlyOnceWith(
       'https://registry.npmjs.org/nuqs/2.8.9'
@@ -272,11 +261,11 @@ describe('verdictFor', () => {
       {
         kind: 'match',
         reproduced: {
-          shasum: 'a'.repeat(40),
           integrity: 'sha512-SAME',
+          shasum: 'a'.repeat(40),
           localTgz: '/out/local.tgz'
         },
-        expected: { shasum: 'a'.repeat(40), integrity: 'sha512-SAME' }
+        expected: { integrity: 'sha512-SAME', shasum: 'a'.repeat(40) }
       },
       ctx
     )
@@ -295,11 +284,11 @@ describe('verdictFor', () => {
       {
         kind: 'mismatch',
         reproduced: {
-          shasum: 'b'.repeat(40),
           integrity: 'sha512-LOCAL',
+          shasum: 'b'.repeat(40),
           localTgz: '/out/local.tgz'
         },
-        expected: { shasum: 'a'.repeat(40), integrity: 'sha512-PUBLISHED' }
+        expected: { integrity: 'sha512-PUBLISHED', shasum: 'a'.repeat(40) }
       },
       ctx
     )

--- a/packages/scripts/verify-release/verify.lib.test.ts
+++ b/packages/scripts/verify-release/verify.lib.test.ts
@@ -90,7 +90,11 @@ describe('verifyReproducibility', () => {
         reproduce: async () => ({ ...REPRO, integrity: 'sha512-ACTUAL' })
       })
     )
-    expect(outcome).toMatchObject({ kind: 'mismatch' })
+    expect(outcome).toEqual({
+      kind: 'mismatch',
+      reproduced: { ...REPRO, integrity: 'sha512-ACTUAL' },
+      expected: { integrity: 'sha512-EXPECTED', shasum: REPRO.shasum }
+    })
   })
 
   it('short-circuits on a toolchain mismatch without reproducing', async () => {
@@ -247,6 +251,16 @@ describe('fetchRegistryMeta', () => {
 
   it('rejects a payload whose shasum is not a 40-char sha1', async () => {
     const bad = { ...validBody, dist: { ...validBody.dist, shasum: 'nope' } }
+    await expect(
+      fetchRegistryMeta('nuqs', '2.8.9', okFetch(bad))
+    ).rejects.toThrow()
+  })
+
+  it('rejects a payload whose integrity is not a sha512 integrity', async () => {
+    const bad = {
+      ...validBody,
+      dist: { ...validBody.dist, integrity: 'sha1-deadbeef' }
+    }
     await expect(
       fetchRegistryMeta('nuqs', '2.8.9', okFetch(bad))
     ).rejects.toThrow()

--- a/packages/scripts/verify-release/verify.lib.ts
+++ b/packages/scripts/verify-release/verify.lib.ts
@@ -42,10 +42,14 @@ export function normalizeTag(input: string): TagVersion {
   return { tag: `v${version}`, version }
 }
 
-/** A reproduced tarball, as hashed on the host from the sandbox's output. */
-export type Reproduction = {
+/** A tarball's digest pair: npm SRI integrity (sha512) + legacy sha1 shasum. */
+export type Digests = {
   integrity: string // npm integrity: `sha512-` + base64(sha512(.tgz))
   shasum: string // sha1 hex of the .tgz
+}
+
+/** A reproduced tarball, as hashed on the host from the sandbox's output. */
+export type Reproduction = Digests & {
   localTgz: string // host path to the reproduced tarball (staged diff needs it)
 }
 
@@ -55,10 +59,7 @@ export type ReproduceInput = {
   version: string
 }
 
-export type VerifyInput = ReproduceInput & {
-  integrity: string
-  shasum: string
-}
+export type VerifyInput = ReproduceInput & Digests
 
 // The I/O surface the engine consumes. Production wires `makeDockerVerifier`
 // (docker + git + fs); tests inject an in-memory fake, controlling the returned
@@ -180,7 +181,7 @@ export function checkGitHead(
 /** The host-computed reproduction set against the expected (published) digests. */
 export type DigestComparison = {
   reproduced: Reproduction
-  expected: { integrity: string; shasum: string }
+  expected: Digests
 }
 
 export type Outcome =
@@ -212,11 +213,11 @@ export async function verifyReproducibility(
     pkg: input.pkg,
     version: input.version
   })
-  // integrity (sha512) is the cryptographic anchor and must match. shasum
-  // (legacy sha1) is required too, as corroboration: a sha1 that agrees while
-  // the sha512 diverges is the signature of a collision attempt, which the
-  // integrity gate rejects. Both derive from the same bytes, so an honest
-  // reproduction agrees on both.
+  // integrity (sha512) is the cryptographic anchor and must match: sha1 is
+  // collision-broken, so it can't be the gate. A crafted tarball with a
+  // matching sha1 but divergent content still fails here, because its sha512
+  // differs. shasum is kept only as a cheap corroborating cross-check; both
+  // digests derive from the same bytes, so an honest reproduction agrees on both.
   const intOk = reproduced.integrity === input.integrity
   const shaOk = reproduced.shasum === input.shasum
   const expected = { integrity: input.integrity, shasum: input.shasum }

--- a/packages/scripts/verify-release/verify.lib.ts
+++ b/packages/scripts/verify-release/verify.lib.ts
@@ -44,8 +44,8 @@ export function normalizeTag(input: string): TagVersion {
 
 /** A reproduced tarball, as hashed on the host from the sandbox's output. */
 export type Reproduction = {
-  shasum: string // sha1 hex of the .tgz
   integrity: string // npm integrity: `sha512-` + base64(sha512(.tgz))
+  shasum: string // sha1 hex of the .tgz
   localTgz: string // host path to the reproduced tarball (staged diff needs it)
 }
 
@@ -56,8 +56,8 @@ export type ReproduceInput = {
 }
 
 export type VerifyInput = ReproduceInput & {
+  integrity: string
   shasum: string
-  integrity?: string
 }
 
 // The I/O surface the engine consumes. Production wires `makeDockerVerifier`
@@ -122,10 +122,10 @@ export const registryMetaSchema = z.object({
     .regex(/^[0-9a-f]{40}$/)
     .optional(),
   dist: z.object({
-    shasum: z.string().regex(/^[0-9a-f]{40}$/, 'dist.shasum must be a sha1'),
     integrity: z
       .string()
       .regex(/^sha512-/, 'dist.integrity must be a sha512 integrity'),
+    shasum: z.string().regex(/^[0-9a-f]{40}$/, 'dist.shasum must be a sha1'),
     tarball: z.string()
   })
 })
@@ -180,7 +180,7 @@ export function checkGitHead(
 /** The host-computed reproduction set against the expected (published) digests. */
 export type DigestComparison = {
   reproduced: Reproduction
-  expected: { shasum: string; integrity?: string }
+  expected: { integrity: string; shasum: string }
 }
 
 export type Outcome =
@@ -212,11 +212,15 @@ export async function verifyReproducibility(
     pkg: input.pkg,
     version: input.version
   })
+  // integrity (sha512) is the cryptographic anchor and must match. shasum
+  // (legacy sha1) is required too, as corroboration: a sha1 that agrees while
+  // the sha512 diverges is the signature of a collision attempt, which the
+  // integrity gate rejects. Both derive from the same bytes, so an honest
+  // reproduction agrees on both.
+  const intOk = reproduced.integrity === input.integrity
   const shaOk = reproduced.shasum === input.shasum
-  const intOk =
-    input.integrity === undefined || reproduced.integrity === input.integrity
-  const expected = { shasum: input.shasum, integrity: input.integrity }
-  return shaOk && intOk
+  const expected = { integrity: input.integrity, shasum: input.shasum }
+  return intOk && shaOk
     ? { kind: 'match', reproduced, expected }
     : { kind: 'mismatch', reproduced, expected }
 }
@@ -237,10 +241,10 @@ export type Verdict = {
  *  so the match (or divergence) is visually checkable, like run1 used to print. */
 function digestLines(c: DigestComparison): string[] {
   return [
-    `  reproduced shasum    : ${c.reproduced.shasum}`,
-    `  published  shasum    : ${c.expected.shasum}`,
     `  reproduced integrity : ${c.reproduced.integrity}`,
-    `  published  integrity : ${c.expected.integrity ?? '<not provided>'}`
+    `  published  integrity : ${c.expected.integrity}`,
+    `  reproduced shasum    : ${c.reproduced.shasum}`,
+    `  published  shasum    : ${c.expected.shasum}`
   ]
 }
 
@@ -483,8 +487,8 @@ export function makeDockerVerifier(config: DockerVerifierConfig): Verifier {
       const localTgz = join(config.outDir, 'local.tgz')
       const bytes = readFileSync(localTgz)
       return {
-        shasum: createHash('sha1').update(bytes).digest('hex'),
         integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
+        shasum: createHash('sha1').update(bytes).digest('hex'),
         localTgz
       }
     }

--- a/packages/scripts/verify-release/verify.production.ts
+++ b/packages/scripts/verify-release/verify.production.ts
@@ -14,7 +14,7 @@
 // Flow:
 //   1. Fetch the tag and resolve it to a commit.
 //   2. Read the published metadata straight from registry.npmjs.org
-//      (shasum, integrity, gitHead) — unauthenticated.
+//      (integrity, shasum, gitHead) — unauthenticated.
 //   3. Cross-check the registry's gitHead against the tag's commit.
 //   4. Reproduce from the tag's source and match the host-computed digests.
 //
@@ -135,8 +135,8 @@ err(`==> Reading published metadata for ${PACKAGE}@${VERSION}`)
 const meta = await fetchRegistryMeta(PACKAGE, VERSION).catch((e: Error) =>
   die(2, styleText('red', `==> ${e.message}`))
 )
-err(`    shasum    : ${meta.dist.shasum}`)
 err(`    integrity : ${meta.dist.integrity}`)
+err(`    shasum    : ${meta.dist.shasum}`)
 err(`    gitHead   : ${meta.gitHead ?? '<not recorded>'}`)
 err(`    tag commit: ${tagCommit}`)
 
@@ -182,8 +182,8 @@ const outcome = await verifyReproducibility(
     ref: TAG,
     pkg: PACKAGE,
     version: VERSION,
-    shasum: meta.dist.shasum,
-    integrity: meta.dist.integrity
+    integrity: meta.dist.integrity,
+    shasum: meta.dist.shasum
   },
   verifier
 ).catch((e: Error) =>

--- a/packages/scripts/verify-release/verify.staged.ts
+++ b/packages/scripts/verify-release/verify.staged.ts
@@ -3,8 +3,8 @@
 // Staged-release verification — host launcher.
 //
 // Usage:
-//   verify.staged.ts --package <name> --version <v> --shasum <s> \
-//             [--sha <sha>] [--stage-id <id>] [--integrity <i>]
+//   verify.staged.ts --package <name> --version <v> --integrity <i> \
+//             --shasum <s> [--sha <sha>] [--stage-id <id>]
 //   (copy the single ready-to-run command from the Draft Release job summary)
 //
 // Flow:
@@ -36,8 +36,8 @@ import {
 const HELP = `Staged-release verification — host launcher.
 
 Usage:
-  verify.staged.ts --package <name> --version <v> --shasum <s> \\
-            [--sha <sha>] [--stage-id <id>] [--integrity <i>]
+  verify.staged.ts --package <name> --version <v> --integrity <i> \\
+            --shasum <s> [--sha <sha>] [--stage-id <id>]
 
 Pass the run-summary fields as flags — copy the single command the Draft
 Release job summary prints. Reproduces the package in a hardened sandbox and
@@ -48,6 +48,8 @@ automatic.
 Required arguments:
   --package <name>      The package name (e.g. nuqs).
   --version <v>         The version string (e.g. 1.2.3).
+  --integrity <i>       The staged tarball's sha512 integrity (sha512-…).
+                        The primary gate; shasum corroborates it.
   --shasum <s>          The staged tarball's SHA1 (40 hex chars).
 
 Optional:
@@ -58,9 +60,6 @@ Optional:
   --stage-id <id>       The staged release ID (UUID).
                         Only needed if the reproduction fails and you want to
                         download the staged tarball for diffing.
-
-  --integrity <i>       The staged tarball's integrity (e.g. sha512-…).
-                        Gates the sha512 check and the mismatch diff download.
 `
 
 const SCRIPT_DIR = import.meta.dirname
@@ -98,8 +97,8 @@ const { values } = (() => {
         version: { type: 'string' },
         sha: { type: 'string' },
         'stage-id': { type: 'string' },
-        shasum: { type: 'string' },
-        integrity: { type: 'string' }
+        integrity: { type: 'string' },
+        shasum: { type: 'string' }
       },
       allowPositionals: false
     })
@@ -113,9 +112,10 @@ if (values.help) {
   process.exit(0)
 }
 
-// Validate + normalise the flags. shasum is a tarball sha1 (40 hex); sha is the
-// git commit (40 hex today, 64 if the repo ever moves to SHA-256). stage-id and
-// integrity are only needed for the mismatch-escalation path.
+// Validate + normalise the flags. integrity is the staged tarball's sha512
+// (the primary gate); shasum is its sha1 (40 hex, corroboration); sha is the
+// git commit (40 hex today, 64 if the repo ever moves to SHA-256). stage-id is
+// only needed for the mismatch-escalation path.
 const releaseFieldsSchema = z.object({
   package: z
     .string({ error: 'missing required --package' })
@@ -130,26 +130,25 @@ const releaseFieldsSchema = z.object({
       '--sha must be a 40- or 64-char hex commit SHA'
     )
     .optional(),
+  integrity: z
+    .string({ error: 'missing required --integrity' })
+    .regex(
+      /^sha512-[A-Za-z0-9+/]+={0,2}$/,
+      "--integrity must look like 'sha512-…'"
+    ),
   shasum: z
     .string({ error: 'missing required --shasum' })
     .regex(/^[0-9a-f]{40}$/, '--shasum must be a 40-char hex sha1'),
-  stageId: z.string().min(1, '--stage-id must not be empty').default(''),
-  integrity: z
-    .string()
-    .regex(
-      /^sha\d+-[A-Za-z0-9+/]+={0,2}$/,
-      "--integrity must look like 'sha512-…'"
-    )
-    .default('')
+  stageId: z.string().min(1, '--stage-id must not be empty').default('')
 })
 
 const parsed = releaseFieldsSchema.safeParse({
   package: values.package,
   version: values.version,
   sha: values.sha,
+  integrity: values.integrity,
   shasum: values.shasum,
-  stageId: values['stage-id'],
-  integrity: values.integrity
+  stageId: values['stage-id']
 })
 if (!parsed.success) {
   die(2, ...parsed.error.issues.map(i => i.message), '', HELP)
@@ -159,8 +158,8 @@ const {
   version: VERSION,
   sha: SHA,
   stageId: STAGE_ID,
-  shasum: SHASUM,
-  integrity: INTEGRITY
+  integrity: INTEGRITY,
+  shasum: SHASUM
 } = parsed.data
 
 const REPO_ROOT = capture('git', ['rev-parse', '--show-toplevel']).trim()
@@ -199,8 +198,8 @@ const outcome = await verifyReproducibility(
     ref: REF,
     pkg: PACKAGE,
     version: VERSION,
-    shasum: SHASUM,
-    integrity: INTEGRITY || undefined
+    integrity: INTEGRITY,
+    shasum: SHASUM
   },
   verifier
 ).catch((e: Error) =>
@@ -210,10 +209,10 @@ const outcome = await verifyReproducibility(
 if (outcome.kind === 'match') {
   // Echo the reproduced vs staged digests so the match is visually checkable.
   err('')
+  err(`    reproduced integrity : ${outcome.reproduced.integrity}`)
+  err(`    staged     integrity : ${INTEGRITY}`)
   err(`    reproduced shasum    : ${outcome.reproduced.shasum}`)
   err(`    staged     shasum    : ${SHASUM}`)
-  err(`    reproduced integrity : ${outcome.reproduced.integrity}`)
-  err(`    staged     integrity : ${INTEGRITY || '<not provided>'}`)
   err(
     styleText('green', '==> PASS — reproduced .tgz matches the staged digests.')
   )
@@ -233,6 +232,8 @@ if (outcome.kind === 'toolchain-mismatch') {
 const localSha = outcome.reproduced.shasum
 err('')
 err(styleText('red', '==> Hash mismatch — reproduced .tgz != staged digests.'))
+err(`    reproduced integrity : ${outcome.reproduced.integrity}`)
+err(`    staged     integrity : ${INTEGRITY}`)
 err(`    reproduced shasum    : ${localSha}`)
 err(`    staged     shasum    : ${SHASUM}`)
 
@@ -263,9 +264,9 @@ const downloadJson = (() => {
 
 const downloadSchema = z.record(
   z.string(),
-  z.object({ shasum: z.string(), integrity: z.string() })
+  z.object({ integrity: z.string(), shasum: z.string() })
 )
-let stagedMeta: { shasum: string; integrity: string } | undefined
+let stagedMeta: { integrity: string; shasum: string } | undefined
 try {
   const meta = downloadSchema.parse(JSON.parse(downloadJson))
   stagedMeta = meta[PACKAGE] ?? Object.values(meta)[0]


### PR DESCRIPTION
The reproducible-release scripts under `packages/scripts/verify-release/` reproduce an npm tarball locally and compare its digests against the published (or staged) ones.

## Why

The SHA-1 `shasum` was the required gate, while the SHA-512 `integrity` (npm SRI, `sha512-<base64>`) was optional. So a PASS could rest on SHA-1 alone.

SHA-1 is collision-broken (chosen-prefix collisions have been practical since 2020). Leaving the weakest hash load-bearing in a tamper-detection tool is the wrong default.

## What changed

- `integrity` (sha512) is now required and the primary trust anchor.
- `shasum` stays, as a required corroborating check. A sha1 that agrees while the sha512 diverges is the shape of a collision attempt, and the integrity gate rejects it. Both must still match for a PASS.
- `integrity` is listed before `shasum` everywhere (types, arg parsing, help text, printed output, the workflow summary table and copy-paste command) to reflect its primacy.

Requiring integrity is safe on both paths:

- Production reads it from the registry metadata, whose schema already requires it.
- The staged path takes it as a now-required `--integrity` flag, which `release-draft.yml` already emits unconditionally.
