### PR TITLE
doc(inertia-adapter): fix shallow updates "Invalid URL" crash

### DIFF
--- a/packages/docs/src/registry/items/adapter-inertia.json
+++ b/packages/docs/src/registry/items/adapter-inertia.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "type": "registry:file",
-      "path": "https://raw.githubusercontent.com/47ng/nuqs-inertia-pingcrm/refs/heads/with-nuqs/resources/js/lib/nuqs-inertia-adapter.ts",
+      "path": "https://raw.githubusercontent.com/47ng/nuqs-inertia-pingcrm/70aeb29b9ce9e333ac5124d84191a6778fd62b3f/resources/js/lib/nuqs-inertia-adapter.ts",
       "target": "~/resources/js/lib/nuqs-inertia-adapter.ts"
     }
   ]


### PR DESCRIPTION
Pin the Inertia community adapter registry item to a specific commit so we control which version the docs expose, and pull in the upstream fixes for the `shallow: true` Invalid URL crash.

Bundled adapter changes (from `47ng/nuqs-inertia-pingcrm`):

- https://github.com/47ng/nuqs-inertia-pingcrm/pull/2
- https://github.com/47ng/nuqs-inertia-pingcrm/pull/3

Fixes #1460