### PR TITLE
fix: share internal state across duplicate library copies

### DIFF
--- a/errors/NUQS-303.md
+++ b/errors/NUQS-303.md
@@ -2,16 +2,14 @@
 
 ## Probable cause
 
-This error occurs in [debug mode](https://nuqs.dev/docs/debugging) in
-certain monorepo setups where references of the adapter context aren't the same
-in different packages, and cause a [`NUQS-404 - nuqs requires an adapter to work with your framework`](./NUQS-404.md) error.
-
-## Root cause
-
-As described in the [React docs](https://react.dev/reference/react/useContext#my-component-doesnt-see-the-value-from-my-provider), this can happen with Context providers (which
-is what adapters are) being re-created in different modules and causing different
-references being used for a provider and consumers.
+Parts of your application are using different versions of `nuqs` or React, so
+they cannot use the same adapter.
 
 ## Possible solutions
 
-See issue [#798](https://github.com/47ng/nuqs/issues/798) for more details.
+Make sure all packages use the same version of `nuqs`. If your application has
+multiple React roots, wrap each one with the appropriate `NuqsAdapter`.
+
+Multiple copies of the same `nuqs` version are supported by the fix in
+[#1469](https://github.com/47ng/nuqs/pull/1469). If needed, upgrade to a release
+that includes it.

--- a/errors/NUQS-404.md
+++ b/errors/NUQS-404.md
@@ -32,15 +32,10 @@ setup/assertion testing facilities.
 
 ### Monorepo setups
 
-This error can also occur in monorepo setups where components using nuqs hooks
-are in different packages resolving to different `nuqs` versions,
-leading to different context references being used.
+Components using nuqs can live in workspace or shared packages. Make sure they
+are rendered below the application's `NuqsAdapter` and that all packages use the
+same version of `nuqs`.
 
-If you [enable debugging](https://nuqs.dev/docs/debugging), you might see a
-[`NUQS-303 - Multiple adapter contexts detected`](./NUQS-303.md) error, confirming
-this hypothesis.
-
-Make sure that all packages resolve to the same version
-of `nuqs` to prevent this issue from arising. See issue
-[#798](https://github.com/47ng/nuqs/issues/798) for more details and
-possible solutions.
+Multiple copies of the same version are supported by the fix in
+[#1469](https://github.com/47ng/nuqs/pull/1469). If every package already uses
+the same version, upgrade to a release that includes it.

--- a/errors/NUQS-409.md
+++ b/errors/NUQS-409.md
@@ -9,5 +9,10 @@ you are also using `nuqs` directly.
 ## Possible Solutions
 
 Inspect your dependencies for duplicate versions of `nuqs` and
-use the `resolutions` field in `package.json` to force all dependencies
-to use the same version.
+use your package manager's overrides or resolutions to align them.
+
+If you publish a library that uses `nuqs`, declare it as a peer dependency and
+exclude it from your bundle.
+
+[#1469](https://github.com/47ng/nuqs/pull/1469) adds support for multiple copies
+of the same version. Different versions still need to be aligned.

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -199,6 +199,7 @@
     "tsdown": "^0.20.1",
     "typescript": "catalog:typescript",
     "valibot": "^1.2.0",
+    "vite": "catalog:vite",
     "vitest": "catalog:vitest",
     "vitest-browser-react": "2.0.4",
     "vitest-package-exports": "^1.1.2",

--- a/packages/nuqs/scripts/prepack.sh
+++ b/packages/nuqs/scripts/prepack.sh
@@ -11,6 +11,13 @@ cp -f ../../README.md ../../LICENSE ./
 # Read the version from package.json
 VERSION=$(jq -r '.version' < package.json)
 
+# The placeholder feeds the globalThis singleton keys shared across
+# duplicate copies: failing to inject the version would make different
+# published versions collide on the same keys.
+if ! find dist -name "*.js" -exec grep -q "0.0.0-inject-version-here" {} + ; then
+  echo "Error: version placeholder not found in dist output" >&2
+  exit 1
+fi
 
 if [[ "$(uname)" == "Darwin" ]]; then
   # macOS requires an empty string as the backup extension

--- a/packages/nuqs/scripts/prepack.sh
+++ b/packages/nuqs/scripts/prepack.sh
@@ -14,7 +14,7 @@ VERSION=$(jq -r '.version' < package.json)
 # The placeholder feeds the globalThis singleton keys shared across
 # duplicate copies: failing to inject the version would make different
 # published versions collide on the same keys.
-if ! find dist -name "*.js" -exec grep -q "0.0.0-inject-version-here" {} + ; then
+if ! grep -rq "0.0.0-inject-version-here" dist --include="*.js"; then
   echo "Error: version placeholder not found in dist output" >&2
   exit 1
 fi

--- a/packages/nuqs/scripts/prepack.test.ts
+++ b/packages/nuqs/scripts/prepack.test.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process'
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { expect, it } from 'vitest'
+
+it('prepares the package when any output contains the version placeholder', async () => {
+  const fixtureRoot = await mkdtemp(join(tmpdir(), 'nuqs-prepack-'))
+  const repoRoot = join(fixtureRoot, 'repo')
+  const packageDir = join(repoRoot, 'packages', 'nuqs')
+  const scriptsDir = join(packageDir, 'scripts')
+  const distDir = join(packageDir, 'dist')
+  const binDir = join(fixtureRoot, 'bin')
+  try {
+    await Promise.all([
+      mkdir(scriptsDir, { recursive: true }),
+      mkdir(distDir, { recursive: true }),
+      mkdir(binDir, { recursive: true })
+    ])
+    await Promise.all([
+      copyFile(
+        new URL('./prepack.sh', import.meta.url),
+        join(scriptsDir, 'prepack.sh')
+      ),
+      writeFile(join(repoRoot, 'README.md'), '# Fixture'),
+      writeFile(join(repoRoot, 'LICENSE'), 'MIT'),
+      writeFile(
+        join(packageDir, 'package.json'),
+        JSON.stringify({ version: '1.2.3' })
+      ),
+      writeFile(
+        join(distDir, 'with-placeholder.js'),
+        'export const version = "0.0.0-inject-version-here"\n'
+      ),
+      writeFile(
+        join(distDir, 'without-placeholder.js'),
+        'export const answer = 42\n'
+      )
+    ])
+
+    const fakeFind = join(binDir, 'find')
+    await writeFile(
+      fakeFind,
+      [
+        '#!/usr/bin/env bash',
+        'if [[ "$*" == *"grep -q"* ]]; then',
+        '  exit 1',
+        'fi',
+        'exec /usr/bin/find "$@"'
+      ].join('\n')
+    )
+    await Promise.all([
+      chmod(join(scriptsDir, 'prepack.sh'), 0o755),
+      chmod(fakeFind, 0o755)
+    ])
+
+    const result = spawnSync(join(scriptsDir, 'prepack.sh'), {
+      cwd: packageDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: binDir + delimiter + process.env.PATH
+      }
+    })
+
+    expect(result.status, result.stderr).toBe(0)
+    await expect(
+      readFile(join(distDir, 'with-placeholder.js'), 'utf8')
+    ).resolves.toContain('1.2.3')
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true })
+  }
+})

--- a/packages/nuqs/src/adapters/lib/context.test.ts
+++ b/packages/nuqs/src/adapters/lib/context.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { version } from '../../lib/version'
+
+describe('adapter context keying across React instances', () => {
+  afterEach(() => {
+    vi.doUnmock('react')
+    vi.resetModules()
+    const registry = globalThis as { [key: symbol]: unknown }
+    delete registry[Symbol.for(`nuqs.${version}.adapter-context`)]
+  })
+
+  it('keeps contexts isolated across distinct createContext identities', async () => {
+    const real = await import('./context')
+    vi.resetModules()
+    vi.doMock('react', async importOriginal => {
+      const actual = await importOriginal<typeof import('react')>()
+      const createContext: typeof actual.createContext = defaultValue =>
+        actual.createContext(defaultValue)
+      return { ...actual, createContext }
+    })
+    const other = await import('./context')
+    expect(other.context).not.toBe(real.context)
+  })
+})

--- a/packages/nuqs/src/adapters/lib/context.ts
+++ b/packages/nuqs/src/adapters/lib/context.ts
@@ -32,13 +32,13 @@ export const context: Context<AdapterContext> = globalWeakSingleton(
   'adapter-context',
   createContext,
   () => {
-    const context = createContext<AdapterContext>({
+    const ctx = createContext<AdapterContext>({
       useAdapter() {
         throw new Error(error(404))
       }
     })
-    context.displayName = 'NuqsAdapterContext'
-    return context
+    ctx.displayName = 'NuqsAdapterContext'
+    return ctx
   }
 )
 
@@ -48,7 +48,9 @@ declare global {
   }
 }
 
-// Detect multiple adapter contexts (e.g. duplicate nuqs copies in a monorepo).
+// Detect adapter contexts that cannot be shared across duplicate copies:
+// nuqs version mismatch, or multiple React instances. Same-version copies
+// on one React share a single context via globalWeakSingleton above.
 if (typeof window !== 'undefined') {
   if (window.__NuqsAdapterContext && window.__NuqsAdapterContext !== context) {
     console.error(error(303))

--- a/packages/nuqs/src/adapters/lib/context.ts
+++ b/packages/nuqs/src/adapters/lib/context.ts
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import type { Options } from '../../defs'
 import { error } from '../../lib/errors'
+import { globalWeakSingleton } from '../../lib/global-singleton'
 import type { AdapterInterface, UseAdapterHook } from './defs'
 
 export type AdapterProps = {
@@ -25,12 +26,21 @@ export type AdapterContext = AdapterProps & {
   useAdapter: UseAdapterHook
 }
 
-export const context: Context<AdapterContext> = createContext<AdapterContext>({
-  useAdapter() {
-    throw new Error(error(404))
+// Keyed by createContext identity: copies sharing one React instance share
+// the context, while distinct React instances keep isolated contexts.
+export const context: Context<AdapterContext> = globalWeakSingleton(
+  'adapter-context',
+  createContext,
+  () => {
+    const context = createContext<AdapterContext>({
+      useAdapter() {
+        throw new Error(error(404))
+      }
+    })
+    context.displayName = 'NuqsAdapterContext'
+    return context
   }
-})
-context.displayName = 'NuqsAdapterContext'
+)
 
 declare global {
   interface Window {

--- a/packages/nuqs/src/adapters/lib/context.ts
+++ b/packages/nuqs/src/adapters/lib/context.ts
@@ -28,6 +28,9 @@ export type AdapterContext = AdapterProps & {
 
 // Keyed by createContext identity: copies sharing one React instance share
 // the context, while distinct React instances keep isolated contexts.
+// Revisit in nuqs@3 (react@^19 only): the React 18/19 Provider shape hazard
+// goes away, but distinct React instances on one page would then share one
+// context object (concurrent renders interleave its _currentValue).
 export const context: Context<AdapterContext> = globalWeakSingleton(
   'adapter-context',
   createContext,

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -1,11 +1,20 @@
 import { debug } from '../../lib/debug'
-import type { Emitter } from '../../lib/emitter'
+import { createEmitter, type Emitter } from '../../lib/emitter'
 import { error } from '../../lib/errors'
+import { globalSingleton } from '../../lib/global-singleton'
 import { resetQueues, spinQueueResetMutex } from '../../lib/queues/reset'
 import { getSearchParams } from '../../lib/search-params'
 import { version } from '../../lib/version'
 
 export type SearchParamsSyncEmitterEvents = { update: URLSearchParams }
+
+export function getHistorySyncEmitter(
+  adapter: string
+): Emitter<SearchParamsSyncEmitterEvents> {
+  return globalSingleton(`history-emitter.${adapter}`, () =>
+    createEmitter<SearchParamsSyncEmitterEvents>()
+  )
+}
 
 export const historyUpdateMarker = '__nuqs__'
 

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -3,6 +3,7 @@ import type { Emitter } from '../../lib/emitter'
 import { error } from '../../lib/errors'
 import { resetQueues, spinQueueResetMutex } from '../../lib/queues/reset'
 import { getSearchParams } from '../../lib/search-params'
+import { version } from '../../lib/version'
 
 export type SearchParamsSyncEmitterEvents = { update: URLSearchParams }
 
@@ -21,16 +22,8 @@ export function shouldPatchHistory(adapter: string): boolean {
   if (typeof history === 'undefined') {
     return false
   }
-  if (
-    history.nuqs?.version &&
-    history.nuqs.version !== '0.0.0-inject-version-here'
-  ) {
-    console.error(
-      error(409),
-      history.nuqs.version,
-      `0.0.0-inject-version-here`,
-      adapter
-    )
+  if (history.nuqs?.version && history.nuqs.version !== version) {
+    console.error(error(409), history.nuqs.version, version, adapter)
     return false
   }
   if (history.nuqs?.adapters?.includes(adapter)) {
@@ -41,8 +34,7 @@ export function shouldPatchHistory(adapter: string): boolean {
 
 export function markHistoryAsPatched(adapter: string): void {
   history.nuqs = history.nuqs ?? {
-    // This will be replaced by the prepack script
-    version: '0.0.0-inject-version-here',
+    version,
     adapters: []
   }
   history.nuqs.adapters.push(adapter)
@@ -67,7 +59,7 @@ export function patchHistory(
     resetQueues()
   })
 
-  debug(21, '0.0.0-inject-version-here', adapter)
+  debug(21, version, adapter)
   function sync(url: URL | string) {
     spinQueueResetMutex()
     try {

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -1,15 +1,14 @@
 import { startTransition, useCallback, useEffect, useState } from 'react'
 import { debug } from '../../lib/debug'
-import { createEmitter } from '../../lib/emitter'
 import { setQueueResetMutex } from '../../lib/queues/reset'
 import { renderQueryString } from '../../lib/url-encoding'
 import { createAdapterProvider, type AdapterProvider } from './context'
 import type { AdapterInterface, AdapterOptions } from './defs'
 import { applyChange, filterSearchParams } from './key-isolation'
 import {
-  patchHistory as applyHistoryPatch,
+  getHistorySyncEmitter,
   historyUpdateMarker,
-  type SearchParamsSyncEmitterEvents
+  patchHistory as applyHistoryPatch
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -42,7 +41,7 @@ export function createReactRouterBasedAdapter({
   NuqsAdapter: AdapterProvider
   useOptimisticSearchParams: () => URLSearchParams
 } {
-  const emitter = createEmitter<SearchParamsSyncEmitterEvents>()
+  const emitter = getHistorySyncEmitter(adapter)
   function useNuqsReactRouterBasedAdapter(
     watchKeys: string[]
   ): AdapterInterface {

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -2,6 +2,7 @@ import { useRouter } from 'next/compat/router.js'
 import type { NextRouter } from 'next/router'
 import { useCallback, useEffect, useMemo } from 'react'
 import { debug } from '../../lib/debug'
+import { globalSingleton } from '../../lib/global-singleton'
 import { resetQueues } from '../../lib/queues/reset'
 import { renderQueryString } from '../../lib/url-encoding'
 import type { AdapterInterface, UpdateUrlFunction } from '../lib/defs'
@@ -22,10 +23,12 @@ export function isPagesRouter(): boolean {
   return typeof window.next?.router?.state?.asPath === 'string'
 }
 
-let isNuqsUpdateMutex: boolean = false
+const updateState = globalSingleton('next-pages-router-update', () => ({
+  isNuqsUpdate: false
+}))
 
 function onNavigation() {
-  if (isNuqsUpdateMutex) {
+  if (updateState.isNuqsUpdate) {
     return
   }
   resetQueues()
@@ -77,7 +80,7 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
     debug(20, 'next/pages', asPath)
     const method =
       options.history === 'push' ? nextRouter.push : nextRouter.replace
-    isNuqsUpdateMutex = true
+    updateState.isNuqsUpdate = true
     method
       .call(
         nextRouter,
@@ -104,7 +107,7 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
         }
       )
       .finally(() => {
-        isNuqsUpdateMutex = false
+        updateState.isNuqsUpdate = false
       })
   }, [])
 

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -81,34 +81,39 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
     const method =
       options.history === 'push' ? nextRouter.push : nextRouter.replace
     updateState.isNuqsUpdate = true
-    method
-      .call(
-        nextRouter,
-        // This is what makes the URL work (mapping dynamic segments placeholders
-        // in pathname to their values in query, plus search params in query too).
-        {
-          pathname: nextRouter.pathname,
-          query: {
-            // Note: we put search params first so that one that conflicts
-            // with dynamic params will be overwritten.
-            ...urlSearchParamsToObject(search),
-            ...urlParams
+    try {
+      method
+        .call(
+          nextRouter,
+          // This is what makes the URL work (mapping dynamic segments placeholders
+          // in pathname to their values in query, plus search params in query too).
+          {
+            pathname: nextRouter.pathname,
+            query: {
+              // Note: we put search params first so that one that conflicts
+              // with dynamic params will be overwritten.
+              ...urlSearchParamsToObject(search),
+              ...urlParams
+            }
+            // For some reason we don't need to pass the hash here,
+            // it's preserved when passed as part of the asPath.
+          },
+          // This is what makes the URL pretty (resolved dynamic segments
+          // and nuqs-formatted search params).
+          asPath,
+          // And these are the options that are passed to the router.
+          {
+            scroll: options.scroll,
+            shallow: options.shallow
           }
-          // For some reason we don't need to pass the hash here,
-          // it's preserved when passed as part of the asPath.
-        },
-        // This is what makes the URL pretty (resolved dynamic segments
-        // and nuqs-formatted search params).
-        asPath,
-        // And these are the options that are passed to the router.
-        {
-          scroll: options.scroll,
-          shallow: options.shallow
-        }
-      )
-      .finally(() => {
-        updateState.isNuqsUpdate = false
-      })
+        )
+        .finally(() => {
+          updateState.isNuqsUpdate = false
+        })
+    } catch (error) {
+      updateState.isNuqsUpdate = false
+      throw error
+    }
   }, [])
 
   return {

--- a/packages/nuqs/src/adapters/react.ts
+++ b/packages/nuqs/src/adapters/react.ts
@@ -9,18 +9,17 @@ import {
   type ReactNode
 } from 'react'
 import { debug } from '../lib/debug'
-import { createEmitter } from '../lib/emitter'
 import { renderQueryString } from '../lib/url-encoding'
 import { createAdapterProvider, type AdapterProps } from './lib/context'
 import type { AdapterInterface, AdapterOptions } from './lib/defs'
 import { filterSearchParams } from './lib/key-isolation'
 import {
+  getHistorySyncEmitter,
   historyUpdateMarker,
-  patchHistory,
-  type SearchParamsSyncEmitterEvents
+  patchHistory
 } from './lib/patch-history'
 
-const emitter = createEmitter<SearchParamsSyncEmitterEvents>()
+const emitter = getHistorySyncEmitter('react')
 
 function generateUpdateUrlFn(fullPageNavigationOnShallowFalseUpdates: boolean) {
   return function updateUrl(search: URLSearchParams, options: AdapterOptions) {

--- a/packages/nuqs/src/duplicate-copies.browser.test.tsx
+++ b/packages/nuqs/src/duplicate-copies.browser.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { render } from 'vitest-browser-react'
+import * as adapterA from './adapters/testing'
+import * as nuqsA from './index'
+import * as nuqsB from 'nuqs-copy-b'
+
+// nuqsB is a second, independent instance of the library source graph
+// (see the duplicateLibraryCopy plugin in vitest.config.ts), simulating
+// a monorepo loading two physical copies of nuqs (issue #798):
+// copy A provides the adapter, copy B consumes the hooks.
+
+describe('duplicate library copies', () => {
+  it('loads distinct module instances (harness self-check)', () => {
+    expect(nuqsB.useQueryState).not.toBe(nuqsA.useQueryState)
+  })
+
+  it('shares the adapter context across copies', async () => {
+    function Demo() {
+      const [q] = nuqsB.useQueryState('q')
+      return <span data-testid="q">{q}</span>
+    }
+    render(<Demo />, {
+      wrapper: adapterA.withNuqsTestingAdapter({ searchParams: '?q=hello' })
+    })
+    await expect.element(page.getByTestId('q')).toHaveTextContent('hello')
+  })
+
+  it('syncs state updates across copies', async () => {
+    function DemoA() {
+      const [q] = nuqsA.useQueryState('q')
+      return <span data-testid="a">{q}</span>
+    }
+    function DemoB() {
+      const [q, setQ] = nuqsB.useQueryState('q')
+      return (
+        <button data-testid="b" onClick={() => setQ('world')}>
+          {q}
+        </button>
+      )
+    }
+    render(
+      <>
+        <DemoA />
+        <DemoB />
+      </>,
+      {
+        wrapper: adapterA.withNuqsTestingAdapter({ searchParams: '?q=hello' })
+      }
+    )
+    await page.getByTestId('b').click()
+    await expect.element(page.getByTestId('b')).toHaveTextContent('world')
+    await expect.element(page.getByTestId('a')).toHaveTextContent('world')
+  })
+
+  it('batches updates from both copies into a single URL update', async () => {
+    const onUrlUpdate = vi.fn<adapterA.OnUrlUpdateFunction>()
+    function Demo() {
+      const [, setA] = nuqsA.useQueryState('a')
+      const [, setB] = nuqsB.useQueryState('b')
+      return (
+        <button
+          data-testid="both"
+          onClick={() => {
+            setA('1')
+            setB('2')
+          }}
+        />
+      )
+    }
+    render(<Demo />, {
+      wrapper: adapterA.withNuqsTestingAdapter({ onUrlUpdate })
+    })
+    await page.getByTestId('both').click()
+    await vi.waitFor(() => expect(onUrlUpdate).toHaveBeenCalled())
+    await new Promise(resolve => setTimeout(resolve, 25))
+    expect(onUrlUpdate).toHaveBeenCalledTimes(1)
+    const [event] = onUrlUpdate.mock.calls[0]!
+    expect(event.searchParams.get('a')).toBe('1')
+    expect(event.searchParams.get('b')).toBe('2')
+  })
+
+  it('cancels a pending debounced update from the other copy', async () => {
+    const onUrlUpdate = vi.fn<adapterA.OnUrlUpdateFunction>()
+    function Demo() {
+      const [, setA] = nuqsA.useQueryState('q')
+      const [, setB] = nuqsB.useQueryState('q')
+      return (
+        <button
+          data-testid="race"
+          onClick={() => {
+            setA('slow', { limitUrlUpdates: nuqsA.debounce(100) })
+            setB('fast')
+          }}
+        />
+      )
+    }
+    render(<Demo />, {
+      wrapper: adapterA.withNuqsTestingAdapter({ onUrlUpdate })
+    })
+    await page.getByTestId('race').click()
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(onUrlUpdate).toHaveBeenCalledTimes(1)
+    const [event] = onUrlUpdate.mock.calls.at(-1)!
+    expect(event.searchParams.get('q')).toBe('fast')
+  })
+
+  it('shows pending debounced state from the other copy', async () => {
+    const onUrlUpdate = vi.fn<adapterA.OnUrlUpdateFunction>()
+    function DemoA() {
+      const [q] = nuqsA.useQueryState('q')
+      return <span data-testid="a">{q}</span>
+    }
+    function DemoB() {
+      const [, setQ] = nuqsB.useQueryState('q')
+      return (
+        <button
+          data-testid="b"
+          onClick={() =>
+            setQ('typed', { limitUrlUpdates: nuqsB.debounce(100) })
+          }
+        />
+      )
+    }
+    render(
+      <>
+        <DemoA />
+        <DemoB />
+      </>,
+      {
+        wrapper: adapterA.withNuqsTestingAdapter({ onUrlUpdate })
+      }
+    )
+    await page.getByTestId('b').click()
+    await expect.element(page.getByTestId('a')).toHaveTextContent('typed')
+    expect(onUrlUpdate).not.toHaveBeenCalled()
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(onUrlUpdate).toHaveBeenCalledTimes(1)
+    const [event] = onUrlUpdate.mock.calls.at(-1)!
+    expect(event.searchParams.get('q')).toBe('typed')
+  })
+})

--- a/packages/nuqs/src/duplicate-copies.browser.test.tsx
+++ b/packages/nuqs/src/duplicate-copies.browser.test.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
+import * as reactAdapterA from './adapters/react'
 import * as adapterA from './adapters/testing'
 import * as nuqsA from './index'
 import * as nuqsB from 'nuqs-copy-b'
+import * as reactAdapterB from 'nuqs-copy-b/adapters/react'
 
 // nuqsB is a second, independent instance of the library source graph
 // (see the duplicateLibraryCopy plugin in vitest.config.ts), simulating
@@ -25,6 +27,55 @@ describe('duplicate library copies', () => {
       wrapper: adapterA.withNuqsTestingAdapter({ searchParams: '?q=hello' })
     })
     await expect.element(page.getByTestId('q')).toHaveTextContent('hello')
+  })
+
+  it('syncs external history updates with adapters from both copies', async () => {
+    const originalUrl = location.href
+    const originalPushState = history.pushState
+    const originalReplaceState = history.replaceState
+    originalReplaceState.call(history, null, '', '?q=hello')
+    reactAdapterA.enableHistorySync()
+    reactAdapterB.enableHistorySync()
+    function DemoA() {
+      const [q] = nuqsA.useQueryState('q')
+      return <span data-testid="history-a">{q}</span>
+    }
+    function DemoB() {
+      const [q] = nuqsB.useQueryState('q')
+      return <span data-testid="history-b">{q}</span>
+    }
+    try {
+      render(
+        <>
+          <reactAdapterA.NuqsAdapter>
+            <DemoA />
+          </reactAdapterA.NuqsAdapter>
+          <reactAdapterB.NuqsAdapter>
+            <DemoB />
+          </reactAdapterB.NuqsAdapter>
+        </>
+      )
+      await expect
+        .element(page.getByTestId('history-a'))
+        .toHaveTextContent('hello')
+      await expect
+        .element(page.getByTestId('history-b'))
+        .toHaveTextContent('hello')
+
+      history.pushState(null, '', '?q=external')
+
+      await expect
+        .element(page.getByTestId('history-a'))
+        .toHaveTextContent('external')
+      await expect
+        .element(page.getByTestId('history-b'))
+        .toHaveTextContent('external')
+    } finally {
+      history.pushState = originalPushState
+      history.replaceState = originalReplaceState
+      delete history.nuqs
+      originalReplaceState.call(history, null, '', originalUrl)
+    }
   })
 
   it('syncs state updates across copies', async () => {

--- a/packages/nuqs/src/duplicate-copies.browser.test.tsx
+++ b/packages/nuqs/src/duplicate-copies.browser.test.tsx
@@ -13,10 +13,21 @@ import * as reactAdapterB from 'nuqs-copy-b/adapters/react'
 const pagesRouterHarness = vi.hoisted(() => {
   type Listener = () => void
   const listeners = new Map<string, Set<Listener>>()
+  let nextUpdateError: Error | null = null
   function emit(event: string) {
     for (const listener of listeners.get(event) ?? []) {
       listener()
     }
+  }
+  function update() {
+    if (nextUpdateError !== null) {
+      const error = nextUpdateError
+      nextUpdateError = null
+      throw error
+    }
+    emit('routeChangeStart')
+    emit('beforeHistoryChange')
+    return Promise.resolve(true)
   }
   const router = {
     asPath: '/',
@@ -33,21 +44,21 @@ const pagesRouterHarness = vi.hoisted(() => {
         listeners.get(event)?.delete(listener)
       }
     },
-    push() {
-      emit('routeChangeStart')
-      emit('beforeHistoryChange')
-      return Promise.resolve(true)
-    },
-    replace() {
-      emit('routeChangeStart')
-      emit('beforeHistoryChange')
-      return Promise.resolve(true)
-    }
+    push: update,
+    replace: update
   }
   return {
     router,
+    failNextUpdate(error: Error) {
+      nextUpdateError = error
+    },
+    navigate() {
+      emit('routeChangeStart')
+      emit('beforeHistoryChange')
+    },
     reset() {
       listeners.clear()
+      nextUpdateError = null
     }
   }
 })
@@ -191,6 +202,70 @@ describe('duplicate library copies', () => {
     } finally {
       window.next = originalNext
       pagesRouterHarness.reset()
+    }
+  })
+
+  it('recovers Pages Router queues across copies after a synchronous navigation failure', async () => {
+    const originalNext = window.next
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    window.next = { router: pagesRouterHarness.router as never }
+    let failedUpdate: Promise<URLSearchParams> | undefined
+    let recoveredUpdate: Promise<URLSearchParams> | undefined
+    function DemoA() {
+      const [, setQ] = nuqsA.useQueryState('q')
+      return (
+        <button
+          data-testid="pages-fail"
+          onClick={() => {
+            failedUpdate = setQ('stale')
+            void failedUpdate.catch(() => {})
+          }}
+        />
+      )
+    }
+    function DemoB() {
+      const [, setOther] = nuqsB.useQueryState('other')
+      return (
+        <button
+          data-testid="pages-recover"
+          onClick={() => {
+            recoveredUpdate = setOther('fresh')
+          }}
+        />
+      )
+    }
+    try {
+      render(
+        <>
+          <nextPagesAdapterA.NuqsAdapter>
+            <DemoA />
+          </nextPagesAdapterA.NuqsAdapter>
+          <nextPagesAdapterB.NuqsAdapter>
+            <DemoB />
+          </nextPagesAdapterB.NuqsAdapter>
+        </>
+      )
+      pagesRouterHarness.failNextUpdate(new Error('router update failed'))
+
+      await page.getByTestId('pages-fail').click()
+      await vi.waitFor(() => expect(failedUpdate).toBeDefined())
+      await expect(failedUpdate).rejects.toBeInstanceOf(URLSearchParams)
+
+      pagesRouterHarness.navigate()
+      await page.getByTestId('pages-recover').click()
+      await vi.waitFor(() => expect(recoveredUpdate).toBeDefined())
+
+      const recoveredSearch = await recoveredUpdate!
+      expect({
+        q: recoveredSearch.get('q'),
+        other: recoveredSearch.get('other')
+      }).toEqual({ q: null, other: 'fresh' })
+    } finally {
+      window.next = originalNext
+      pagesRouterHarness.reset()
+      consoleErrorSpy.mockRestore()
     }
   })
 

--- a/packages/nuqs/src/duplicate-copies.browser.test.tsx
+++ b/packages/nuqs/src/duplicate-copies.browser.test.tsx
@@ -2,11 +2,60 @@ import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
+import * as nextPagesAdapterA from './adapters/next/pages'
 import * as reactAdapterA from './adapters/react'
 import * as adapterA from './adapters/testing'
 import * as nuqsA from './index'
 import * as nuqsB from 'nuqs-copy-b'
+import * as nextPagesAdapterB from 'nuqs-copy-b/adapters/next/pages'
 import * as reactAdapterB from 'nuqs-copy-b/adapters/react'
+
+const pagesRouterHarness = vi.hoisted(() => {
+  type Listener = () => void
+  const listeners = new Map<string, Set<Listener>>()
+  function emit(event: string) {
+    for (const listener of listeners.get(event) ?? []) {
+      listener()
+    }
+  }
+  const router = {
+    asPath: '/',
+    pathname: '/',
+    query: {},
+    state: { asPath: '/' },
+    events: {
+      on(event: string, listener: Listener) {
+        const eventListeners = listeners.get(event) ?? new Set()
+        eventListeners.add(listener)
+        listeners.set(event, eventListeners)
+      },
+      off(event: string, listener: Listener) {
+        listeners.get(event)?.delete(listener)
+      }
+    },
+    push() {
+      emit('routeChangeStart')
+      emit('beforeHistoryChange')
+      return Promise.resolve(true)
+    },
+    replace() {
+      emit('routeChangeStart')
+      emit('beforeHistoryChange')
+      return Promise.resolve(true)
+    }
+  }
+  return {
+    router,
+    reset() {
+      listeners.clear()
+    }
+  }
+})
+
+vi.mock('next/compat/router.js', () => {
+  const useRouter = () => pagesRouterHarness.router
+  return { default: { useRouter }, useRouter }
+})
 
 // nuqsB is a second, independent instance of the library source graph
 // (see the duplicateLibraryCopy plugin in vitest.config.ts), simulating
@@ -103,6 +152,46 @@ describe('duplicate library copies', () => {
     await page.getByTestId('b').click()
     await expect.element(page.getByTestId('b')).toHaveTextContent('world')
     await expect.element(page.getByTestId('a')).toHaveTextContent('world')
+  })
+
+  it("does not abort another copy's Pages Router update", async () => {
+    const originalNext = window.next
+    window.next = { router: pagesRouterHarness.router as never }
+    let updatePromise: Promise<URLSearchParams> | undefined
+    function DemoA() {
+      const [, setQ] = nuqsA.useQueryState('q')
+      return (
+        <button
+          data-testid="pages-a"
+          onClick={() => {
+            updatePromise = setQ('from-a')
+          }}
+        />
+      )
+    }
+    function DemoB() {
+      nuqsB.useQueryState('other')
+      return null
+    }
+    try {
+      render(
+        <>
+          <nextPagesAdapterA.NuqsAdapter>
+            <DemoA />
+          </nextPagesAdapterA.NuqsAdapter>
+          <nextPagesAdapterB.NuqsAdapter>
+            <DemoB />
+          </nextPagesAdapterB.NuqsAdapter>
+        </>
+      )
+      await page.getByTestId('pages-a').click()
+      await vi.waitFor(() => expect(updatePromise).toBeDefined())
+      const search = await updatePromise!
+      expect(search.get('q')).toBe('from-a')
+    } finally {
+      window.next = originalNext
+      pagesRouterHarness.reset()
+    }
   })
 
   it('batches updates from both copies into a single URL update', async () => {

--- a/packages/nuqs/src/duplicate-copies.browser.test.tsx
+++ b/packages/nuqs/src/duplicate-copies.browser.test.tsx
@@ -106,6 +106,40 @@ describe('duplicate library copies', () => {
     expect(event.searchParams.get('q')).toBe('fast')
   })
 
+  it('shows optimistic state from the other copy before the URL commits', async () => {
+    const onUrlUpdate = vi.fn<adapterA.OnUrlUpdateFunction>()
+    function DemoA() {
+      const [q] = nuqsA.useQueryState('q')
+      return <span data-testid="a">{q}</span>
+    }
+    function DemoB() {
+      const [, setQ] = nuqsB.useQueryState('q')
+      return (
+        <button
+          data-testid="b"
+          onClick={() =>
+            setQ('optimistic', { limitUrlUpdates: nuqsB.throttle(500) })
+          }
+        />
+      )
+    }
+    render(
+      <>
+        <DemoA />
+        <DemoB />
+      </>,
+      {
+        wrapper: adapterA.withNuqsTestingAdapter({
+          onUrlUpdate,
+          rateLimitFactor: 1
+        })
+      }
+    )
+    await page.getByTestId('b').click()
+    await expect.element(page.getByTestId('a')).toHaveTextContent('optimistic')
+    expect(onUrlUpdate).not.toHaveBeenCalled()
+  })
+
   it('shows pending debounced state from the other copy', async () => {
     const onUrlUpdate = vi.fn<adapterA.OnUrlUpdateFunction>()
     function DemoA() {

--- a/packages/nuqs/src/hardened-global.test.ts
+++ b/packages/nuqs/src/hardened-global.test.ts
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+
+describe('hardened globalThis', () => {
+  it('loads the public client entry in a non-extensible realm', () => {
+    const entry = new URL('../dist/index.js', import.meta.url).href
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `Object.preventExtensions(globalThis); await import(${JSON.stringify(entry)})`
+      ],
+      { encoding: 'utf8' }
+    )
+    expect(result.status, result.stderr).toBe(0)
+  })
+})

--- a/packages/nuqs/src/lib/global-singleton.test.ts
+++ b/packages/nuqs/src/lib/global-singleton.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { globalSingleton, globalWeakSingleton } from './global-singleton'
+import { version } from './version'
+
+const registry = globalThis as { [key: symbol]: unknown }
+const usedScopes: string[] = []
+
+function testScope(name: string): string {
+  usedScopes.push(name)
+  return name
+}
+
+afterEach(() => {
+  for (const scope of usedScopes.splice(0)) {
+    delete registry[Symbol.for(`nuqs.${version}.${scope}`)]
+  }
+})
+
+describe('globalSingleton', () => {
+  it('creates the instance once and reuses it', () => {
+    const scope = testScope('singleton-memo')
+    let creations = 0
+    const create = () => {
+      creations++
+      return { creations }
+    }
+    const first = globalSingleton(scope, create)
+    const second = globalSingleton(scope, create)
+    expect(second).toBe(first)
+    expect(creations).toBe(1)
+  })
+
+  it('isolates instances across scopes', () => {
+    const scopeA = testScope('singleton-scope-a')
+    const scopeB = testScope('singleton-scope-b')
+    expect(globalSingleton(scopeA, () => ({}))).not.toBe(
+      globalSingleton(scopeB, () => ({}))
+    )
+  })
+
+  it('stores instances under a version-keyed global symbol', () => {
+    const scope = testScope('singleton-key-format')
+    const instance = globalSingleton(scope, () => ({}))
+    expect(registry[Symbol.for(`nuqs.${version}.${scope}`)]).toBe(instance)
+  })
+})
+
+describe('globalWeakSingleton', () => {
+  it('creates the instance once per key identity', () => {
+    const scope = testScope('weak-memo')
+    const key = new (class KeyA {})()
+    const first = globalWeakSingleton(scope, key, () => ({}))
+    const second = globalWeakSingleton(scope, key, () => ({}))
+    expect(second).toBe(first)
+  })
+
+  it('isolates instances across key identities', () => {
+    const scope = testScope('weak-isolation')
+    const keyA = new (class KeyA {})()
+    const keyB = new (class KeyB {})()
+    expect(globalWeakSingleton(scope, keyA, () => ({}))).not.toBe(
+      globalWeakSingleton(scope, keyB, () => ({}))
+    )
+  })
+})

--- a/packages/nuqs/src/lib/global-singleton.ts
+++ b/packages/nuqs/src/lib/global-singleton.ts
@@ -8,7 +8,8 @@ type GlobalRegistry = {
  * Store a module-level singleton on globalThis, keyed by library version,
  * so that duplicate copies of the library loaded side by side (e.g. in
  * monorepos, see issue #798) share the same instance instead of each
- * creating their own.
+ * creating their own. Copies of different versions deliberately keep
+ * separate instances, as internal state shapes may differ across versions.
  */
 export function globalSingleton<T>(scope: string, create: () => T): T {
   const key = Symbol.for(`nuqs.${version}.${scope}`)

--- a/packages/nuqs/src/lib/global-singleton.ts
+++ b/packages/nuqs/src/lib/global-singleton.ts
@@ -1,0 +1,37 @@
+import { version } from './version'
+
+type GlobalRegistry = {
+  [key: symbol]: unknown
+}
+
+/**
+ * Store a module-level singleton on globalThis, keyed by library version,
+ * so that duplicate copies of the library loaded side by side (e.g. in
+ * monorepos, see issue #798) share the same instance instead of each
+ * creating their own.
+ */
+export function globalSingleton<T>(scope: string, create: () => T): T {
+  const key = Symbol.for(`nuqs.${version}.${scope}`)
+  const registry = globalThis as GlobalRegistry
+  return (registry[key] ??= create()) as T
+}
+
+/**
+ * Like globalSingleton, but additionally keyed by the identity of a
+ * runtime object, for singletons that must not be shared across distinct
+ * runtimes (e.g. one React context per React instance).
+ */
+export function globalWeakSingleton<T>(
+  scope: string,
+  key: WeakKey,
+  create: () => T
+): T {
+  const instances = globalSingleton(
+    scope,
+    () => new WeakMap<WeakKey, unknown>()
+  )
+  if (!instances.has(key)) {
+    instances.set(key, create())
+  }
+  return instances.get(key) as T
+}

--- a/packages/nuqs/src/lib/global-singleton.ts
+++ b/packages/nuqs/src/lib/global-singleton.ts
@@ -4,6 +4,8 @@ type GlobalRegistry = {
   [key: symbol]: unknown
 }
 
+const fallbackRegistry: GlobalRegistry = {}
+
 /**
  * Store a module-level singleton on globalThis, keyed by library version,
  * so that duplicate copies of the library loaded side by side (e.g. in
@@ -14,7 +16,11 @@ type GlobalRegistry = {
 export function globalSingleton<T>(scope: string, create: () => T): T {
   const key = Symbol.for(`nuqs.${version}.${scope}`)
   const registry = globalThis as GlobalRegistry
-  return (registry[key] ??= create()) as T
+  if (registry[key] != null) {
+    return registry[key] as T
+  }
+  const target = Object.isExtensible(registry) ? registry : fallbackRegistry
+  return (target[key] ??= create()) as T
 }
 
 /**

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -1,5 +1,6 @@
 import { debug } from '../debug'
 import { createEmitter, type Emitter } from '../emitter'
+import { globalSingleton } from '../global-singleton'
 import type { Query } from '../search-params'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
@@ -72,14 +73,6 @@ export class DebounceController {
 
   constructor(throttleQueue: ThrottledQueue = new ThrottledQueue()) {
     this.throttleQueue = throttleQueue
-  }
-
-  useQueuedQueries(keys: string[]): Record<string, Query | null | undefined> {
-    return useSyncExternalStores(
-      keys,
-      (key, callback) => this.queuedQuerySync.on(key, callback),
-      (key: string) => this.getQueuedQuery(key)
-    )
   }
 
   push(
@@ -161,6 +154,20 @@ export class DebounceController {
   }
 }
 
-export const debounceController: DebounceController = new DebounceController(
-  globalThrottleQueue
+export const debounceController: DebounceController = globalSingleton(
+  'debounce-controller',
+  () => new DebounceController(globalThrottleQueue)
 )
+
+// Module-scoped rather than a DebounceController method: the controller is
+// shared across duplicate library copies, and each copy must compose the
+// shared data with hooks from its own React instance.
+export function useQueuedQueries(
+  keys: string[]
+): Record<string, Query | null | undefined> {
+  return useSyncExternalStores(
+    keys,
+    (key, callback) => debounceController.queuedQuerySync.on(key, callback),
+    (key: string) => debounceController.getQueuedQuery(key)
+  )
+}

--- a/packages/nuqs/src/lib/queues/reset.test.ts
+++ b/packages/nuqs/src/lib/queues/reset.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('queue reset mutex across duplicate library copies', () => {
+  afterEach(async () => {
+    const { setQueueResetMutex } = await import('./reset')
+    setQueueResetMutex(0)
+  })
+
+  it('suppresses resets spun from another copy', async () => {
+    const copyA = await import('./reset')
+    vi.resetModules()
+    const copyB = await import('./reset')
+    expect(copyB.spinQueueResetMutex).not.toBe(copyA.spinQueueResetMutex)
+    const onReset = vi.fn()
+    copyA.setQueueResetMutex(2)
+    copyB.spinQueueResetMutex(onReset)
+    expect(onReset).not.toHaveBeenCalled()
+    copyB.spinQueueResetMutex(onReset)
+    expect(onReset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/nuqs/src/lib/queues/reset.ts
+++ b/packages/nuqs/src/lib/queues/reset.ts
@@ -1,17 +1,18 @@
 import { debug } from '../debug'
+import { globalSingleton } from '../global-singleton'
 import { debounceController } from './debounce'
 import { globalThrottleQueue } from './throttle'
 
-let mutex = 0
+const state = globalSingleton('queue-reset', () => ({ mutex: 0 }))
 
 export function setQueueResetMutex(value = 1): void {
-  mutex = value
+  state.mutex = value
 }
 
 export function spinQueueResetMutex(onReset: () => void = resetQueues): void {
   // Don't let values become too negatively large and wrap around
-  mutex = Math.max(0, mutex - 1)
-  if (mutex > 0) {
+  state.mutex = Math.max(0, state.mutex - 1)
+  if (state.mutex > 0) {
     return
   }
   onReset()

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -3,6 +3,7 @@ import type { Options } from '../../defs'
 import { compose } from '../compose'
 import { debug } from '../debug'
 import { error } from '../errors'
+import { globalSingleton } from '../global-singleton'
 import { write, type Query } from '../search-params'
 import { timeout } from '../timeout'
 import { withResolvers, type Resolvers } from '../with-resolvers'
@@ -206,4 +207,7 @@ export class ThrottledQueue {
   }
 }
 
-export const globalThrottleQueue: ThrottledQueue = new ThrottledQueue()
+export const globalThrottleQueue: ThrottledQueue = globalSingleton(
+  'throttle-queue',
+  () => new ThrottledQueue()
+)

--- a/packages/nuqs/src/lib/sync.ts
+++ b/packages/nuqs/src/lib/sync.ts
@@ -1,4 +1,5 @@
 import { createEmitter, type Emitter } from './emitter'
+import { globalSingleton } from './global-singleton'
 import type { Query } from './search-params'
 
 export type CrossHookSyncPayload = {
@@ -10,4 +11,6 @@ type EventMap = {
   [key: string]: CrossHookSyncPayload
 }
 
-export const emitter: Emitter<EventMap> = createEmitter()
+export const emitter: Emitter<EventMap> = globalSingleton('sync-emitter', () =>
+  createEmitter<EventMap>()
+)

--- a/packages/nuqs/src/lib/version.ts
+++ b/packages/nuqs/src/lib/version.ts
@@ -1,0 +1,2 @@
+// This will be replaced by the prepack script
+export const version = '0.0.0-inject-version-here'

--- a/packages/nuqs/src/lib/version.ts
+++ b/packages/nuqs/src/lib/version.ts
@@ -1,2 +1,3 @@
-// This will be replaced by the prepack script
+// Replaced in dist output by the prepack script (must match its sed
+// pattern); source builds and tests keep the placeholder value.
 export const version = '0.0.0-inject-version-here'

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -7,7 +7,7 @@ import {
 import type { Nullable, Options, UrlKeys } from './defs'
 import { compareQuery } from './lib/compare'
 import { debug } from './lib/debug'
-import { debounceController } from './lib/queues/debounce'
+import { debounceController, useQueuedQueries } from './lib/queues/debounce'
 import { defaultRateLimit } from './lib/queues/rate-limiting'
 import {
   globalThrottleQueue,
@@ -126,9 +126,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         .join(',')
     ]
   )
-  const queuedQueries = debounceController.useQueuedQueries(
-    Object.values(resolvedUrlKeys)
-  )
+  const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
   const [internalState, setInternalState] = useState<V>(
     () => parseMap(keyMap, urlKeys, initialSearchParams, queuedQueries).state
   )

--- a/packages/nuqs/tsconfig.json
+++ b/packages/nuqs/tsconfig.json
@@ -10,6 +10,11 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
+    "paths": {
+      // Virtual second copy of the library for the duplicate-copies tests,
+      // see the duplicateLibraryCopy plugin in vitest.config.ts
+      "nuqs-copy-b": ["./src/index.ts"]
+    },
     // Language & Environment
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/packages/nuqs/tsconfig.json
+++ b/packages/nuqs/tsconfig.json
@@ -11,8 +11,8 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "paths": {
-      // Virtual second copy of the library for the duplicate-copies tests,
-      // see the duplicateLibraryCopy plugin in vitest.config.ts
+      // Type resolution for the virtual second copy of the library served
+      // by the duplicateLibraryCopy plugin in vitest.config.ts
       "nuqs-copy-b": ["./src/index.ts"]
     },
     // Language & Environment

--- a/packages/nuqs/tsconfig.json
+++ b/packages/nuqs/tsconfig.json
@@ -12,7 +12,8 @@
     "paths": {
       // Type resolution for the virtual second copy of the library served
       // by the duplicateLibraryCopy plugin in vitest.config.ts
-      "nuqs-copy-b": ["./src/index.ts"]
+      "nuqs-copy-b": ["./src/index.ts"],
+      "nuqs-copy-b/*": ["./src/*"]
     },
     // Language & Environment
     "target": "ESNext",

--- a/packages/nuqs/vitest.config.ts
+++ b/packages/nuqs/vitest.config.ts
@@ -1,7 +1,59 @@
 import { playwright } from '@vitest/browser-playwright'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { normalizePath, type Plugin } from 'vite'
 import { defineConfig, type ViteUserConfig } from 'vitest/config'
 
+const srcDir = normalizePath(resolve(import.meta.dirname, 'src'))
+const copyPrefix = '/@nuqs-copy-b'
+
+/**
+ * Serves a second, independent copy of the library source graph under the
+ * virtual `nuqs-copy-b` specifier, while sharing bare imports (react, etc.).
+ * This simulates a monorepo loading two physical copies of nuqs (issue #798)
+ * for the duplicate-copies tests.
+ */
+function duplicateLibraryCopy(): Plugin {
+  return {
+    name: 'nuqs:duplicate-library-copy',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      if (source === 'nuqs-copy-b') {
+        // The dependency scanner has no load hook for virtual modules,
+        // keep it from aborting the pre-bundling scan (see optimizeDeps).
+        if ('scan' in options && options.scan) {
+          return { id: source, external: true }
+        }
+        return copyPrefix + srcDir + '/index.ts'
+      }
+      if (source.startsWith(copyPrefix)) {
+        return source
+      }
+      if (importer?.startsWith(copyPrefix)) {
+        const resolved = await this.resolve(
+          source,
+          importer.slice(copyPrefix.length),
+          { skipSelf: true }
+        )
+        if (resolved?.id.startsWith(srcDir)) {
+          return copyPrefix + resolved.id
+        }
+        return resolved?.id
+      }
+    },
+    load(id) {
+      if (id.startsWith(copyPrefix)) {
+        return readFile(id.slice(copyPrefix.length), 'utf8')
+      }
+    }
+  }
+}
+
 const config: ViteUserConfig = defineConfig({
+  plugins: [duplicateLibraryCopy()],
+  optimizeDeps: {
+    exclude: ['nuqs-copy-b']
+  },
   define: {
     /**
      * We need to polyfill process.env because it is not meant to exist by default in a browser.

--- a/packages/nuqs/vitest.config.ts
+++ b/packages/nuqs/vitest.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, type ViteUserConfig } from 'vitest/config'
 const pkgDir = normalizePath(import.meta.dirname)
 const srcDir = pkgDir + '/src'
 const copyPrefix = '/@nuqs-copy-b'
+const copySpecifier = 'nuqs-copy-b'
 
 /**
  * Serves a second, independent copy of the library source graph under the
@@ -18,13 +19,14 @@ function duplicateLibraryCopy(): Plugin {
     name: 'nuqs:duplicate-library-copy',
     enforce: 'pre',
     async resolveId(source, importer, options) {
-      if (source === 'nuqs-copy-b') {
+      if (source === copySpecifier || source.startsWith(copySpecifier + '/')) {
         // The dependency scanner has no load hook for virtual modules,
         // keep it from aborting the pre-bundling scan (see optimizeDeps).
         if ('scan' in options && options.scan) {
           return { id: source, external: true }
         }
-        return copyPrefix + srcDir + '/index.ts'
+        const subpath = source.slice(copySpecifier.length)
+        return copyPrefix + srcDir + (subpath || '/index') + '.ts'
       }
       if (source.startsWith(copyPrefix)) {
         return source
@@ -64,7 +66,7 @@ function duplicateLibraryCopy(): Plugin {
 const config: ViteUserConfig = defineConfig({
   plugins: [duplicateLibraryCopy()],
   optimizeDeps: {
-    exclude: ['nuqs-copy-b']
+    exclude: [copySpecifier]
   },
   define: {
     /**

--- a/packages/nuqs/vitest.config.ts
+++ b/packages/nuqs/vitest.config.ts
@@ -66,7 +66,8 @@ function duplicateLibraryCopy(): Plugin {
 const config: ViteUserConfig = defineConfig({
   plugins: [duplicateLibraryCopy()],
   optimizeDeps: {
-    exclude: [copySpecifier]
+    exclude: [copySpecifier],
+    include: ['next/compat/router.js']
   },
   define: {
     /**

--- a/packages/nuqs/vitest.config.ts
+++ b/packages/nuqs/vitest.config.ts
@@ -1,10 +1,10 @@
 import { playwright } from '@vitest/browser-playwright'
 import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
 import { normalizePath, type Plugin } from 'vite'
 import { defineConfig, type ViteUserConfig } from 'vitest/config'
 
-const srcDir = normalizePath(resolve(import.meta.dirname, 'src'))
+const pkgDir = normalizePath(import.meta.dirname)
+const srcDir = pkgDir + '/src'
 const copyPrefix = '/@nuqs-copy-b'
 
 /**
@@ -37,6 +37,18 @@ function duplicateLibraryCopy(): Plugin {
         )
         if (resolved?.id.startsWith(srcDir)) {
           return copyPrefix + resolved.id
+        }
+        if (
+          resolved &&
+          !resolved.external &&
+          resolved.id.startsWith(pkgDir) &&
+          !resolved.id.includes('/node_modules/')
+        ) {
+          // A src-internal module escaping the prefix would be shared by
+          // module identity, silently defeating the duplicate-copies tests.
+          this.error(
+            `duplicateLibraryCopy leak: ${source} (from ${importer}) resolved outside the copy graph: ${resolved.id}`
+          )
         }
         return resolved?.id
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,9 @@ importers:
       valibot:
         specifier: ^1.2.0
         version: 1.2.0(typescript@5.9.3)
+      vite:
+        specifier: catalog:vite
+        version: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)
       vitest:
         specifier: catalog:vitest
         version: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))


### PR DESCRIPTION
Monorepos can load multiple physical copies of the same nuqs version, especially when pnpm resolves different peer sets. Previously, each copy created its own adapter context and update queues, so hooks from one copy could not see an adapter from another and threw NUQS-404.

This PR moves internal mutable state to a versioned `globalThis` registry. Same-version copies now share:

- adapter context, scoped per React instance
- hook and History API sync emitters
- throttle and debounce queues
- queue reset and Pages Router update guards

Different nuqs versions remain isolated. In environments where `globalThis` is non-extensible, nuqs falls back to module-local state instead of failing during import.

The duplicate-copy test harness loads a real second source graph and covers context sharing, optimistic updates, batching, debounce behavior, external History API updates, and Pages Router queue safety. A Node test also covers hardened realms.

Verified with the full test suite, a packed pnpm workspace reproduction, and Next.js Turbopack.

No public API or type changes.

Closes #798.