### PR TITLE
ci: refresh the docs on a GA release via ISR tag invalidation

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -9,9 +9,9 @@ name: Finalize Release
 # before any checkout) -> discover the impacted issues/PRs from the commit
 # graph between tag checkpoints (the shared engine, identical to the draft
 # notes) -> comment + label every one of them, channel-aware and re-run-safe
-# (the channel label is the idempotency filter) -> on a GA release, redeploy
-# nuqs.dev and bust the contributors/releases ISR caches so the published docs
-# reflect the new version.
+# (the channel label is the idempotency filter) -> on a GA release, bust the
+# docs ISR cache tags (npm-version + contributors + releases) so nuqs.dev
+# reflects the new version without a redeploy.
 
 on:
   release:
@@ -96,78 +96,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Redeploy the docs site on Vercel
-        # GA-only, gated on the comment loop succeeding: publishing a stable
-        # release triggers a fresh production build of nuqs.dev from the tip of
-        # `next`, shipping the just-released docs source and re-resolving the
-        # published GA version the version gate compares against (frozen per
-        # build — see the version-gated docs design), which is what reveals the
-        # newly-released content. The contributors + releases pages are refreshed
-        # separately by the ISR busts below: their cached GitHub fetches live in
-        # Vercel's Data Cache, which persists across deployments and is not
-        # updated by a build, so the redeploy alone won't refresh them.
-        # Betas never redeploy: they don't move `latest`, so the gate wouldn't
-        # open anyway. `success()` skips it on a failed comment loop; a green
-        # re-run is what finally fires it. A 2xx confirms the build was queued,
-        # not that it shipped — a failed Vercel build is surfaced by Vercel's own
-        # notifications, not here; this step fails only if the trigger fails.
-        if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
-        run: |
-          set -euo pipefail
-          : "${VERCEL_DEPLOYMENT_WEBHOOK:?secret is empty or unset; cannot trigger the docs redeploy}"
-          curl -fsS -X POST -o /dev/null "$VERCEL_DEPLOYMENT_WEBHOOK"
-          echo "Triggered a production redeploy of nuqs.dev from the tip of next."
-        env:
-          # The deploy-hook URL embeds a secret token, so the whole URL is stored
-          # as a secret and read at runtime — never inlined into the YAML text.
-          VERCEL_DEPLOYMENT_WEBHOOK: ${{ secrets.VERCEL_DEPLOYMENT_WEBHOOK }}
-
-      - name: Invalidate contributors ISR cache in the docs
-        # Refresh the runtime fetch data the redeploy can't reach: the
-        # contributors page caches its GitHub fetch under the `contributors` tag
-        # in Vercel's Data Cache, which persists across deployments and is not
-        # updated at build time — only revalidateTag refreshes it. Ordering
-        # against the redeploy above is not load-bearing: the bust marks the tag
-        # stale in the cross-deployment cache, so the next request to whichever
-        # deployment is live regenerates the page fresh.
+      - name: Bust the docs ISR cache tags
+        # GA-only, gated on the comment loop succeeding. Merges to `next` deploy
+        # to prod, so by the time finalize runs the just-released docs source is
+        # already live on nuqs.dev — only version-gated. The gate compares the
+        # rendered version against npm's `latest` dist-tag, whose fetch is a
+        # force-cached, tag-only entry in Vercel's Data Cache (persisted across
+        # deployments, not updated at build time); the contributors and releases
+        # pages cache their GitHub fetches the same way. So one revalidateTag
+        # sweep is all it takes: busting `npm-version` re-resolves the gate and
+        # reveals the released content, while `contributors` + `releases` repaint
+        # those pages. No redeploy needed — the source is already shipped, and a
+        # bust forces a fresh fetch where a rebuild would reuse the persisted
+        # cache.
         #
-        # GA-only and gated on the comment loop succeeding: the page repaints
-        # when a stable release actually ships, not on betas, and not while a red
-        # finalize is mid-convergence. `success()` skips it on a failed comment
-        # loop; a green re-run is what finally fires it. Not best-effort: a failed
-        # bust fails the job (so the maintainer re-runs rather than leaving the
-        # page silently stale) — the curl is idempotent.
+        # Betas never bust: they don't move `latest`, so the gate wouldn't open.
+        # `success()` skips it on a failed comment loop; a green re-run is what
+        # finally fires it. Not best-effort: a failed bust fails the job (so the
+        # maintainer re-runs rather than leaving the docs silently stale) — the
+        # curl is idempotent, and the endpoint busts every tag in one call.
         if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
         run: |
           set -euo pipefail
-          : "${ISR_TOKEN:?secret is empty or unset; cannot bust the contributors ISR cache}"
-          curl -fsS "https://nuqs.dev/api/isr?tag=contributors&token=$ISR_TOKEN"
+          : "${ISR_TOKEN:?secret is empty or unset; cannot bust the docs ISR caches}"
+          curl -fsS "https://nuqs.dev/api/isr?tag=npm-version&tag=contributors&tag=releases&token=$ISR_TOKEN"
         env:
           # Passed via env and read as $ISR_TOKEN at runtime, so the literal
           # secret never appears in the workflow YAML text (same stance as TAG).
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
-      - name: Invalidate releases ISR cache in the docs
-        # Same mechanism, same fail-hard stance as the contributors bust above:
-        # the changelog's `releases` fetch is a tag-only Data Cache entry with no
-        # build or TTL fallback, so only revalidateTag refreshes it. A missed bust
-        # would leave the public changelog stale until the next release's bust, so
-        # fail the job and let the maintainer re-run — the curl is idempotent.
-        if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
-        run: |
-          set -euo pipefail
-          : "${ISR_TOKEN:?secret is empty or unset; cannot bust the releases ISR cache}"
-          curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"
-        env:
-          ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
-
       - name: Notify on Slack
         # Last, and always: on success a 🚀/🧪 release card (packageName +
         # version + channel → the action derives the npm + release-notes links);
-        # on a red run (a failed comment loop, a failed docs redeploy, or a
-        # failed ISR cache bust above) the standard step-breakdown notice instead.
-        # So a shipped release and a finalize failure are both visible without
-        # watching the Actions tab.
+        # on a red run (a failed comment loop or a failed ISR cache bust above)
+        # the standard step-breakdown notice instead. So a shipped release and a
+        # finalize failure are both visible without watching the Actions tab.
         if: always()
         uses: 47ng/actions-slack-notify@df42545060c07ca99a040d0a520ab8457ce3c222
         with:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -9,7 +9,9 @@ name: Finalize Release
 # before any checkout) -> discover the impacted issues/PRs from the commit
 # graph between tag checkpoints (the shared engine, identical to the draft
 # notes) -> comment + label every one of them, channel-aware and re-run-safe
-# (the channel label is the idempotency filter).
+# (the channel label is the idempotency filter) -> on a GA release, redeploy
+# nuqs.dev and bust the contributors/releases ISR caches so the published docs
+# reflect the new version.
 
 on:
   release:
@@ -94,14 +96,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Redeploy the docs site on Vercel
+        # GA-only, gated on the comment loop succeeding: publishing a stable
+        # release triggers a fresh production build of nuqs.dev from the tip of
+        # `next`, shipping the just-released docs source and re-resolving the
+        # published GA version the version gate compares against (frozen per
+        # build — see the version-gated docs design), which is what reveals the
+        # newly-released content. The contributors + releases pages are refreshed
+        # separately by the ISR busts below: their cached GitHub fetches live in
+        # Vercel's Data Cache, which persists across deployments and is not
+        # updated by a build, so the redeploy alone won't refresh them.
+        # Betas never redeploy: they don't move `latest`, so the gate wouldn't
+        # open anyway. `success()` skips it on a failed comment loop; a green
+        # re-run is what finally fires it. A 2xx confirms the build was queued,
+        # not that it shipped — a failed Vercel build is surfaced by Vercel's own
+        # notifications, not here; this step fails only if the trigger fails.
+        if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
+        run: |
+          set -euo pipefail
+          : "${VERCEL_DEPLOYMENT_WEBHOOK:?secret is empty or unset; cannot trigger the docs redeploy}"
+          curl -fsS -X POST -o /dev/null "$VERCEL_DEPLOYMENT_WEBHOOK"
+          echo "Triggered a production redeploy of nuqs.dev from the tip of next."
+        env:
+          # The deploy-hook URL embeds a secret token, so the whole URL is stored
+          # as a secret and read at runtime — never inlined into the YAML text.
+          VERCEL_DEPLOYMENT_WEBHOOK: ${{ secrets.VERCEL_DEPLOYMENT_WEBHOOK }}
+
       - name: Invalidate contributors ISR cache in the docs
-        # GA-only, and gated on the comment loop succeeding: the public
-        # contributors page repaints once — when a stable release actually
-        # ships, not on betas, and not while a red finalize is mid-convergence.
-        # `success()` is what skips it on a failed comment loop; a re-run that
-        # completes the stragglers green is what finally fires it. Not
-        # best-effort: a failed bust fails the job (so the maintainer re-runs
-        # rather than leaving the page silently stale) — the curl is idempotent.
+        # Refresh the runtime fetch data the redeploy can't reach: the
+        # contributors page caches its GitHub fetch under the `contributors` tag
+        # in Vercel's Data Cache, which persists across deployments and is not
+        # updated at build time — only revalidateTag refreshes it. Ordering
+        # against the redeploy above is not load-bearing: the bust marks the tag
+        # stale in the cross-deployment cache, so the next request to whichever
+        # deployment is live regenerates the page fresh.
+        #
+        # GA-only and gated on the comment loop succeeding: the page repaints
+        # when a stable release actually ships, not on betas, and not while a red
+        # finalize is mid-convergence. `success()` skips it on a failed comment
+        # loop; a green re-run is what finally fires it. Not best-effort: a failed
+        # bust fails the job (so the maintainer re-runs rather than leaving the
+        # page silently stale) — the curl is idempotent.
         if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
         run: curl -fsS "https://nuqs.dev/api/isr?tag=contributors&token=$ISR_TOKEN"
         env:
@@ -110,6 +145,9 @@ jobs:
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
       - name: Invalidate releases ISR cache in the docs
+        # Same mechanism for the changelog's `releases` fetch, but best-effort:
+        # the changelog also refreshes on the next release or build, so a missed
+        # bust degrades to a warning rather than failing the finalize.
         if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
         run: |
           set -euo pipefail
@@ -122,9 +160,10 @@ jobs:
       - name: Notify on Slack
         # Last, and always: on success a 🚀/🧪 release card (packageName +
         # version + channel → the action derives the npm + release-notes links);
-        # on a red run (a failed comment loop, or a failed ISR bust above) the
-        # standard step-breakdown notice instead. So a shipped release and a
-        # finalize failure are both visible without watching the Actions tab.
+        # on a red run (a failed comment loop, a failed docs redeploy, or a
+        # failed contributors ISR bust above) the standard step-breakdown notice
+        # instead. So a shipped release and a finalize failure are both visible
+        # without watching the Actions tab.
         if: always()
         uses: 47ng/actions-slack-notify@df42545060c07ca99a040d0a520ab8457ce3c222
         with:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           set -euo pipefail
           : "${ISR_TOKEN:?secret is empty or unset; cannot bust the docs ISR caches}"
-          curl -fsS "https://nuqs.dev/api/isr?tag=npm-version&tag=contributors&tag=releases&token=$ISR_TOKEN"
+          curl -fsSL "https://nuqs.dev/api/isr?tag=npm-version&tag=contributors&tag=releases&token=$ISR_TOKEN"
         env:
           # Passed via env and read as $ISR_TOKEN at runtime, so the literal
           # secret never appears in the workflow YAML text (same stance as TAG).

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -138,22 +138,26 @@ jobs:
         # bust fails the job (so the maintainer re-runs rather than leaving the
         # page silently stale) — the curl is idempotent.
         if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
-        run: curl -fsS "https://nuqs.dev/api/isr?tag=contributors&token=$ISR_TOKEN"
+        run: |
+          set -euo pipefail
+          : "${ISR_TOKEN:?secret is empty or unset; cannot bust the contributors ISR cache}"
+          curl -fsS "https://nuqs.dev/api/isr?tag=contributors&token=$ISR_TOKEN"
         env:
           # Passed via env and read as $ISR_TOKEN at runtime, so the literal
           # secret never appears in the workflow YAML text (same stance as TAG).
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
       - name: Invalidate releases ISR cache in the docs
-        # Same mechanism for the changelog's `releases` fetch, but best-effort:
-        # the changelog also refreshes on the next release or build, so a missed
-        # bust degrades to a warning rather than failing the finalize.
+        # Same mechanism, same fail-hard stance as the contributors bust above:
+        # the changelog's `releases` fetch is a tag-only Data Cache entry with no
+        # build or TTL fallback, so only revalidateTag refreshes it. A missed bust
+        # would leave the public changelog stale until the next release's bust, so
+        # fail the job and let the maintainer re-run — the curl is idempotent.
         if: ${{ success() && !contains(github.event.release.tag_name, '-beta.') }}
         run: |
           set -euo pipefail
-          if ! curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"; then
-            echo "::warning::Could not bust the 'releases' ISR cache. The changelog page will refresh on the next release or build."
-          fi
+          : "${ISR_TOKEN:?secret is empty or unset; cannot bust the releases ISR cache}"
+          curl -fsS "https://nuqs.dev/api/isr?tag=releases&token=$ISR_TOKEN"
         env:
           ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
@@ -161,9 +165,9 @@ jobs:
         # Last, and always: on success a 🚀/🧪 release card (packageName +
         # version + channel → the action derives the npm + release-notes links);
         # on a red run (a failed comment loop, a failed docs redeploy, or a
-        # failed contributors ISR bust above) the standard step-breakdown notice
-        # instead. So a shipped release and a finalize failure are both visible
-        # without watching the Actions tab.
+        # failed ISR cache bust above) the standard step-breakdown notice instead.
+        # So a shipped release and a finalize failure are both visible without
+        # watching the Actions tab.
         if: always()
         uses: 47ng/actions-slack-notify@df42545060c07ca99a040d0a520ab8457ce3c222
         with:

--- a/packages/docs/src/app/api/isr/route.ts
+++ b/packages/docs/src/app/api/isr/route.ts
@@ -5,6 +5,7 @@ import { timingSafeEqual } from 'node:crypto'
 const ACCEPTED_TAGS = [
   'github',
   'github-actions-status',
+  'npm-version',
   'npm-stats',
   'contributors',
   'releases'
@@ -28,13 +29,18 @@ export async function GET(req: NextRequest) {
     console.log('Invalid token `%s`', token?.slice(0, 256))
     return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
   }
-  const tag = req.nextUrl.searchParams.get('tag')
-  if (!tag || !ACCEPTED_TAGS.includes(tag)) {
+  // Accept one or more `tag` params so a single call can bust several tags
+  // atomically (the release sweep busts npm-version + contributors + releases
+  // at once).
+  const tags = req.nextUrl.searchParams.getAll('tag')
+  if (tags.length === 0 || tags.some(tag => !ACCEPTED_TAGS.includes(tag))) {
     return NextResponse.json({ error: 'Invalid tag' }, { status: 400 })
   }
-  revalidateTag(tag, 'max')
+  for (const tag of tags) {
+    revalidateTag(tag, 'max')
+  }
   return NextResponse.json({
     at: new Date().toISOString(),
-    revalidated: tag
+    revalidated: tags
   })
 }

--- a/packages/docs/src/lib/published-version.ts
+++ b/packages/docs/src/lib/published-version.ts
@@ -3,14 +3,20 @@ const NPM_REGISTRY_URL = 'https://registry.npmjs.org/nuqs'
 /**
  * The latest GA version of nuqs published on npm.
  *
- * Resolved once at build (`force-cache`, no time-based revalidation) and frozen
- * into the statically generated output, so the docs reveal newly-released
- * content only on the next deployment. Throws on a registry failure to fail the
- * build loudly — leaving the current deployment up — rather than ship a docs
- * site gated against a wrong version.
+ * Cached indefinitely (`force-cache`, no TTL) under the `npm-version` tag in the
+ * Data Cache, which persists across deployments. The version gate compares
+ * against this value, so a release reveals its newly-published (already-deployed
+ * but gated) content by busting the `npm-version` tag from release-finalize.yml
+ * — not by waiting for a redeploy. Throws on a registry failure rather than
+ * serve docs gated against a wrong version: at build it fails loudly (leaving
+ * the current deployment up); during on-demand regeneration after a bust, Next
+ * keeps serving the last good page.
  */
 export async function getPublishedVersion(): Promise<string> {
-  const response = await fetch(NPM_REGISTRY_URL, { cache: 'force-cache' })
+  const response = await fetch(NPM_REGISTRY_URL, {
+    cache: 'force-cache',
+    next: { tags: ['npm-version'] }
+  })
   if (!response.ok) {
     throw new Error(
       `Failed to resolve the latest nuqs version from npm (${response.status} ${response.statusText})`


### PR DESCRIPTION
Part of the branch-unification work to deploy nuqs.dev from `next` with version-gated docs. When a stable release ships, production needs to reveal the newly-released docs.

Because merges to `next` already deploy to production, by the time `release-finalize` runs the just-released docs source is **already live** on nuqs.dev — only hidden behind the version gate. The gate compares the rendered version against npm's `latest` dist-tag, whose fetch is a force-cached, tag-only entry in Vercel's Data Cache (persisted across deployments, **not** updated at build time). The contributors and releases pages cache their GitHub fetches the same way.

So instead of triggering a full redeploy, finalize now busts the relevant cache tags on-demand:

- **Tag the version-gate fetch** with `npm-version` so it can be invalidated (it previously had no tag, only `force-cache`).
- **`/api/isr` accepts multiple `tag` params** and busts them in a single call (validation is all-or-nothing, before any bust; single-tag callers stay compatible).
- **`release-finalize` makes one `revalidateTag` sweep**: `npm-version` (re-resolves the gate → reveals the released content) + `contributors` + `releases` (repaint those pages).

A tag bust is more reliable than a redeploy here: it forces a fresh fetch (cache MISS → refetch), whereas a rebuild can reuse the persisted Data Cache and keep serving stale data.

Everything stays gated on a stable (non-beta) release and on the comment loop succeeding, same as before. A missed bust fails the job (the curl is idempotent, so a re-run is safe).