### PR TITLE
chore: prevent finalize re-runs from double-commenting

### DIFF
--- a/packages/scripts/release-finalize.test.ts
+++ b/packages/scripts/release-finalize.test.ts
@@ -11,8 +11,13 @@ import {
   type ThreadComment
 } from './release-finalize'
 
-// The login finalize comments author as (the CI GITHUB_TOKEN identity).
-const githubActionsBot = 'github-actions[bot]'
+// The login finalize comments author as: the GitHub Actions app (the CI
+// GITHUB_TOKEN identity). Finalize reads threads over GraphQL, which returns the
+// bare `github-actions` — the value that actually reaches the guard at runtime, so
+// it's the one the fixtures use. (REST spells the same actor `github-actions[bot]`;
+// the guard accepts both — see githubActionsBotRest.)
+const githubActionsBot = 'github-actions'
+const githubActionsBotRest = 'github-actions[bot]'
 
 describe('releaseMarker', () => {
   it('keys the marker by release version (GA tag, no leading v)', () => {
@@ -143,6 +148,13 @@ describe('hasReleaseComment', () => {
   it("returns true when the bot has posted a comment bearing this release's marker", () => {
     const comments: ThreadComment[] = [
       { author: githubActionsBot, body: `done\n${marker}\n` }
+    ]
+    expect(hasReleaseComment(comments, marker)).toBe(true)
+  })
+
+  it('also accepts the REST [bot] form of the bot login (dual-convention guard)', () => {
+    const comments: ThreadComment[] = [
+      { author: githubActionsBotRest, body: `done\n${marker}\n` }
     ]
     expect(hasReleaseComment(comments, marker)).toBe(true)
   })

--- a/packages/scripts/release-finalize.test.ts
+++ b/packages/scripts/release-finalize.test.ts
@@ -159,6 +159,13 @@ describe('hasReleaseComment', () => {
     expect(hasReleaseComment(comments, marker)).toBe(true)
   })
 
+  it('matches the bot login case-insensitively', () => {
+    const comments: ThreadComment[] = [
+      { author: 'GitHub-Actions', body: `done\n${marker}\n` }
+    ]
+    expect(hasReleaseComment(comments, marker)).toBe(true)
+  })
+
   it('returns false when no comment carries the marker', () => {
     const comments: ThreadComment[] = [
       { author: githubActionsBot, body: 'unrelated chatter' }

--- a/packages/scripts/release-finalize.ts
+++ b/packages/scripts/release-finalize.ts
@@ -90,12 +90,25 @@ ${tryBeta}${releaseMarker(tag)}
 // check needs — no ids, timestamps, or reactions.
 export type ThreadComment = { author: string; body: string }
 
-// Comments are posted by the release CI job under GITHUB_TOKEN, authoring as
-// `github-actions[bot]`. The marker check requires this author: the sentinel is
-// plain text visible in the page source, so a human — or an AI agent that echoes
-// it back in a comment — could otherwise suppress a real release notification by
-// posting the marker themselves.
-export const RELEASE_BOT_LOGIN = 'github-actions[bot]'
+// The release CI job posts comments under GITHUB_TOKEN, whose actor is the GitHub
+// Actions app. That one actor's login is spelled two ways depending on the API:
+// GraphQL returns the bare `github-actions`, REST returns `github-actions[bot]`.
+// Finalize reads threads over GraphQL, so the bare form is what actually reaches
+// this guard at runtime — but `isReleaseBot` tolerates both, mirroring `isBot` in
+// commit-graph.ts, which already encodes this same dual-convention quirk (and was
+// the reason this guard's earlier `=== 'github-actions[bot]'` silently never
+// matched, re-commenting on every re-run).
+//
+// The marker check requires this author: the sentinel is plain text visible in the
+// page source, so a human — or an AI agent that echoes it back in a comment — could
+// otherwise suppress a real release notification by posting the marker themselves.
+// The `github-actions` login namespace is GitHub-controlled (a user cannot claim
+// it), so matching the login is a sufficient anti-spoof guard.
+const RELEASE_BOT_LOGIN = 'github-actions'
+
+export function isReleaseBot(login: string): boolean {
+  return login.replace(/\[bot\]$/, '') === RELEASE_BOT_LOGIN
+}
 
 // Comment gate: this bot has already posted this release's marker comment.
 // The marker lives in the comment body, so posting the comment and persisting the
@@ -111,7 +124,7 @@ export function hasReleaseComment(
   marker: string
 ): boolean {
   return comments.some(
-    ({ author, body }) => author === RELEASE_BOT_LOGIN && body.includes(marker)
+    ({ author, body }) => isReleaseBot(author) && body.includes(marker)
   )
 }
 

--- a/packages/scripts/release-finalize.ts
+++ b/packages/scripts/release-finalize.ts
@@ -107,7 +107,7 @@ export type ThreadComment = { author: string; body: string }
 const RELEASE_BOT_LOGIN = 'github-actions'
 
 export function isReleaseBot(login: string): boolean {
-  return login.replace(/\[bot\]$/, '') === RELEASE_BOT_LOGIN
+  return login.replace(/\[bot\]$/, '').toLowerCase() === RELEASE_BOT_LOGIN
 }
 
 // Comment gate: this bot has already posted this release's marker comment.


### PR DESCRIPTION
## What happened

Shipping nuqs@2.9.0, the finalize job's first run commented and labelled all 92 impacted issues and PRs, then failed on the ISR cache bust (the docs had been rolled back to a build that 400s on the multi-tag URL). Re-running the failed job re-ran the comment loop, which posted a second comment on every target it reached before being cancelled. The result was double "released in nuqs@2.9.0" comments.

## Root cause

The comment idempotency guard skips a target once our release bot has posted the marker. It compared the comment author against `github-actions[bot]`, which is the REST spelling. Finalize reads threads over GraphQL, and GraphQL returns the bare login `github-actions`, with no `[bot]` suffix. So the author check never matched, `hasReleaseComment` always returned false, and every re-run re-posted.

The label gate was fine, because it reads the labels list rather than the author. That asymmetry is exactly what the logs showed: re-runs re-commented but did not re-label.

The same package already knows about this convention. `isBot` in `commit-graph.ts` tolerates both spellings. The finalize guard just hardcoded the REST one.

## The fix

A small `isReleaseBot(login)` predicate strips an optional trailing `[bot]` before comparing to `github-actions`, so both spellings of the same actor are recognised. The `github-actions` login namespace is GitHub-controlled, so matching on it stays a sufficient anti-spoof guard.

## Tests

The old fixtures used the REST login, the same value the buggy constant used, so the tests agreed with the bug and stayed green. They now use the real GraphQL login (bare `github-actions`), plus a case covering the `[bot]` form. Reverting the predicate to its old behaviour now turns the suite red, which it did not do before.

## Cleanup (already done)

The 15 duplicate comments on the 2.9.0 targets were removed, keeping the first comment on each (the one that also carries the `released` label). A read-only sweep over all 92 targets confirms no duplicates remain.
