### PR TITLE
doc: strip unreleased headings from the production ToC

### DIFF
--- a/packages/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/packages/docs/src/app/docs/[[...slug]]/page.tsx
@@ -6,6 +6,8 @@ import {
   CopyMarkdownUrlButton,
   ViewOptions
 } from '@/src/components/ai/page-actions'
+import { getPublishedVersion, isPublished } from '@/src/lib/published-version'
+import { gatedHeadingIds } from '@/src/lib/strip-unreleased'
 import { getBaseUrl } from '@/src/lib/url'
 import { github } from '@/src/lib/utils'
 import {
@@ -31,9 +33,18 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
 
   const MDX = page.data.body
 
+  // The ToC is extracted from the raw headings at build time, bypassing the
+  // `SinceVersion` runtime gate — prune headings of unreleased sections so they
+  // don't leak into production's "On this page".
+  const published = await getPublishedVersion()
+  const gated = gatedHeadingIds(await page.data.getText('raw'), version =>
+    isPublished(version, published)
+  )
+  const toc = page.data.toc.filter(item => !gated.has(item.url.replace(/^#/, '')))
+
   return (
     <DocsPage
-      toc={page.data.toc}
+      toc={toc}
       tableOfContent={{
         footer: <AsideSponsors />
       }}

--- a/packages/docs/src/lib/strip-unreleased.test.ts
+++ b/packages/docs/src/lib/strip-unreleased.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { stripUnreleased } from './strip-unreleased.ts'
+import { gatedHeadingIds, stripUnreleased } from './strip-unreleased.ts'
 
 const showAll = () => true
 const hideAll = () => false
@@ -82,5 +82,73 @@ describe('stripUnreleased', () => {
       'outro'
     ].join('\n')
     expect(stripUnreleased(input, hideAll)).toBe(input)
+  })
+})
+
+describe('gatedHeadingIds', () => {
+  it('collects the explicit id of a heading inside a hidden block', () => {
+    const input = [
+      '## Shipped [#shipped]',
+      '<SinceVersion v="2.9.0">',
+      '## React Router v8 [#react-router-v8]',
+      '</SinceVersion>'
+    ].join('\n')
+    expect(gatedHeadingIds(input, hideAll)).toEqual(new Set(['react-router-v8']))
+  })
+
+  it('collects nothing when the block is visible', () => {
+    const input = [
+      '<SinceVersion v="2.9.0">',
+      '## React Router v8 [#react-router-v8]',
+      '</SinceVersion>'
+    ].join('\n')
+    expect(gatedHeadingIds(input, showAll)).toEqual(new Set())
+  })
+
+  it('falls back to a slug when the heading has no explicit id', () => {
+    const input = [
+      '<SinceVersion v="2.9.0">',
+      '### Some New Option',
+      '</SinceVersion>'
+    ].join('\n')
+    expect(gatedHeadingIds(input, hideAll)).toEqual(new Set(['some-new-option']))
+  })
+
+  it('ignores inline JSX when slugifying a heading title', () => {
+    const input = [
+      '<SinceVersion v="2.9.0">',
+      "## <Icon className='mr-2' />React Router v8",
+      '</SinceVersion>'
+    ].join('\n')
+    expect(gatedHeadingIds(input, hideAll)).toEqual(new Set(['react-router-v8']))
+  })
+
+  it('ignores headings outside any hidden block', () => {
+    const input = ['## Visible [#visible]', 'body'].join('\n')
+    expect(gatedHeadingIds(input, hideAll)).toEqual(new Set())
+  })
+
+  it('ignores heading-like lines inside fenced code blocks', () => {
+    const input = [
+      '<SinceVersion v="2.9.0">',
+      '```md',
+      '## Not a heading [#nope]',
+      '```',
+      '## Real [#real]',
+      '</SinceVersion>'
+    ].join('\n')
+    expect(gatedHeadingIds(input, hideAll)).toEqual(new Set(['real']))
+  })
+
+  it('collects nested headings of a hidden block', () => {
+    const input = [
+      '<SinceVersion v="2.9.0">',
+      '## Parent [#parent]',
+      '### Child [#child]',
+      '</SinceVersion>'
+    ].join('\n')
+    expect(gatedHeadingIds(input, hideAll)).toEqual(
+      new Set(['parent', 'child'])
+    )
   })
 })

--- a/packages/docs/src/lib/strip-unreleased.test.ts
+++ b/packages/docs/src/lib/strip-unreleased.test.ts
@@ -114,10 +114,10 @@ describe('gatedHeadingIds', () => {
     expect(gatedHeadingIds(input, hideAll)).toEqual(new Set(['some-new-option']))
   })
 
-  it('ignores inline JSX when slugifying a heading title', () => {
+  it('uses the explicit id for a heading that carries inline JSX', () => {
     const input = [
       '<SinceVersion v="2.9.0">',
-      "## <Icon className='mr-2' />React Router v8",
+      "## <Icon className='mr-2' />React Router v8 [#react-router-v8]",
       '</SinceVersion>'
     ].join('\n')
     expect(gatedHeadingIds(input, hideAll)).toEqual(new Set(['react-router-v8']))

--- a/packages/docs/src/lib/strip-unreleased.ts
+++ b/packages/docs/src/lib/strip-unreleased.ts
@@ -1,5 +1,7 @@
 const OPEN_TAG = /^<SinceVersion\s+[^>]*?\bv=['"]([^'"]+)['"][^>]*>/
 const CLOSE_TAG = '</SinceVersion>'
+const HEADING = /^#{1,6}\s+(.*)$/
+const EXPLICIT_ID = /\[#([^\]]+)\]\s*$/
 
 /**
  * Applies `<SinceVersion>` gating to the Markdown source of the LLM outputs,
@@ -48,4 +50,72 @@ export function stripUnreleased(
   }
 
   return output.join('\n')
+}
+
+/**
+ * Collects the heading ids that live inside hidden `<SinceVersion>` blocks, so
+ * the page can prune them from the table of contents — fumadocs extracts the ToC
+ * from the raw headings at build time, bypassing the `SinceVersion` runtime gate.
+ *
+ * Ids come from an explicit `[#id]` when present (matching the ToC anchors), and
+ * otherwise from a slug of the heading text. Shares the fence/nesting-aware walk
+ * of `stripUnreleased`, so the two surfaces gate identically.
+ */
+export function gatedHeadingIds(
+  markdown: string,
+  isVisible: (version: string) => boolean
+): Set<string> {
+  const ids = new Set<string>()
+  let inFence = false
+  let depth = 0
+  let hiddenFrom = -1
+
+  for (const line of markdown.split('\n')) {
+    if (line.startsWith('```')) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) {
+      continue
+    }
+
+    const open = line.trimStart().match(OPEN_TAG)
+    if (open) {
+      depth++
+      if (hiddenFrom === -1 && !isVisible(open[1]!)) {
+        hiddenFrom = depth
+      }
+      continue
+    }
+    if (line.trimStart().startsWith(CLOSE_TAG)) {
+      if (depth === hiddenFrom) {
+        hiddenFrom = -1
+      }
+      depth = Math.max(0, depth - 1)
+      continue
+    }
+
+    if (hiddenFrom !== -1) {
+      const heading = line.match(HEADING)
+      if (heading) {
+        ids.add(headingId(heading[1]!))
+      }
+    }
+  }
+
+  return ids
+}
+
+function headingId(headingText: string): string {
+  return headingText.match(EXPLICIT_ID)?.[1] ?? slugify(headingText)
+}
+
+function slugify(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, '') // drop inline JSX/HTML
+    .replace(/\[#[^\]]+\]/g, '') // drop any explicit-id syntax
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }

--- a/packages/docs/src/lib/strip-unreleased.ts
+++ b/packages/docs/src/lib/strip-unreleased.ts
@@ -106,14 +106,17 @@ export function gatedHeadingIds(
   return ids
 }
 
+/**
+ * Resolves a heading line to its ToC id. Gated headings carry an explicit
+ * `[#id]` (matching the anchor fumadocs emits); the slug is a best-effort
+ * fallback for plain-text headings without one.
+ */
 function headingId(headingText: string): string {
   return headingText.match(EXPLICIT_ID)?.[1] ?? slugify(headingText)
 }
 
 function slugify(text: string): string {
   return text
-    .replace(/<[^>]*>/g, '') // drop inline JSX/HTML
-    .replace(/\[#[^\]]+\]/g, '') // drop any explicit-id syntax
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')


### PR DESCRIPTION
The version gating from #1454 hides docs for unreleased features in production. The `SinceVersion` component does this at render time, so it can react to what's actually published on npm and to whether we're on a preview or production deployment.

The Table of Contents has its own path. fumadocs extracts it from the raw headings at build time, before any of that runtime logic runs. So a gated section was correctly hidden from the page body, but its heading still showed up in "On this page" in production. The React Router v8 entry is the one that leaked.

This prunes the ToC at render time using the same version check the component relies on. Headings of unreleased sections are dropped in production and kept on preview, so both surfaces now gate identically. They share the same `SinceVersion` parser, which keeps them from drifting apart.

No new build plumbing. The page reads the raw MDX, reuses the existing walker to find headings inside hidden blocks, and filters those entries out before handing the ToC to fumadocs. The npm lookup is deduped with the call the component already makes, so there's no extra request.

## Known remaining surface

The search index is built from the same build-time structured data, so production search could still surface unreleased content. Left for a follow-up.
