### PR TITLE
doc: remove old references to master

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
-  "githubPullRequests.ignoredPullRequestBranches": ["next", "master"],
+  "githubPullRequests.ignoredPullRequestBranches": ["next"],
   "githubPullRequests.queries": [
     {
       "label": "Backlog",

--- a/packages/docs/src/lib/get-last-modified.ts
+++ b/packages/docs/src/lib/get-last-modified.ts
@@ -1,13 +1,14 @@
 import { getGithubLastEdit } from 'fumadocs-core/content/github'
+import { github } from './utils'
 
 export async function getLastModified(
   path: string,
-  branch = 'master'
+  branch = github.branch
 ): Promise<Date> {
   try {
     const lastEdit = await getGithubLastEdit({
-      owner: '47ng',
-      repo: 'nuqs',
+      owner: github.owner,
+      repo: github.repo,
       path: `packages/docs${path}`,
       sha: branch,
       token: `Bearer ${process.env.GITHUB_TOKEN}`

--- a/packages/docs/src/lib/utils.ts
+++ b/packages/docs/src/lib/utils.ts
@@ -8,5 +8,5 @@ export function cn(...inputs: ClassValue[]) {
 export const github = {
   owner: "47ng",
   repo: "nuqs",
-  branch: "master",
+  branch: "next",
 }


### PR DESCRIPTION
## Why

The repo was unified onto `next` in #1454, deleting the `master` branch. Several hardcoded `master` references in the docs were left behind. They surfaced in the production Vercel build for `dpl_6Trb48kjJjn9GviMbaWwxDhiK36R`:

- `getLastModified` defaulted to `branch = 'master'`, so the GitHub "last edit" fetch 404'd for **every** doc file (`sha=master` no longer resolves) — flooding the build log and silently falling back to build-time dates in the sitemap and registry RSS feed.
- `github.branch = "master"` in `utils.ts` produced 404 links for "Edit on GitHub" / "View source" across docs and the `Source:` URLs in the llms.txt output.

## Changes

- Point `github.branch` at `next` and route `getLastModified`'s owner/repo/branch through the shared `github` constant (single source of truth).
- Drop the dead `master` entry from `.vscode/settings.json`.

Takes effect on the next deploy.