### PR TITLE
test(docs): cover network-boundary fetchers with MSW

### DIFF
--- a/packages/docs/src/app/(pages)/_landing/contributors.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/contributors.test.ts
@@ -1,0 +1,88 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { fetchContributors } from './contributors.tsx'
+
+const endpoint = 'https://api.github.com/repos/47ng/nuqs/contributors'
+
+function contributor(overrides: Record<string, unknown> = {}) {
+  return {
+    login: 'octocat',
+    html_url: 'https://github.com/octocat',
+    avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+    type: 'User',
+    contributions: 10,
+    ...overrides
+  }
+}
+
+describe('fetchContributors', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('returns human contributors sorted by contributions descending', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([
+          contributor({ login: 'low', contributions: 3 }),
+          contributor({ login: 'high', contributions: 99 }),
+          contributor({ login: 'mid', contributions: 42 })
+        ])
+      )
+    )
+    const contributors = await fetchContributors()
+    expect(contributors.map(c => c.login)).toEqual(['high', 'mid', 'low'])
+  })
+
+  it('filters bots by type, known bot id, and [bot] suffix', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([
+          contributor({ login: 'human', contributions: 50 }),
+          contributor({ login: 'some-bot', type: 'Bot', contributions: 40 }),
+          contributor({ login: 'dependabot[bot]', contributions: 30 }),
+          contributor({ login: 'Renovate[bot]', contributions: 20 }),
+          contributor({ login: 'custom[bot]', contributions: 10 })
+        ])
+      )
+    )
+    const contributors = await fetchContributors()
+    expect(contributors.map(c => c.login)).toEqual(['human'])
+  })
+
+  it('paginates until a page returns fewer than the page size', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) =>
+      contributor({ login: `p1-${i}`, contributions: 1000 - i })
+    )
+    const page2 = [contributor({ login: 'last', contributions: 1 })]
+    server.use(
+      http.get(endpoint, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page')
+        return HttpResponse.json(page === '1' ? page1 : page2)
+      })
+    )
+    const contributors = await fetchContributors()
+    expect(contributors).toHaveLength(101)
+    expect(contributors.at(-1)?.login).toBe('last')
+  })
+
+  it('throws on a non-ok response', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json({}, { status: 500, statusText: 'Server Error' })
+      )
+    )
+    await expect(fetchContributors()).rejects.toThrow(/500 Server Error/)
+  })
+
+  it('throws when the response fails schema validation', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([{ login: 'octocat' }]) // missing required fields
+      )
+    )
+    await expect(fetchContributors()).rejects.toThrow()
+  })
+})

--- a/packages/docs/src/app/(pages)/_landing/contributors.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/contributors.test.ts
@@ -5,15 +5,20 @@ import { fetchContributors } from './contributors.tsx'
 
 const endpoint = 'https://api.github.com/repos/47ng/nuqs/contributors'
 
-function contributor(overrides: Record<string, unknown> = {}) {
-  return {
-    login: 'octocat',
-    html_url: 'https://github.com/octocat',
-    avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
-    type: 'User',
-    contributions: 10,
-    ...overrides
-  }
+const contributorDefaults = {
+  login: 'octocat',
+  html_url: 'https://github.com/octocat',
+  avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+  type: 'User',
+  contributions: 10
+}
+
+// Keys constrained to the fixture shape: a typo'd override (e.g. `contribution`)
+// is a compile error, not a silently-dropped value that false-greens the test.
+function contributor(
+  overrides: Partial<Record<keyof typeof contributorDefaults, unknown>> = {}
+) {
+  return { ...contributorDefaults, ...overrides }
 }
 
 describe('fetchContributors', () => {
@@ -79,8 +84,9 @@ describe('fetchContributors', () => {
 
   it('throws when the response fails schema validation', async () => {
     server.use(
-      http.get(endpoint, () =>
-        HttpResponse.json([{ login: 'octocat' }]) // missing required fields
+      http.get(
+        endpoint,
+        () => HttpResponse.json([{ login: 'octocat' }]) // missing required fields
       )
     )
     await expect(fetchContributors()).rejects.toThrow()

--- a/packages/docs/src/app/(pages)/_landing/contributors.tsx
+++ b/packages/docs/src/app/(pages)/_landing/contributors.tsx
@@ -10,7 +10,7 @@ const contributorSchema = z.object({
 })
 type Contributor = z.infer<typeof contributorSchema>
 
-async function fetchContributors(): Promise<Contributor[]> {
+export async function fetchContributors(): Promise<Contributor[]> {
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json'
   }

--- a/packages/docs/src/app/(pages)/_landing/dependents.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/dependents.test.ts
@@ -1,0 +1,59 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { fetchDependents } from './dependents.tsx'
+
+const endpoint = 'https://dependents.47ng.com'
+
+function dependent(overrides: Record<string, unknown> = {}) {
+  return {
+    stars: 1200,
+    owner: 'acme',
+    name: 'webapp',
+    pkg: 'nuqs',
+    avatarURL: 'https://avatars.githubusercontent.com/u/1?v=4',
+    version: '2.0.0',
+    createdAt: '2024-01-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('fetchDependents', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('parses the dependents array and coerces createdAt to a Date', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([
+          dependent({ owner: 'a', name: 'one' }),
+          dependent({ owner: 'b', name: 'two', version: null, pkg: 'next-usequerystate' })
+        ])
+      )
+    )
+    const dependents = await fetchDependents()
+    expect(dependents).toHaveLength(2)
+    expect(dependents[0].createdAt).toBeInstanceOf(Date)
+    expect(dependents[1].version).toBeNull()
+  })
+
+  it('rejects a payload with missing fields', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([{ owner: 'a', name: 'one' }])
+      )
+    )
+    await expect(fetchDependents()).rejects.toThrow()
+  })
+
+  it('rejects a payload with wrong field types', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([dependent({ stars: 'lots' })])
+      )
+    )
+    await expect(fetchDependents()).rejects.toThrow()
+  })
+})

--- a/packages/docs/src/app/(pages)/_landing/dependents.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/dependents.test.ts
@@ -5,17 +5,22 @@ import { fetchDependents } from './dependents.tsx'
 
 const endpoint = 'https://dependents.47ng.com'
 
-function dependent(overrides: Record<string, unknown> = {}) {
-  return {
-    stars: 1200,
-    owner: 'acme',
-    name: 'webapp',
-    pkg: 'nuqs',
-    avatarURL: 'https://avatars.githubusercontent.com/u/1?v=4',
-    version: '2.0.0',
-    createdAt: '2024-01-01T00:00:00Z',
-    ...overrides
-  }
+const dependentDefaults = {
+  stars: 1200,
+  owner: 'acme',
+  name: 'webapp',
+  pkg: 'nuqs',
+  avatarURL: 'https://avatars.githubusercontent.com/u/1?v=4',
+  version: '2.0.0',
+  createdAt: '2024-01-01T00:00:00Z'
+}
+
+// Keys constrained to the fixture shape so a typo'd override is a compile error.
+// Values stay `unknown` so the schema-rejection tests can still pass wrong types.
+function dependent(
+  overrides: Partial<Record<keyof typeof dependentDefaults, unknown>> = {}
+) {
+  return { ...dependentDefaults, ...overrides }
 }
 
 describe('fetchDependents', () => {
@@ -29,7 +34,12 @@ describe('fetchDependents', () => {
       http.get(endpoint, () =>
         HttpResponse.json([
           dependent({ owner: 'a', name: 'one' }),
-          dependent({ owner: 'b', name: 'two', version: null, pkg: 'next-usequerystate' })
+          dependent({
+            owner: 'b',
+            name: 'two',
+            version: null,
+            pkg: 'next-usequerystate'
+          })
         ])
       )
     )
@@ -41,9 +51,7 @@ describe('fetchDependents', () => {
 
   it('rejects a payload with missing fields', async () => {
     server.use(
-      http.get(endpoint, () =>
-        HttpResponse.json([{ owner: 'a', name: 'one' }])
-      )
+      http.get(endpoint, () => HttpResponse.json([{ owner: 'a', name: 'one' }]))
     )
     await expect(fetchDependents()).rejects.toThrow()
   })

--- a/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
@@ -1,0 +1,63 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { getGitHubActionsStatus } from './gha-status.tsx'
+
+const endpoint = 'https://api.github.com/graphql'
+
+function run(id: string, status: string, conclusion: string | null = 'SUCCESS') {
+  return {
+    id,
+    url: `https://github.com/47ng/nuqs/actions/runs/${id}`,
+    createdAt: '2024-01-01T00:00:00Z',
+    checkSuite: { status, conclusion }
+  }
+}
+
+function respondWith(nodes: unknown[]) {
+  return http.post(endpoint, () =>
+    HttpResponse.json({ data: { node: { runs: { nodes } } } })
+  )
+}
+
+describe('getGitHubActionsStatus', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('keeps the last 5 completed runs, ordered oldest to newest', async () => {
+    // API returns newest-first; n2 and n8 are not completed and must drop out.
+    server.use(
+      respondWith([
+        run('n1', 'COMPLETED'),
+        run('n2', 'IN_PROGRESS', null),
+        run('n3', 'COMPLETED'),
+        run('n4', 'COMPLETED'),
+        run('n5', 'COMPLETED'),
+        run('n6', 'COMPLETED'),
+        run('n7', 'COMPLETED'),
+        run('n8', 'PENDING', null)
+      ])
+    )
+    const statuses = await getGitHubActionsStatus()
+    // Newest 5 completed are n1,n3,n4,n5,n6 → reversed to oldest-first.
+    expect(statuses.map(s => s.id)).toEqual(['n6', 'n5', 'n4', 'n3', 'n1'])
+    expect(statuses.every(s => s.checkSuite.status === 'COMPLETED')).toBe(true)
+  })
+
+  it('returns an empty array when there are no completed runs', async () => {
+    server.use(respondWith([run('n1', 'IN_PROGRESS', null)]))
+    await expect(getGitHubActionsStatus()).resolves.toEqual([])
+  })
+
+  it('returns an empty array on a malformed response shape', async () => {
+    server.use(http.post(endpoint, () => HttpResponse.json({ data: {} })))
+    await expect(getGitHubActionsStatus()).resolves.toEqual([])
+  })
+
+  it('returns an empty array on an API error', async () => {
+    server.use(http.post(endpoint, () => HttpResponse.error()))
+    await expect(getGitHubActionsStatus()).resolves.toEqual([])
+  })
+})

--- a/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
@@ -1,11 +1,23 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
 import { getGitHubActionsStatus } from './gha-status.tsx'
 
 const endpoint = 'https://api.github.com/graphql'
 
-function run(id: string, status: string, conclusion: string | null = 'SUCCESS') {
+function run(
+  id: string,
+  status: string,
+  conclusion: string | null = 'SUCCESS'
+) {
   return {
     id,
     url: `https://github.com/47ng/nuqs/actions/runs/${id}`,
@@ -23,7 +35,10 @@ function respondWith(nodes: unknown[]) {
 describe('getGitHubActionsStatus', () => {
   const server = setupServer()
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-  afterEach(() => server.resetHandlers())
+  afterEach(() => {
+    server.resetHandlers()
+    vi.restoreAllMocks()
+  })
   afterAll(() => server.close())
 
   it('keeps the last 5 completed runs, ordered oldest to newest', async () => {
@@ -46,18 +61,33 @@ describe('getGitHubActionsStatus', () => {
     expect(statuses.every(s => s.checkSuite.status === 'COMPLETED')).toBe(true)
   })
 
-  it('returns an empty array when there are no completed runs', async () => {
+  it('returns an empty array when no run survives the completed filter', async () => {
     server.use(respondWith([run('n1', 'IN_PROGRESS', null)]))
     await expect(getGitHubActionsStatus()).resolves.toEqual([])
   })
 
-  it('returns an empty array on a malformed response shape', async () => {
-    server.use(http.post(endpoint, () => HttpResponse.json({ data: {} })))
+  it('returns [] and logs when nodes is present but not an array (zod guard)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json({ data: { node: { runs: { nodes: 'oops' } } } })
+      )
+    )
     await expect(getGitHubActionsStatus()).resolves.toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
   })
 
-  it('returns an empty array on an API error', async () => {
+  it('returns [] and logs when the response shape is broken (deref throws)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    server.use(http.post(endpoint, () => HttpResponse.json({ data: {} })))
+    await expect(getGitHubActionsStatus()).resolves.toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
+  })
+
+  it('returns [] and logs on an API/network error', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     server.use(http.post(endpoint, () => HttpResponse.error()))
     await expect(getGitHubActionsStatus()).resolves.toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
   })
 })

--- a/packages/docs/src/app/(pages)/_landing/gha-status.tsx
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.tsx
@@ -61,7 +61,7 @@ const ghaStatusSchema = z.object({
   })
 })
 
-async function getGitHubActionsStatus() {
+export async function getGitHubActionsStatus() {
   // Fetch a few more than needed to filter out non-completed runs
   const query = `query {
     node(id: "W_kwDOD6wJuM4EeKz5") {

--- a/packages/docs/src/app/(pages)/stats/lib/github.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.test.ts
@@ -96,6 +96,25 @@ describe('getStarHistory', () => {
     })
   })
 
+  it('includes the oldest in-window day and excludes the day before it', async () => {
+    // Window is [today .. today-11] = [06-15 .. 06-04]; 06-04 is bins[11], 06-03 is out.
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json(
+          page([
+            edge('boundary', '2024-06-04T10:00:00Z'),
+            edge('excluded', '2024-06-03T23:00:00Z')
+          ])
+        )
+      )
+    )
+    const history = await getStarHistory()
+    expect(history.bins[11].date).toBe('2024-06-04')
+    expect(history.bins[11].stargarzers.map(s => s.login)).toEqual(['boundary'])
+    const allLogins = history.bins.flatMap(b => b.stargarzers.map(s => s.login))
+    expect(allLogins).not.toContain('excluded')
+  })
+
   it('follows the cursor across pages until the window is exhausted', async () => {
     server.use(
       http.post(endpoint, async ({ request }) => {

--- a/packages/docs/src/app/(pages)/stats/lib/github.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.test.ts
@@ -1,0 +1,171 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { getStarHistory } from './github.ts'
+
+const endpoint = 'https://api.github.com/graphql'
+
+function edge(login: string, starredAt: string) {
+  return {
+    starredAt,
+    node: {
+      login,
+      name: null,
+      avatarUrl: `https://avatars.githubusercontent.com/${login}`,
+      company: null,
+      followers: { totalCount: 0 }
+    }
+  }
+}
+
+function page(
+  edges: ReturnType<typeof edge>[],
+  {
+    totalCount = 100,
+    hasNextPage = false,
+    endCursor = null as string | null
+  } = {}
+) {
+  return {
+    data: {
+      repository: {
+        stargazers: {
+          totalCount,
+          pageInfo: { hasNextPage, endCursor },
+          edges
+        }
+      }
+    }
+  }
+}
+
+const server = setupServer()
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+// Pin "today" to a fixed UTC day so the 12-day window is deterministic.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
+})
+afterEach(() => vi.useRealTimers())
+
+describe('getStarHistory', () => {
+  it('fills the 12-day bins and computes end-of-day star totals', async () => {
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json(
+          page(
+            [
+              edge('a', '2024-06-15T10:00:00Z'),
+              edge('b', '2024-06-15T11:00:00Z'),
+              edge('c', '2024-06-14T09:00:00Z')
+            ],
+            { totalCount: 100 }
+          )
+        )
+      )
+    )
+    const history = await getStarHistory()
+    expect(history.count).toBe(100)
+    expect(history.bins).toHaveLength(12)
+    expect(history.bins[0]).toMatchObject({
+      date: '2024-06-15',
+      diff: 2,
+      stars: 100
+    })
+    expect(history.bins[0].stargarzers.map(s => s.login)).toEqual(['a', 'b'])
+    // 06-14 earned 1 star; end-of-day total is the prior day minus its diff.
+    expect(history.bins[1]).toMatchObject({
+      date: '2024-06-14',
+      diff: 1,
+      stars: 98
+    })
+  })
+
+  it('follows the cursor across pages until the window is exhausted', async () => {
+    server.use(
+      http.post(endpoint, async ({ request }) => {
+        const { query } = (await request.json()) as { query: string }
+        if (query.includes('"c1"')) {
+          return HttpResponse.json(
+            page([
+              edge('p2a', '2024-06-13T10:00:00Z'),
+              edge('old', '2024-06-01T10:00:00Z') // before the window
+            ])
+          )
+        }
+        return HttpResponse.json(
+          page(
+            [
+              edge('p1a', '2024-06-15T10:00:00Z'),
+              edge('p1b', '2024-06-14T10:00:00Z')
+            ],
+            { hasNextPage: true, endCursor: 'c1' }
+          )
+        )
+      })
+    )
+    const history = await getStarHistory()
+    // p2a only appears if the second page was fetched via the cursor.
+    expect(history.bins[0].stargarzers.map(s => s.login)).toEqual(['p1a'])
+    expect(history.bins[1].stargarzers.map(s => s.login)).toEqual(['p1b'])
+    expect(history.bins[2].stargarzers.map(s => s.login)).toEqual(['p2a'])
+  })
+
+  it('terminates on an empty page', async () => {
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json(
+          page([], { totalCount: 50, hasNextPage: true, endCursor: 'c1' })
+        )
+      )
+    )
+    const history = await getStarHistory()
+    expect(history.count).toBe(50)
+    expect(history.bins).toHaveLength(12)
+    expect(history.bins.every(b => b.diff === 0)).toBe(true)
+    expect(history.bins[0].stars).toBe(50)
+  })
+
+  it('returns empty bins with the total count when nothing was starred in the window', async () => {
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json(
+          page([edge('old', '2024-05-01T10:00:00Z')], { totalCount: 200 })
+        )
+      )
+    )
+    const history = await getStarHistory()
+    expect(history.count).toBe(200)
+    expect(history.bins[0]).toMatchObject({ stars: 200, diff: 0 })
+    expect(history.bins.every(b => b.stargarzers.length === 0)).toBe(true)
+  })
+
+  it('throws on a malformed GraphQL response', async () => {
+    server.use(http.post(endpoint, () => HttpResponse.json({ data: {} })))
+    await expect(getStarHistory()).rejects.toThrow()
+  })
+
+  it('throws on a non-ok API response', async () => {
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json({}, { status: 500, statusText: 'Server Error' })
+      )
+    )
+    await expect(getStarHistory()).rejects.toThrow(/GitHub API error: 500/)
+  })
+})

--- a/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
@@ -1,0 +1,222 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import {
+  combineStats,
+  fetchNpmPackage,
+  getAllTime,
+  getLastNDays,
+  getPackageCreationDate,
+  interpolateZeroDays,
+  type Datum,
+  type NpmPackageStatsData
+} from './npm.ts'
+
+const rangeEndpoint = 'https://api.npmjs.org/downloads/range/:range/:pkg'
+const registryEndpoint = 'https://registry.npmjs.org/:pkg'
+
+const server = setupServer()
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+// Fake only Date so the date-derived request URLs and loop bounds are
+// deterministic, while leaving real timers for the fetch/MSW plumbing.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
+})
+afterEach(() => vi.useRealTimers())
+
+describe('interpolateZeroDays', () => {
+  function datum(downloads: number, i: number): Datum {
+    return { date: `2024-06-${String(i + 1).padStart(2, '0')}`, downloads }
+  }
+
+  it('estimates a zero day by averaging the backward and forward week trends', () => {
+    // i=8: base=D-7=idx1=100, backward=(idx7-idx0)/idx0=0.2, forward=(idx9-idx2)/idx2=0.4
+    const data = [100, 100, 100, 100, 100, 100, 100, 120, 0, 140].map(datum)
+    const result = interpolateZeroDays(data)
+    expect(result[8]).toMatchObject({ downloads: 130, estimated: true })
+  })
+
+  it('falls back to the D-7 baseline when no trend is available', () => {
+    // i=7: base=idx0=100, backward null (i-8<0), forward null (i+1 out of range)
+    const data = [100, 50, 50, 50, 50, 50, 50, 0].map(datum)
+    const result = interpolateZeroDays(data)
+    expect(result[7]).toMatchObject({ downloads: 100, estimated: true })
+  })
+
+  it('leaves a zero day untouched when it is in the first week', () => {
+    const data = [100, 100, 0, 100, 100].map(datum)
+    const result = interpolateZeroDays(data)
+    expect(result[2]).toEqual({ date: data[2].date, downloads: 0 })
+  })
+
+  it('leaves a zero day untouched when its D-7 baseline is also zero', () => {
+    const data = [0, 100, 100, 100, 100, 100, 100, 0].map(datum)
+    const result = interpolateZeroDays(data)
+    expect(result[7]).toEqual({ date: data[7].date, downloads: 0 })
+  })
+})
+
+describe('getLastNDays', () => {
+  it('maps the range response to dated download counts', async () => {
+    server.use(
+      http.get(rangeEndpoint, () =>
+        HttpResponse.json({
+          downloads: [
+            { downloads: 10, day: '2024-06-01' },
+            { downloads: 20, day: '2024-06-02' }
+          ]
+        })
+      )
+    )
+    await expect(getLastNDays('nuqs', 30)).resolves.toEqual([
+      { date: '2024-06-01', downloads: 10 },
+      { date: '2024-06-02', downloads: 20 }
+    ])
+  })
+
+  it('drops a trailing zero-download day (stats not in yet)', async () => {
+    server.use(
+      http.get(rangeEndpoint, () =>
+        HttpResponse.json({
+          downloads: [
+            { downloads: 20, day: '2024-06-01' },
+            { downloads: 0, day: '2024-06-02' }
+          ]
+        })
+      )
+    )
+    const data = await getLastNDays('nuqs', 30)
+    expect(data).toEqual([{ date: '2024-06-01', downloads: 20 }])
+  })
+
+  it('returns an empty array on a malformed response', async () => {
+    server.use(
+      http.get(rangeEndpoint, () => HttpResponse.json({ nope: true }))
+    )
+    await expect(getLastNDays('nuqs', 30)).resolves.toEqual([])
+  })
+})
+
+describe('getPackageCreationDate', () => {
+  it('parses time.created from the registry', async () => {
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2020-06-01T00:00:00Z' } })
+      )
+    )
+    const date = await getPackageCreationDate('nuqs')
+    expect(date.format('YYYY-MM-DD')).toBe('2020-06-01')
+  })
+
+  it('clamps a pre-epoch creation date to the npm stats epoch', async () => {
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2010-01-01T00:00:00Z' } })
+      )
+    )
+    const date = await getPackageCreationDate('nuqs')
+    expect(date.format('YYYY-MM-DD')).toBe('2015-01-10')
+  })
+
+  it('falls back to the npm stats epoch on a malformed response', async () => {
+    server.use(http.get(registryEndpoint, () => HttpResponse.json({})))
+    const date = await getPackageCreationDate('nuqs')
+    expect(date.format('YYYY-MM-DD')).toBe('2015-01-10')
+  })
+})
+
+describe('getAllTime', () => {
+  it('sums downloads across each 18-month window up to today', async () => {
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2020-01-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, () =>
+        HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      )
+    )
+    // 2020-01 → 2021-07 → 2023-01 → 2024-07 spans three windows before today.
+    await expect(getAllTime('nuqs')).resolves.toBe(36)
+  })
+
+  it('stops and returns the partial sum if a window request fails', async () => {
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2023-01-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, () => HttpResponse.json({ broken: true }))
+    )
+    await expect(getAllTime('nuqs')).resolves.toBe(0)
+  })
+})
+
+describe('fetchNpmPackage', () => {
+  it('combines all-time, last-30-day and weekly-grouped last-90-day stats', async () => {
+    const days = Array.from({ length: 14 }, (_, i) => ({
+      downloads: 100,
+      day: `2024-06-${String(i + 1).padStart(2, '0')}`
+    }))
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, () => HttpResponse.json({ downloads: days }))
+    )
+    const stats = await fetchNpmPackage('nuqs')
+    // One 18-month window from a June-2024 creation date: 14 × 100.
+    expect(stats.allTime).toBe(1400)
+    expect(stats.last30Days).toHaveLength(14)
+    // last90Days is grouped by ISO week, so fewer entries keyed as 'YYWww.
+    expect(stats.last90Days.length).toBeLessThan(14)
+    expect(stats.last90Days.every(d => /^'\d{2}W\d{2}$/.test(d.date))).toBe(true)
+  })
+})
+
+describe('combineStats', () => {
+  function stats(
+    allTime: number,
+    last30: Datum[],
+    last90: Datum[]
+  ): NpmPackageStatsData {
+    return { allTime, last30Days: last30, last90Days: last90 }
+  }
+
+  it('sums all-time and merges both packages per day', () => {
+    const combined = combineStats(
+      stats(
+        100,
+        [{ date: 'd1', downloads: 10, estimated: true }],
+        [{ date: 'w1', downloads: 70 }]
+      ),
+      stats(50, [{ date: 'd1', downloads: 5 }], [{ date: 'w1', downloads: 35 }])
+    )
+    expect(combined.allTime).toBe(150)
+    expect(combined.last30Days[0]).toEqual({
+      date: 'd1',
+      nuqs: 10,
+      'next-usequerystate': 5,
+      estimated: true
+    })
+    expect(combined.last90Days[0]).toEqual({
+      date: 'w1',
+      nuqs: 70,
+      'next-usequerystate': 35
+    })
+  })
+})

--- a/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
@@ -38,7 +38,10 @@ beforeEach(() => {
   vi.useFakeTimers({ toFake: ['Date'] })
   vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
 })
-afterEach(() => vi.useRealTimers())
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 describe('interpolateZeroDays', () => {
   function datum(downloads: number, i: number): Datum {
@@ -50,6 +53,20 @@ describe('interpolateZeroDays', () => {
     const data = [100, 100, 100, 100, 100, 100, 100, 120, 0, 140].map(datum)
     const result = interpolateZeroDays(data)
     expect(result[8]).toMatchObject({ downloads: 130, estimated: true })
+  })
+
+  it('uses the backward trend alone when the forward week is unavailable', () => {
+    // i=9 (last): forward null (no D+1), backward=(idx8-idx1)/idx1=0.3, base=idx2=100
+    const data = [100, 100, 100, 100, 100, 100, 100, 100, 130, 0].map(datum)
+    const result = interpolateZeroDays(data)
+    expect(result[9]).toMatchObject({ downloads: 130, estimated: true })
+  })
+
+  it('uses the forward trend alone when the backward week is unavailable', () => {
+    // i=7: backward null (i-8<0), forward=(idx8-idx1)/idx1=0.4, base=idx0=100
+    const data = [100, 100, 100, 100, 100, 100, 100, 0, 140].map(datum)
+    const result = interpolateZeroDays(data)
+    expect(result[7]).toMatchObject({ downloads: 140, estimated: true })
   })
 
   it('falls back to the D-7 baseline when no trend is available', () => {
@@ -105,11 +122,11 @@ describe('getLastNDays', () => {
     expect(data).toEqual([{ date: '2024-06-01', downloads: 20 }])
   })
 
-  it('returns an empty array on a malformed response', async () => {
-    server.use(
-      http.get(rangeEndpoint, () => HttpResponse.json({ nope: true }))
-    )
+  it('returns an empty array and logs on a malformed response', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    server.use(http.get(rangeEndpoint, () => HttpResponse.json({ nope: true })))
     await expect(getLastNDays('nuqs', 30)).resolves.toEqual([])
+    expect(errorSpy).toHaveBeenCalled()
   })
 })
 
@@ -121,7 +138,9 @@ describe('getPackageCreationDate', () => {
       )
     )
     const date = await getPackageCreationDate('nuqs')
-    expect(date.format('YYYY-MM-DD')).toBe('2020-06-01')
+    // npm.ts does not extend dayjs/utc, so .format() renders in local time —
+    // assert on the instant to stay timezone-independent across CI/contributors.
+    expect(date.valueOf()).toBe(new Date('2020-06-01T00:00:00Z').valueOf())
   })
 
   it('clamps a pre-epoch creation date to the npm stats epoch', async () => {
@@ -134,10 +153,12 @@ describe('getPackageCreationDate', () => {
     expect(date.format('YYYY-MM-DD')).toBe('2015-01-10')
   })
 
-  it('falls back to the npm stats epoch on a malformed response', async () => {
+  it('falls back to the npm stats epoch and logs on a malformed response', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     server.use(http.get(registryEndpoint, () => HttpResponse.json({})))
     const date = await getPackageCreationDate('nuqs')
     expect(date.format('YYYY-MM-DD')).toBe('2015-01-10')
+    expect(errorSpy).toHaveBeenCalled()
   })
 })
 
@@ -155,14 +176,24 @@ describe('getAllTime', () => {
     await expect(getAllTime('nuqs')).resolves.toBe(36)
   })
 
-  it('stops and returns the partial sum if a window request fails', async () => {
+  it('keeps the accumulated partial sum when a later window request fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    let rangeCalls = 0
     server.use(
       http.get(registryEndpoint, () =>
-        HttpResponse.json({ time: { created: '2023-01-01T00:00:00Z' } })
+        HttpResponse.json({ time: { created: '2020-01-01T00:00:00Z' } })
       ),
-      http.get(rangeEndpoint, () => HttpResponse.json({ broken: true }))
+      http.get(rangeEndpoint, () => {
+        rangeCalls++
+        // First two 18-month windows succeed (12 each); the third is broken.
+        return rangeCalls <= 2
+          ? HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+          : HttpResponse.json({ broken: true })
+      })
     )
-    await expect(getAllTime('nuqs')).resolves.toBe(0)
+    // Break must preserve the 24 already accumulated, not reset to 0.
+    await expect(getAllTime('nuqs')).resolves.toBe(24)
+    expect(errorSpy).toHaveBeenCalled()
   })
 })
 
@@ -184,7 +215,9 @@ describe('fetchNpmPackage', () => {
     expect(stats.last30Days).toHaveLength(14)
     // last90Days is grouped by ISO week, so fewer entries keyed as 'YYWww.
     expect(stats.last90Days.length).toBeLessThan(14)
-    expect(stats.last90Days.every(d => /^'\d{2}W\d{2}$/.test(d.date))).toBe(true)
+    expect(stats.last90Days.every(d => /^'\d{2}W\d{2}$/.test(d.date))).toBe(
+      true
+    )
   })
 })
 

--- a/packages/docs/src/app/(pages)/stats/lib/npm.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.ts
@@ -44,7 +44,7 @@ const rangeResponseSchema = z.object({
   )
 })
 
-async function getLastNDays(pkg: string, n: number): Promise<Datum[]> {
+export async function getLastNDays(pkg: string, n: number): Promise<Datum[]> {
   const start = dayjs().subtract(n, 'day').format('YYYY-MM-DD')
   const end = dayjs().subtract(1, 'day').endOf('day').format('YYYY-MM-DD')
   const url = `https://api.npmjs.org/downloads/range/${start}:${end}/${pkg}`
@@ -71,7 +71,7 @@ async function getLastNDays(pkg: string, n: number): Promise<Datum[]> {
  * Interpolate zero-download days using weekly rhythm-aware estimation.
  * Processes left-to-right so earlier interpolated values can feed later ones.
  */
-function interpolateZeroDays(data: Datum[]): Datum[] {
+export function interpolateZeroDays(data: Datum[]): Datum[] {
   for (let i = 0; i < data.length; i++) {
     if (data[i].downloads !== 0) continue
 
@@ -133,7 +133,9 @@ const packageResponseSchema = z.object({
   })
 })
 
-async function getPackageCreationDate(pkg: string): Promise<dayjs.Dayjs> {
+export async function getPackageCreationDate(
+  pkg: string
+): Promise<dayjs.Dayjs> {
   const npmStatsEpoch = dayjs('2015-01-10')
   const url = `https://registry.npmjs.org/${pkg}`
   try {
@@ -149,7 +151,7 @@ async function getPackageCreationDate(pkg: string): Promise<dayjs.Dayjs> {
   }
 }
 
-async function getAllTime(pkg: string): Promise<number> {
+export async function getAllTime(pkg: string): Promise<number> {
   let downloads: number = 0
   let start = dayjs(await getPackageCreationDate(pkg))
   let end = start.add(18, 'month')

--- a/packages/docs/src/app/docs/changelog/_lib.test.ts
+++ b/packages/docs/src/app/docs/changelog/_lib.test.ts
@@ -1,5 +1,23 @@
-import { describe, expect, it } from 'vitest'
-import { bumpHeadings } from './_lib.ts'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { bumpHeadings, fetchReleases } from './_lib.ts'
+
+const releasesEndpoint = 'https://api.github.com/repos/47ng/nuqs/releases'
+
+function release(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    tag_name: 'v2.0.0',
+    name: 'nuqs@2.0.0',
+    html_url: 'https://github.com/47ng/nuqs/releases/tag/v2.0.0',
+    published_at: '2024-01-01T00:00:00Z',
+    body: 'Release notes',
+    draft: false,
+    prerelease: false,
+    ...overrides
+  }
+}
 
 describe('bumpHeadings', () => {
   it('bumps every ATX heading one level deeper', () => {
@@ -41,5 +59,57 @@ describe('bumpHeadings', () => {
     expect(bumpHeadings(body)).toBe(
       ['## Heading', '~~~', '# not a heading', '~~~', '### After'].join('\n')
     )
+  })
+})
+
+describe('fetchReleases', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('returns GA releases, filtering out drafts and prereleases', async () => {
+    server.use(
+      http.get(releasesEndpoint, () =>
+        HttpResponse.json([
+          release({ id: 1, tag_name: 'v2.0.0' }),
+          release({ id: 2, tag_name: 'v2.1.0-beta.1', prerelease: true }),
+          release({ id: 3, tag_name: 'v2.1.0-draft', draft: true }),
+          release({ id: 4, tag_name: 'v2.1.0' })
+        ])
+      )
+    )
+    const releases = await fetchReleases()
+    expect(releases.map(r => r.tag_name)).toEqual(['v2.0.0', 'v2.1.0'])
+  })
+
+  it('treats missing draft/prerelease flags as GA releases', async () => {
+    server.use(
+      http.get(releasesEndpoint, () =>
+        HttpResponse.json([
+          { ...release({ id: 5, tag_name: 'v1.0.0' }), draft: undefined, prerelease: undefined }
+        ])
+      )
+    )
+    const releases = await fetchReleases()
+    expect(releases).toHaveLength(1)
+  })
+
+  it('throws on a non-ok response rather than caching an empty changelog', async () => {
+    server.use(
+      http.get(releasesEndpoint, () =>
+        HttpResponse.json({}, { status: 502, statusText: 'Bad Gateway' })
+      )
+    )
+    await expect(fetchReleases()).rejects.toThrow(/502 Bad Gateway/)
+  })
+
+  it('throws when the response body fails schema validation', async () => {
+    server.use(
+      http.get(releasesEndpoint, () =>
+        HttpResponse.json([{ tag_name: 'v2.0.0' }]) // missing required fields
+      )
+    )
+    await expect(fetchReleases()).rejects.toThrow()
   })
 })

--- a/packages/docs/src/app/docs/changelog/_lib.test.ts
+++ b/packages/docs/src/app/docs/changelog/_lib.test.ts
@@ -1,22 +1,27 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { bumpHeadings, fetchReleases } from './_lib.ts'
+import { bumpHeadings, fetchReleases, getChangelogMarkdown } from './_lib.ts'
 
 const releasesEndpoint = 'https://api.github.com/repos/47ng/nuqs/releases'
 
-function release(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 1,
-    tag_name: 'v2.0.0',
-    name: 'nuqs@2.0.0',
-    html_url: 'https://github.com/47ng/nuqs/releases/tag/v2.0.0',
-    published_at: '2024-01-01T00:00:00Z',
-    body: 'Release notes',
-    draft: false,
-    prerelease: false,
-    ...overrides
-  }
+const releaseDefaults = {
+  id: 1,
+  tag_name: 'v2.0.0',
+  name: 'nuqs@2.0.0',
+  html_url: 'https://github.com/47ng/nuqs/releases/tag/v2.0.0',
+  published_at: '2024-01-01T00:00:00Z',
+  body: 'Release notes',
+  draft: false,
+  prerelease: false
+}
+
+// Keys are constrained to the fixture shape so a typo'd override (e.g. `tagname`)
+// is a compile error rather than a silently-ignored, false-green test.
+function release(
+  overrides: Partial<Record<keyof typeof releaseDefaults, unknown>> = {}
+) {
+  return { ...releaseDefaults, ...overrides }
 }
 
 describe('bumpHeadings', () => {
@@ -72,10 +77,10 @@ describe('fetchReleases', () => {
     server.use(
       http.get(releasesEndpoint, () =>
         HttpResponse.json([
-          release({ id: 1, tag_name: 'v2.0.0' }),
-          release({ id: 2, tag_name: 'v2.1.0-beta.1', prerelease: true }),
-          release({ id: 3, tag_name: 'v2.1.0-draft', draft: true }),
-          release({ id: 4, tag_name: 'v2.1.0' })
+          release(), // v2.0.0 GA default
+          release({ tag_name: 'v2.1.0-beta.1', prerelease: true }),
+          release({ tag_name: 'v2.1.0-draft', draft: true }),
+          release({ tag_name: 'v2.1.0' })
         ])
       )
     )
@@ -87,7 +92,7 @@ describe('fetchReleases', () => {
     server.use(
       http.get(releasesEndpoint, () =>
         HttpResponse.json([
-          { ...release({ id: 5, tag_name: 'v1.0.0' }), draft: undefined, prerelease: undefined }
+          { ...release(), draft: undefined, prerelease: undefined }
         ])
       )
     )
@@ -106,10 +111,44 @@ describe('fetchReleases', () => {
 
   it('throws when the response body fails schema validation', async () => {
     server.use(
-      http.get(releasesEndpoint, () =>
-        HttpResponse.json([{ tag_name: 'v2.0.0' }]) // missing required fields
+      http.get(
+        releasesEndpoint,
+        () => HttpResponse.json([{ tag_name: 'v2.0.0' }]) // missing required fields
       )
     )
     await expect(fetchReleases()).rejects.toThrow()
+  })
+})
+
+describe('getChangelogMarkdown', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('renders a section per non-empty release, bumping headings and stripping the DTO', async () => {
+    server.use(
+      http.get(releasesEndpoint, () =>
+        HttpResponse.json([
+          release({
+            tag_name: 'v2.0.0',
+            name: 'nuqs@2.0.0',
+            body: '## Features\n\n- A thing<!--\n<changelog:dto>{"x":1}</changelog:dto>\n-->'
+          }),
+          release({ tag_name: 'v1.9.0', name: null, body: 'Plain notes' }),
+          release({ tag_name: 'v1.8.0', body: '   ' }) // whitespace-only → dropped
+        ])
+      )
+    )
+    const md = await getChangelogMarkdown()
+    expect(md.startsWith('# Changelog')).toBe(true)
+    expect(md).toContain('## nuqs@2.0.0') // explicit name
+    expect(md).toContain('## v1.9.0') // falls back to tag_name when name is null
+    expect(md).toContain('### Features') // headings bumped one level deeper
+    expect(md).not.toContain('changelog:dto') // machine DTO comment stripped
+    expect(md).toMatch(/Published on \d{4}-\d{2}-\d{2}/)
+    expect(md).toContain('[View on GitHub]')
+    expect(md).toContain('\n---\n') // section separator between the two kept releases
+    expect(md).not.toContain('v1.8.0') // whitespace-only body filtered out
   })
 })

--- a/packages/docs/src/components/release-contribution-graph.client.tsx
+++ b/packages/docs/src/components/release-contribution-graph.client.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/src/components/ui/tooltip'
 import { cn } from '@/src/lib/utils'
 import { useState } from 'react'
-import type { ReleasesByDate } from './release-contribution-graph'
+import type { ReleasesByDate } from './release-contribution-graph.lib'
 
 type ReleaseContributionGraphClientProps = {
   activities: Activity[]

--- a/packages/docs/src/components/release-contribution-graph.lib.test.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.test.ts
@@ -36,6 +36,21 @@ describe('processReleases', () => {
     expect(releasesByDate['2024-03-15']).toEqual(['v2.0.0', 'v2.0.1'])
   })
 
+  it('marks a day with both a stable and a beta release as stable (level 2)', () => {
+    const { activities, releasesByDate } = processReleases(
+      [
+        { tag_name: 'v2.0.0', published_at: '2024-05-01T10:00:00Z' },
+        { tag_name: 'v2.1.0-beta.1', published_at: '2024-05-01T12:00:00Z' }
+      ],
+      2024
+    )
+    expect(activities.find(a => a.date === '2024-05-01')).toMatchObject({
+      count: 1,
+      level: 2
+    })
+    expect(releasesByDate['2024-05-01']).toEqual(['v2.0.0', 'v2.1.0-beta.1'])
+  })
+
   it('marks beta-only release days at level 1', () => {
     const { activities, releasesByDate } = processReleases(releases, 2024)
     const betaDay = activities.find(a => a.date === '2024-04-01')
@@ -67,9 +82,7 @@ describe('fetchGitHubReleases', () => {
 
   it('returns the releases from a single short page', async () => {
     server.use(
-      http.get(endpoint, () =>
-        HttpResponse.json([release(1), release(2)])
-      )
+      http.get(endpoint, () => HttpResponse.json([release(1), release(2)]))
     )
     const releases = await fetchGitHubReleases()
     expect(releases.map(r => r.tag_name)).toEqual(['v1', 'v2'])
@@ -101,9 +114,7 @@ describe('fetchGitHubReleases', () => {
   })
 
   it('throws on a non-ok response', async () => {
-    server.use(
-      http.get(endpoint, () => HttpResponse.json({}, { status: 500 }))
-    )
+    server.use(http.get(endpoint, () => HttpResponse.json({}, { status: 500 })))
     await expect(fetchGitHubReleases()).rejects.toThrow(/GitHub API error: 500/)
   })
 

--- a/packages/docs/src/components/release-contribution-graph.lib.test.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.test.ts
@@ -1,0 +1,116 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  fetchGitHubReleases,
+  isBetaVersion,
+  processReleases
+} from './release-contribution-graph.lib.ts'
+
+const endpoint = 'https://api.github.com/repos/47ng/nuqs/releases'
+
+describe('isBetaVersion', () => {
+  it('flags beta, alpha and rc tags', () => {
+    expect(isBetaVersion('v2.0.0-beta.1')).toBe(true)
+    expect(isBetaVersion('v2.0.0-alpha.3')).toBe(true)
+    expect(isBetaVersion('v2.0.0-rc.2')).toBe(true)
+  })
+
+  it('does not flag a stable tag', () => {
+    expect(isBetaVersion('v2.0.0')).toBe(false)
+  })
+})
+
+describe('processReleases', () => {
+  const releases = [
+    { tag_name: 'v2.0.0', published_at: '2024-03-15T10:00:00Z' },
+    { tag_name: 'v2.0.1', published_at: '2024-03-15T12:00:00Z' },
+    { tag_name: 'v2.1.0-beta.1', published_at: '2024-04-01T10:00:00Z' },
+    { tag_name: 'v1.0.0', published_at: '2023-12-31T10:00:00Z' }
+  ]
+
+  it('marks stable release days at level 2 and groups same-day versions', () => {
+    const { activities, releasesByDate } = processReleases(releases, 2024)
+    const stableDay = activities.find(a => a.date === '2024-03-15')
+    expect(stableDay).toMatchObject({ count: 1, level: 2 })
+    expect(releasesByDate['2024-03-15']).toEqual(['v2.0.0', 'v2.0.1'])
+  })
+
+  it('marks beta-only release days at level 1', () => {
+    const { activities, releasesByDate } = processReleases(releases, 2024)
+    const betaDay = activities.find(a => a.date === '2024-04-01')
+    expect(betaDay).toMatchObject({ count: 1, level: 1 })
+    expect(releasesByDate['2024-04-01']).toEqual(['v2.1.0-beta.1'])
+  })
+
+  it('leaves non-release days idle and excludes other years', () => {
+    const { activities, releasesByDate } = processReleases(releases, 2024)
+    expect(activities.find(a => a.date === '2024-06-01')).toMatchObject({
+      count: 0,
+      level: 0
+    })
+    expect(releasesByDate['2023-12-31']).toBeUndefined()
+    // 2024 is a leap year: 366 daily activities.
+    expect(activities).toHaveLength(366)
+  })
+})
+
+describe('fetchGitHubReleases', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  function release(i: number) {
+    return { tag_name: `v${i}`, published_at: '2024-01-01T00:00:00Z' }
+  }
+
+  it('returns the releases from a single short page', async () => {
+    server.use(
+      http.get(endpoint, () =>
+        HttpResponse.json([release(1), release(2)])
+      )
+    )
+    const releases = await fetchGitHubReleases()
+    expect(releases.map(r => r.tag_name)).toEqual(['v1', 'v2'])
+  })
+
+  it('concatenates across pages until a short page', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => release(i))
+    server.use(
+      http.get(endpoint, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page')
+        return HttpResponse.json(page === '1' ? fullPage : [release(999)])
+      })
+    )
+    const releases = await fetchGitHubReleases()
+    expect(releases).toHaveLength(101)
+    expect(releases.at(-1)?.tag_name).toBe('v999')
+  })
+
+  it('stops paginating on an empty page', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => release(i))
+    server.use(
+      http.get(endpoint, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page')
+        return HttpResponse.json(page === '1' ? fullPage : [])
+      })
+    )
+    const releases = await fetchGitHubReleases()
+    expect(releases).toHaveLength(100)
+  })
+
+  it('throws on a non-ok response', async () => {
+    server.use(
+      http.get(endpoint, () => HttpResponse.json({}, { status: 500 }))
+    )
+    await expect(fetchGitHubReleases()).rejects.toThrow(/GitHub API error: 500/)
+  })
+
+  it('throws when the response fails schema validation', async () => {
+    server.use(
+      http.get(endpoint, () => HttpResponse.json([{ tag_name: 'v1' }]))
+    )
+    await expect(fetchGitHubReleases()).rejects.toThrow()
+  })
+})

--- a/packages/docs/src/components/release-contribution-graph.lib.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 
-// Structurally mirrors the kibo-ui `Activity` shape consumed by the graph
-// client. Declared locally so this (test-covered) data module stays free of the
-// client-only component subtree.
+// Structurally mirrors the kibo-ui `Activity` consumed by the graph client.
+// Kept local so this data module has no import edge into the `'use client'`
+// component subtree (which also keeps it, and its test, out of that subtree in
+// the module graph). A compile-time guard in `release-contribution-graph.tsx`
+// pins this shape to the kibo-ui one so the two cannot drift.
 type Activity = {
   date: string
   count: number

--- a/packages/docs/src/components/release-contribution-graph.lib.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod'
+
+// Structurally mirrors the kibo-ui `Activity` shape consumed by the graph
+// client. Declared locally so this (test-covered) data module stays free of the
+// client-only component subtree.
+type Activity = {
+  date: string
+  count: number
+  level: number
+}
+
+const gitHubReleaseSchema = z.object({
+  tag_name: z.string(),
+  published_at: z.string()
+})
+
+const gitHubReleasesSchema = z.array(gitHubReleaseSchema)
+
+export type GitHubRelease = z.infer<typeof gitHubReleaseSchema>
+
+export async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
+  const releases: GitHubRelease[] = []
+  let page = 1
+  const perPage = 100
+
+  while (true) {
+    const response = await fetch(
+      `https://api.github.com/repos/47ng/nuqs/releases?per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: 'application/vnd.github.v3+json'
+        },
+        next: { revalidate: 3600 } // Cache for 1 hour
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status}`)
+    }
+
+    const json = await response.json()
+    const data = gitHubReleasesSchema.parse(json)
+
+    if (data.length === 0) {
+      break
+    }
+
+    releases.push(...data)
+
+    if (data.length < perPage) {
+      break
+    }
+
+    page++
+  }
+
+  return releases
+}
+
+export function isBetaVersion(tag: string): boolean {
+  return tag.includes('beta') || tag.includes('alpha') || tag.includes('rc')
+}
+
+type ReleaseDay = {
+  date: string
+  hasStable: boolean
+  hasBeta: boolean
+  versions: string[]
+}
+
+export type ReleasesByDate = Record<string, string[]>
+
+type ProcessedReleases = {
+  activities: Activity[]
+  releasesByDate: ReleasesByDate
+}
+
+export function processReleases(
+  releases: GitHubRelease[],
+  year: number
+): ProcessedReleases {
+  const yearPrefix = `${year}-`
+
+  // Filter to specified year releases only
+  const yearReleases = releases.filter(r =>
+    r.published_at.startsWith(yearPrefix)
+  )
+
+  // Group releases by date
+  const releaseDayMap = new Map<string, ReleaseDay>()
+
+  for (const release of yearReleases) {
+    const date = release.published_at.split('T')[0]
+    const isBeta = isBetaVersion(release.tag_name)
+
+    const existing = releaseDayMap.get(date)
+    if (existing) {
+      if (isBeta) {
+        existing.hasBeta = true
+      } else {
+        existing.hasStable = true
+      }
+      existing.versions.push(release.tag_name)
+    } else {
+      releaseDayMap.set(date, {
+        date,
+        hasStable: !isBeta,
+        hasBeta: isBeta,
+        versions: [release.tag_name]
+      })
+    }
+  }
+
+  // Generate all days of the year
+  const startDate = new Date(`${year}-01-01`)
+  const endDate = new Date(`${year}-12-31`)
+  const activities: Activity[] = []
+
+  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+    const dateStr = d.toISOString().split('T')[0]
+    const releaseDay = releaseDayMap.get(dateStr)
+
+    let level = 0
+    if (releaseDay?.hasStable) {
+      level = 2 // Green for stable
+    } else if (releaseDay?.hasBeta) {
+      level = 1 // Amber for beta
+    }
+
+    activities.push({
+      date: dateStr,
+      count: level > 0 ? 1 : 0,
+      level
+    })
+  }
+
+  // Convert map to plain object for serialization
+  const releasesByDate: ReleasesByDate = {}
+  for (const [date, day] of releaseDayMap) {
+    releasesByDate[date] = day.versions
+  }
+
+  return { activities, releasesByDate }
+}

--- a/packages/docs/src/components/release-contribution-graph.tsx
+++ b/packages/docs/src/components/release-contribution-graph.tsx
@@ -1,9 +1,21 @@
+import { type Activity } from '@/src/components/kibo-ui/contribution-graph'
 import { Suspense } from 'react'
 import {
   fetchGitHubReleases,
   processReleases
 } from './release-contribution-graph.lib'
 import { ReleaseContributionGraphClient } from './release-contribution-graph.client'
+
+// Compile-time guard: the lib's local `Activity` must stay shape-equivalent to
+// the kibo-ui one it ultimately feeds, regardless of how the JSX wiring evolves.
+// Resolves to `never` (failing assignment below) if either side drifts.
+type LibActivity = ReturnType<typeof processReleases>['activities'][number]
+type ShapeEqual<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : never
+  : never
+const _activityInSync: ShapeEqual<LibActivity, Activity> = true
 
 function ReleaseContributionGraphSkeleton() {
   return (

--- a/packages/docs/src/components/release-contribution-graph.tsx
+++ b/packages/docs/src/components/release-contribution-graph.tsx
@@ -1,6 +1,8 @@
-import { type Activity } from '@/src/components/kibo-ui/contribution-graph'
 import { Suspense } from 'react'
-import { z } from 'zod'
+import {
+  fetchGitHubReleases,
+  processReleases
+} from './release-contribution-graph.lib'
 import { ReleaseContributionGraphClient } from './release-contribution-graph.client'
 
 function ReleaseContributionGraphSkeleton() {
@@ -28,141 +30,6 @@ export function ReleaseContributionGraph({
 }
 
 // --
-
-const gitHubReleaseSchema = z.object({
-  tag_name: z.string(),
-  published_at: z.string()
-})
-
-const gitHubReleasesSchema = z.array(gitHubReleaseSchema)
-
-type GitHubRelease = z.infer<typeof gitHubReleaseSchema>
-
-async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
-  const releases: GitHubRelease[] = []
-  let page = 1
-  const perPage = 100
-
-  while (true) {
-    const response = await fetch(
-      `https://api.github.com/repos/47ng/nuqs/releases?per_page=${perPage}&page=${page}`,
-      {
-        headers: {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-          Accept: 'application/vnd.github.v3+json'
-        },
-        next: { revalidate: 3600 } // Cache for 1 hour
-      }
-    )
-
-    if (!response.ok) {
-      throw new Error(`GitHub API error: ${response.status}`)
-    }
-
-    const json = await response.json()
-    const data = gitHubReleasesSchema.parse(json)
-
-    if (data.length === 0) {
-      break
-    }
-
-    releases.push(...data)
-
-    if (data.length < perPage) {
-      break
-    }
-
-    page++
-  }
-
-  return releases
-}
-
-function isBetaVersion(tag: string): boolean {
-  return tag.includes('beta') || tag.includes('alpha') || tag.includes('rc')
-}
-
-type ReleaseDay = {
-  date: string
-  hasStable: boolean
-  hasBeta: boolean
-  versions: string[]
-}
-
-export type ReleasesByDate = Record<string, string[]>
-
-type ProcessedReleases = {
-  activities: Activity[]
-  releasesByDate: ReleasesByDate
-}
-
-function processReleases(
-  releases: GitHubRelease[],
-  year: number
-): ProcessedReleases {
-  const yearPrefix = `${year}-`
-
-  // Filter to specified year releases only
-  const yearReleases = releases.filter(r =>
-    r.published_at.startsWith(yearPrefix)
-  )
-
-  // Group releases by date
-  const releaseDayMap = new Map<string, ReleaseDay>()
-
-  for (const release of yearReleases) {
-    const date = release.published_at.split('T')[0]
-    const isBeta = isBetaVersion(release.tag_name)
-
-    const existing = releaseDayMap.get(date)
-    if (existing) {
-      if (isBeta) {
-        existing.hasBeta = true
-      } else {
-        existing.hasStable = true
-      }
-      existing.versions.push(release.tag_name)
-    } else {
-      releaseDayMap.set(date, {
-        date,
-        hasStable: !isBeta,
-        hasBeta: isBeta,
-        versions: [release.tag_name]
-      })
-    }
-  }
-
-  // Generate all days of the year
-  const startDate = new Date(`${year}-01-01`)
-  const endDate = new Date(`${year}-12-31`)
-  const activities: Activity[] = []
-
-  for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
-    const dateStr = d.toISOString().split('T')[0]
-    const releaseDay = releaseDayMap.get(dateStr)
-
-    let level = 0
-    if (releaseDay?.hasStable) {
-      level = 2 // Green for stable
-    } else if (releaseDay?.hasBeta) {
-      level = 1 // Amber for beta
-    }
-
-    activities.push({
-      date: dateStr,
-      count: level > 0 ? 1 : 0,
-      level
-    })
-  }
-
-  // Convert map to plain object for serialization
-  const releasesByDate: ReleasesByDate = {}
-  for (const [date, day] of releaseDayMap) {
-    releasesByDate[date] = day.versions
-  }
-
-  return { activities, releasesByDate }
-}
 
 type ReleaseContributionGraphProps = {
   year: number

--- a/packages/docs/src/components/ui/pr-line.test.tsx
+++ b/packages/docs/src/components/ui/pr-line.test.tsx
@@ -8,19 +8,23 @@ function endpoint(number: number | string) {
   return `https://api.github.com/repos/47ng/nuqs/pulls/${number}`
 }
 
-function pull(overrides: Record<string, unknown> = {}) {
-  return {
-    title: 'feat: add a feature',
-    state: 'open',
-    draft: false,
-    merged: false,
-    html_url: 'https://github.com/47ng/nuqs/pull/1',
-    user: {
-      login: 'octocat',
-      avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
-    },
-    ...overrides
+const pullDefaults = {
+  title: 'feat: add a feature',
+  state: 'open',
+  draft: false,
+  merged: false,
+  html_url: 'https://github.com/47ng/nuqs/pull/1',
+  user: {
+    login: 'octocat',
+    avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
   }
+}
+
+// Keys constrained to the fixture shape so a typo'd override is a compile error.
+function pull(
+  overrides: Partial<Record<keyof typeof pullDefaults, unknown>> = {}
+) {
+  return { ...pullDefaults, ...overrides }
 }
 
 async function render(number: number | string) {
@@ -47,7 +51,13 @@ describe('PullRequestLine', () => {
 
   it('renders the author login and a link to their profile', async () => {
     server.use(
-      http.get(endpoint(1), () => HttpResponse.json(pull({ user: { login: 'franky47', avatar_url: 'https://example.com/a.png' } })))
+      http.get(endpoint(1), () =>
+        HttpResponse.json(
+          pull({
+            user: { login: 'franky47', avatar_url: 'https://example.com/a.png' }
+          })
+        )
+      )
     )
     const html = await render(1)
     expect(html).toContain('franky47')
@@ -87,7 +97,9 @@ describe('PullRequestLine', () => {
   it('classifies a closed (unmerged) PR', async () => {
     server.use(
       http.get(endpoint(1), () =>
-        HttpResponse.json(pull({ merged: false, draft: false, state: 'closed' }))
+        HttpResponse.json(
+          pull({ merged: false, draft: false, state: 'closed' })
+        )
       )
     )
     const html = await render(1)
@@ -109,7 +121,13 @@ describe('PullRequestLine', () => {
   it('throws when an ok response fails schema validation', async () => {
     server.use(
       http.get(endpoint(1), () =>
-        HttpResponse.json({ title: 'no user field', state: 'open', draft: false, merged: false, html_url: 'https://github.com/47ng/nuqs/pull/1' })
+        HttpResponse.json({
+          title: 'no user field',
+          state: 'open',
+          draft: false,
+          merged: false,
+          html_url: 'https://github.com/47ng/nuqs/pull/1'
+        })
       )
     )
     await expect(PullRequestLine({ number: 1 })).rejects.toThrow()

--- a/packages/docs/src/components/ui/pr-line.test.tsx
+++ b/packages/docs/src/components/ui/pr-line.test.tsx
@@ -1,0 +1,117 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { PullRequestLine } from './pr-line.tsx'
+
+function endpoint(number: number | string) {
+  return `https://api.github.com/repos/47ng/nuqs/pulls/${number}`
+}
+
+function pull(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'feat: add a feature',
+    state: 'open',
+    draft: false,
+    merged: false,
+    html_url: 'https://github.com/47ng/nuqs/pull/1',
+    user: {
+      login: 'octocat',
+      avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4'
+    },
+    ...overrides
+  }
+}
+
+async function render(number: number | string) {
+  const element = await PullRequestLine({ number })
+  return renderToStaticMarkup(element)
+}
+
+describe('PullRequestLine', () => {
+  const server = setupServer()
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  afterEach(() => server.resetHandlers())
+  afterAll(() => server.close())
+
+  it('strips the conventional-commit prefix (with scope) from the title', async () => {
+    server.use(
+      http.get(endpoint(1), () =>
+        HttpResponse.json(pull({ title: 'fix(core): handle empty values' }))
+      )
+    )
+    const html = await render(1)
+    expect(html).toContain('handle empty values')
+    expect(html).not.toContain('fix(core)')
+  })
+
+  it('renders the author login and a link to their profile', async () => {
+    server.use(
+      http.get(endpoint(1), () => HttpResponse.json(pull({ user: { login: 'franky47', avatar_url: 'https://example.com/a.png' } })))
+    )
+    const html = await render(1)
+    expect(html).toContain('franky47')
+    expect(html).toContain('https://github.com/franky47')
+  })
+
+  it('classifies a merged PR ahead of its open/closed state', async () => {
+    server.use(
+      http.get(endpoint(1), () =>
+        HttpResponse.json(pull({ merged: true, state: 'closed', draft: false }))
+      )
+    )
+    const html = await render(1)
+    expect(html).toContain('merged PR')
+  })
+
+  it('classifies a draft PR ahead of its open state', async () => {
+    server.use(
+      http.get(endpoint(1), () =>
+        HttpResponse.json(pull({ merged: false, draft: true, state: 'open' }))
+      )
+    )
+    const html = await render(1)
+    expect(html).toContain('draft PR')
+  })
+
+  it('classifies an open PR', async () => {
+    server.use(
+      http.get(endpoint(1), () =>
+        HttpResponse.json(pull({ merged: false, draft: false, state: 'open' }))
+      )
+    )
+    const html = await render(1)
+    expect(html).toContain('open PR')
+  })
+
+  it('classifies a closed (unmerged) PR', async () => {
+    server.use(
+      http.get(endpoint(1), () =>
+        HttpResponse.json(pull({ merged: false, draft: false, state: 'closed' }))
+      )
+    )
+    const html = await render(1)
+    expect(html).toContain('closed PR')
+  })
+
+  it('renders a fallback message on a non-ok response without throwing', async () => {
+    server.use(
+      http.get(endpoint(42), () =>
+        HttpResponse.json({}, { status: 404, statusText: 'Not Found' })
+      )
+    )
+    const html = await render(42)
+    expect(html).toContain('Failed to fetch details')
+    expect(html).toContain('404')
+    expect(html).toContain('42')
+  })
+
+  it('throws when an ok response fails schema validation', async () => {
+    server.use(
+      http.get(endpoint(1), () =>
+        HttpResponse.json({ title: 'no user field', state: 'open', draft: false, merged: false, html_url: 'https://github.com/47ng/nuqs/pull/1' })
+      )
+    )
+    await expect(PullRequestLine({ number: 1 })).rejects.toThrow()
+  })
+})

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -12,8 +12,9 @@ export default defineConfig({
   test: {
     // Scope to source tests only. Vitest's defaults don't exclude `.next/`, and
     // the registry generates `.ts` items — restricting the glob keeps the runner
-    // off build output and codegen. `.tsx` is included for the RSC fetch boundary
-    // tests (e.g. pr-line) that render their output to assert on it.
+    // off build output and codegen. `.tsx` is included so component tests can be
+    // co-named with their `.tsx` source (e.g. pr-line, an async RSC rendered to
+    // static markup).
     include: ['src/**/*.test.{ts,tsx}']
   }
 })

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -1,10 +1,19 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    // Mirror the `@/*` path alias from tsconfig so source modules under test can
+    // be imported as-is. Vitest does not read tsconfig `paths` on its own.
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url))
+    }
+  },
   test: {
     // Scope to source tests only. Vitest's defaults don't exclude `.next/`, and
     // the registry generates `.ts` items — restricting the glob keeps the runner
-    // off build output and codegen.
-    include: ['src/**/*.test.ts']
+    // off build output and codegen. `.tsx` is included for the RSC fetch boundary
+    // tests (e.g. pr-line) that render their output to assert on it.
+    include: ['src/**/*.test.{ts,tsx}']
   }
 })


### PR DESCRIPTION
## What

Adds MSW-based vitest tests covering every network call the docs app makes. Until now only `getPublishedVersion` had coverage, so the npm registry, the GitHub REST and GraphQL APIs, and dependents.47ng.com could regress without CI noticing. Anything wrong there would only surface at build time or, worse, on a live page.

Each test mocks the specific endpoint with `msw/node` and checks the parse, transform, pagination and error paths, following the pattern already set by `published-version.test.ts`.

## What's covered

- Changelog releases (`fetchReleases`, `getChangelogMarkdown`)
- npm download stats (the range and registry calls, the 18-month all-time loop, zero-day interpolation)
- GitHub star history (cursor pagination, the 12-day window boundary)
- Contributors (bot filtering, page-size pagination)
- GitHub Actions status (completed-run filter, slice then reverse)
- Release contribution graph (paginated releases, day grouping)
- PR line component (rendered title, status precedence, error fallback)
- Dependents board (Zod validation)

The `mailpace` sender already had tests, so it was left alone.

## Supporting changes

A few small source edits make the above testable. No behaviour reaches the site differently.

- Some internal functions are now exported so tests can reach them directly.
- The data layer of `release-contribution-graph` moved into a sibling `.lib.ts`. The component keeps its `'use client'` chain, the lib stays free of it, and the tests import the lib. This also keeps knip quiet.
- The vitest config gains the `@` path alias and `.tsx` in its include glob.

## Notes

- One assertion was timezone-dependent, because `npm.ts` formats dates in local time. It now compares instants, so the suite is green wherever it runs.
- Tests never touch the real network and need no `GITHUB_TOKEN`, so `pnpm test` stays fast and deterministic.
