### PR TITLE
test: snapshot the exported types API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-# API snapshots are compared byte-for-byte by vitest's toMatchFileSnapshot,
-# so they must not be CRLF-converted on Windows checkouts.
+# vitest normalizes CRLF when comparing file snapshots, but an update run
+# on a CRLF checkout would rewrite them as LF and churn the working tree.
 packages/nuqs/tests/snapshots/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# API snapshots are compared byte-for-byte by vitest's toMatchFileSnapshot,
+# so they must not be CRLF-converted on Windows checkouts.
+packages/nuqs/tests/snapshots/** text eol=lf

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@
 **/dist/
 **/.next/
 **/.turbo/
+
+# Generated API snapshots, raw dist text (see packages/nuqs/src/api.test.ts)
+packages/nuqs/tests/snapshots/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,6 @@
 **/.next/
 **/.turbo/
 
-# Generated API snapshots, raw dist text (see packages/nuqs/src/api.test.ts)
+# Generated API snapshot skeletons (see packages/nuqs/src/api.test.ts);
+# their duplicate `_` parameters aren't parseable by prettier.
 packages/nuqs/tests/snapshots/

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -197,11 +197,11 @@
     "react-router-dom": "6.30.3",
     "size-limit": "^12.0.0",
     "tsdown": "^0.20.1",
+    "tsnapi": "^1.0.0",
     "typescript": "catalog:typescript",
     "valibot": "^1.2.0",
     "vitest": "catalog:vitest",
     "vitest-browser-react": "2.0.4",
-    "vitest-package-exports": "^1.1.2",
     "zod": "^4.3.6"
   },
   "size-limit": [

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -4,11 +4,16 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { extractDts, extractRuntime, resolvePackageEntriesSync } from 'tsnapi'
 import { describe, expect, it } from 'vitest'
 
-// Snapshots the public API of each package.json entry point,
+// Snapshots the public API of each package.json entry point (issue #1059),
 // as extracted from the built output in dist:
 // runtime exports, type declarations, and importability.
-// Update the snapshots when updating the API with `pnpm test:unit -u`
+// Update the snapshots when changing the API
+// with `pnpm build && pnpm test:unit -u`
 // (and adjust the documentation accordingly).
+// Limitation: types referenced in signatures but not exported
+// (eg: LimitUrlUpdates) appear by name only, without their declaration,
+// so changes to their shape don't surface here;
+// behavioral coverage for those lives in tests/*.test-d.ts.
 
 const packageRoot = fileURLToPath(new URL('..', import.meta.url))
 const distRoot = join(packageRoot, 'dist')
@@ -50,7 +55,8 @@ async function loadChunkSources() {
 // 2. Specifiers are resolved to dist-root-relative form (the exact map keys)
 //    to bypass tsnapi's match-by-basename fallback,
 //    which is ambiguous when dist files share a basename (eg: testing.js).
-// This shim could be upstreamed as a tsnapi option (see issue #1059).
+// This shim could be upstreamed to tsnapi as a chunk-sources option:
+// https://github.com/antfu/tsnapi
 function canonicalizeSpecifiers(
   code: string,
   entryDir: string,
@@ -70,6 +76,39 @@ function distSource(map: Map<string, string>, key: string) {
     throw new Error(`No dist source found for ${key}`)
   }
   return source
+}
+
+// Direct map hits are load-bearing (see canonicalizeSpecifiers):
+// a miss would engage tsnapi's ambiguous basename fallback,
+// or signal that the canonicalization regex no longer matches the dist output.
+function assertSpecifiersResolve(
+  code: string,
+  map: Map<string, string>,
+  entryName: string
+) {
+  for (const [, specifier = ''] of code.matchAll(/from "(\.[^"]+)"/g)) {
+    if (!map.has(specifier)) {
+      throw new Error(
+        `Unresolved import specifier in ${entryName}: ${specifier}`
+      )
+    }
+  }
+}
+
+// Guards against tsnapi degradations that would otherwise stay green:
+// a re-export it cannot resolve renders as a bare `export { name }`
+// instead of erroring (resolved declarations carry their full text,
+// and passthrough re-exports keep their `from` clause),
+// and a failed extraction renders as an empty snapshot,
+// indistinguishable from a side-effect-only module (only ./debug is one).
+function assertExtracted(snapshot: string, entryName: string) {
+  const collapsed = snapshot.match(/^export (?:type )?\{[^}]*\}$/m)
+  if (collapsed) {
+    throw new Error(`Unresolved re-export in ${entryName}: ${collapsed[0]}`)
+  }
+  if (snapshot.trim() === '' && entryName !== './debug') {
+    throw new Error(`Empty API snapshot for ${entryName}`)
+  }
 }
 
 function stemOf(entryName: string) {
@@ -92,9 +131,11 @@ describe('public API', () => {
           posix.dirname(path),
           '.js'
         )
+        assertSpecifiersResolve(code, chunkSources.runtime, entry.name)
         const snapshot = await extractRuntime(path, code, {
           chunkSources: chunkSources.runtime
         })
+        assertExtracted(snapshot, entry.name)
         await expect(normalize(snapshot)).toMatchFileSnapshot(
           join(snapshotRoot, `${stem}.snapshot.js`)
         )
@@ -114,15 +155,36 @@ describe('public API', () => {
           posix.dirname(path),
           '.d.mts'
         )
+        assertSpecifiersResolve(code, chunkSources.dts, entry.name)
         const snapshot = await extractDts(path, code, {
           chunkSources: chunkSources.dts
         })
+        assertExtracted(snapshot, entry.name)
         await expect(normalize(snapshot)).toMatchFileSnapshot(
           join(snapshotRoot, `${stem}.snapshot.d.ts`)
         )
       })
     }
   }
+
+  it('covers every package.json export', async () => {
+    const pkg = JSON.parse(
+      await readFile(join(packageRoot, 'package.json'), 'utf-8')
+    )
+    const expected = Object.keys(pkg.exports)
+      .filter(name => name !== './package.json')
+      .sort()
+    // The whole suite is generated from tsnapi's entry enumeration:
+    // this pins it to the exports map, so an entry it fails to resolve
+    // (unusual condition shape, tsnapi regression) cannot ship untracked.
+    expect(entries.map(entry => entry.name).sort()).toEqual(expected)
+    for (const entry of entries) {
+      // All entries currently resolve both files; if a types-only or
+      // runtime-only entry ever appears, make the exception explicit here.
+      expect(entry.runtime, `${entry.name} runtime`).not.toBeNull()
+      expect(entry.dts, `${entry.name} types`).not.toBeNull()
+    }
+  })
 
   it('has no orphaned snapshots', async () => {
     const expected = entries

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -1,12 +1,12 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { join, posix, relative, sep } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 import { extractDts, extractRuntime, resolvePackageEntriesSync } from 'tsnapi'
 import { describe, expect, it } from 'vitest'
 
 // Snapshots the public API of each package.json entry point (issue #1059),
 // as extracted from the built output in dist:
-// runtime exports, type declarations, and importability.
+// runtime exports and type declarations.
 // Update the snapshots when changing the API
 // with `pnpm build && pnpm test:unit -u`
 // (and adjust the documentation accordingly).
@@ -123,8 +123,7 @@ describe('public API', () => {
   for (const entry of entries) {
     const stem = stemOf(entry.name)
     if (entry.runtime) {
-      const runtimeFile = entry.runtime
-      const path = relative(distRoot, runtimeFile).split(sep).join('/')
+      const path = relative(distRoot, entry.runtime).split(sep).join('/')
       it(`${entry.name} (runtime)`, async () => {
         const code = canonicalizeSpecifiers(
           distSource(chunkSources.runtime, `./${path}`),
@@ -139,11 +138,6 @@ describe('public API', () => {
         await expect(normalize(snapshot)).toMatchFileSnapshot(
           join(snapshotRoot, `${stem}.snapshot.js`)
         )
-      })
-      it(`${entry.name} (import)`, async () => {
-        await expect(
-          import(pathToFileURL(runtimeFile).href)
-        ).resolves.toBeDefined()
       })
     }
     if (entry.dts) {

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -1,7 +1,8 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { join, posix, relative, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { afterAll, describe, expect, it } from 'vitest'
+import { extractDts, extractRuntime, resolvePackageEntriesSync } from 'tsnapi'
+import { describe, expect, it } from 'vitest'
 
 // Snapshots the public API of each package.json entry point (issue #1059),
 // as extracted from the built output in dist:
@@ -14,68 +15,21 @@ import { afterAll, describe, expect, it } from 'vitest'
 // so changes to their shape don't surface here;
 // behavioral coverage for those lives in tests/*.test-d.ts.
 
-// -- Timing instrumentation --
-
-type Timing = { total: number; count: number; max: number }
-const timings = new Map<string, Timing>()
-
-function record(label: string, ms: number) {
-  const timing = timings.get(label) ?? { total: 0, count: 0, max: 0 }
-  timing.total += ms
-  timing.count += 1
-  timing.max = Math.max(timing.max, ms)
-  timings.set(label, timing)
-}
-
-async function timed<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
-  const start = performance.now()
-  try {
-    return await fn()
-  } finally {
-    record(label, performance.now() - start)
-  }
-}
-
-afterAll(() => {
-  const ms = (value: number) => value.toFixed(1).padStart(7)
-  const rows = [...timings.entries()].sort((a, b) => b[1].total - a[1].total)
-  const lines = rows.map(
-    ([label, { total, count, max }]) =>
-      `${ms(total)} ms  ${String(count).padStart(3)}×  ${ms(max)} ms  ${label}`
-  )
-  process.stdout.write(
-    `\napi.test.ts step timings (total | calls | max):\n${lines.join('\n')}\n\n`
-  )
-})
-
-// -- Module initialization (runs at collection time) --
-
-const { extractDts, extractRuntime, resolvePackageEntriesSync } = await timed(
-  'import tsnapi (incl. oxc-parser binding)',
-  () => import('tsnapi')
-)
-
 const packageRoot = fileURLToPath(new URL('..', import.meta.url))
 const distRoot = join(packageRoot, 'dist')
 const snapshotRoot = join(packageRoot, 'tests', 'snapshots')
-const entries = await timed('resolvePackageEntriesSync', () =>
-  resolvePackageEntriesSync(packageRoot)
-)
-const chunkSources = await timed('loadChunkSources', loadChunkSources)
+const entries = resolvePackageEntriesSync(packageRoot)
+const chunkSources = await loadChunkSources()
 
 async function loadChunkSources() {
-  const files = (await timed('  readdir dist', () =>
-    readdir(distRoot, { recursive: true })
-  ))
+  const files = (await readdir(distRoot, { recursive: true }))
     .map(file => file.split(sep).join('/'))
     .filter(path => path.endsWith('.d.ts') || path.endsWith('.js'))
     .sort()
-  const sources = await timed('  readFile dist sources', () =>
-    Promise.all(
-      files.map(
-        async path =>
-          [path, await readFile(join(distRoot, path), 'utf-8')] as const
-      )
+  const sources = await Promise.all(
+    files.map(
+      async path =>
+        [path, await readFile(join(distRoot, path), 'utf-8')] as const
     )
   )
   const runtime = new Map<string, string>()
@@ -172,56 +126,42 @@ describe('public API', () => {
       const runtimeFile = entry.runtime
       const path = relative(distRoot, runtimeFile).split(sep).join('/')
       it(`${entry.name} (runtime)`, async () => {
-        const code = await timed('canonicalize + assert (runtime)', () => {
-          const code = canonicalizeSpecifiers(
-            distSource(chunkSources.runtime, `./${path}`),
-            posix.dirname(path),
-            '.js'
-          )
-          assertSpecifiersResolve(code, chunkSources.runtime, entry.name)
-          return code
-        })
-        const snapshot = await timed('extractRuntime', () =>
-          extractRuntime(path, code, {
-            chunkSources: chunkSources.runtime
-          })
+        const code = canonicalizeSpecifiers(
+          distSource(chunkSources.runtime, `./${path}`),
+          posix.dirname(path),
+          '.js'
         )
+        assertSpecifiersResolve(code, chunkSources.runtime, entry.name)
+        const snapshot = await extractRuntime(path, code, {
+          chunkSources: chunkSources.runtime
+        })
         assertExtracted(snapshot, entry.name)
-        await timed('toMatchFileSnapshot (runtime)', () =>
-          expect(normalize(snapshot)).toMatchFileSnapshot(
-            join(snapshotRoot, `${stem}.snapshot.js`)
-          )
+        await expect(normalize(snapshot)).toMatchFileSnapshot(
+          join(snapshotRoot, `${stem}.snapshot.js`)
         )
       })
       it(`${entry.name} (import)`, async () => {
-        await timed('import dist entry', () =>
-          expect(import(pathToFileURL(runtimeFile).href)).resolves.toBeDefined()
-        )
+        await expect(
+          import(pathToFileURL(runtimeFile).href)
+        ).resolves.toBeDefined()
       })
     }
     if (entry.dts) {
       const path = relative(distRoot, entry.dts).split(sep).join('/')
       it(`${entry.name} (types)`, async () => {
-        const code = await timed('canonicalize + assert (types)', () => {
-          const key = `./${path.replace(/\.d\.ts$/, '.d.mts')}`
-          const code = canonicalizeSpecifiers(
-            distSource(chunkSources.dts, key),
-            posix.dirname(path),
-            '.d.mts'
-          )
-          assertSpecifiersResolve(code, chunkSources.dts, entry.name)
-          return code
-        })
-        const snapshot = await timed('extractDts', () =>
-          extractDts(path, code, {
-            chunkSources: chunkSources.dts
-          })
+        const key = `./${path.replace(/\.d\.ts$/, '.d.mts')}`
+        const code = canonicalizeSpecifiers(
+          distSource(chunkSources.dts, key),
+          posix.dirname(path),
+          '.d.mts'
         )
+        assertSpecifiersResolve(code, chunkSources.dts, entry.name)
+        const snapshot = await extractDts(path, code, {
+          chunkSources: chunkSources.dts
+        })
         assertExtracted(snapshot, entry.name)
-        await timed('toMatchFileSnapshot (types)', () =>
-          expect(normalize(snapshot)).toMatchFileSnapshot(
-            join(snapshotRoot, `${stem}.snapshot.d.ts`)
-          )
+        await expect(normalize(snapshot)).toMatchFileSnapshot(
+          join(snapshotRoot, `${stem}.snapshot.d.ts`)
         )
       })
     }

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -1,121 +1,142 @@
-import { fileURLToPath } from 'node:url'
-import { expect, it } from 'vitest'
-import { getPackageExportsManifest } from 'vitest-package-exports'
+import { readdir, readFile } from 'node:fs/promises'
+import { join, posix, relative, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { extractDts, extractRuntime, resolvePackageEntriesSync } from 'tsnapi'
+import { describe, expect, it } from 'vitest'
 
-// Update the snapshot when updating the API
+// Snapshots the public API of each package.json entry point,
+// as extracted from the built output in dist:
+// runtime exports, type declarations, and importability.
+// Update the snapshots when updating the API with `pnpm test:unit -u`
 // (and adjust the documentation accordingly).
-const exports = `
-{
-  ".": {
-    "createLoader": "function",
-    "createMultiParser": "function",
-    "createParser": "function",
-    "createSerializer": "function",
-    "createStandardSchemaV1": "function",
-    "debounce": "function",
-    "defaultRateLimit": "object",
-    "parseAsArrayOf": "function",
-    "parseAsBoolean": "object",
-    "parseAsFloat": "object",
-    "parseAsHex": "object",
-    "parseAsIndex": "object",
-    "parseAsInteger": "object",
-    "parseAsIsoDate": "object",
-    "parseAsIsoDateTime": "object",
-    "parseAsJson": "function",
-    "parseAsNativeArrayOf": "function",
-    "parseAsNumberLiteral": "function",
-    "parseAsString": "object",
-    "parseAsStringEnum": "function",
-    "parseAsStringLiteral": "function",
-    "parseAsTimestamp": "object",
-    "throttle": "function",
-    "useQueryState": "function",
-    "useQueryStates": "function",
-  },
-  "./adapters/custom": {
-    "renderQueryString": "function",
-    "unstable_createAdapterProvider": "function",
-  },
-  "./adapters/next": {
-    "NuqsAdapter": "function",
-  },
-  "./adapters/next/app": {
-    "NuqsAdapter": "function",
-  },
-  "./adapters/next/pages": {
-    "NuqsAdapter": "function",
-  },
-  "./adapters/react": {
-    "NuqsAdapter": "function",
-    "enableHistorySync": "function",
-  },
-  "./adapters/react-router": {
-    "NuqsAdapter": "function",
-    "useOptimisticSearchParams": "function",
-  },
-  "./adapters/react-router/v6": {
-    "NuqsAdapter": "function",
-    "useOptimisticSearchParams": "function",
-  },
-  "./adapters/react-router/v7": {
-    "NuqsAdapter": "function",
-    "useOptimisticSearchParams": "function",
-  },
-  "./adapters/react-router/v8": {
-    "NuqsAdapter": "function",
-    "useOptimisticSearchParams": "function",
-  },
-  "./adapters/remix": {
-    "NuqsAdapter": "function",
-    "useOptimisticSearchParams": "function",
-  },
-  "./adapters/tanstack-router": {
-    "NuqsAdapter": "function",
-  },
-  "./adapters/testing": {
-    "NuqsTestingAdapter": "function",
-    "withNuqsTestingAdapter": "function",
-  },
-  "./debug": {},
-  "./server": {
-    "createLoader": "function",
-    "createMultiParser": "function",
-    "createParser": "function",
-    "createSearchParamsCache": "function",
-    "createSerializer": "function",
-    "createStandardSchemaV1": "function",
-    "debounce": "function",
-    "defaultRateLimit": "object",
-    "parseAsArrayOf": "function",
-    "parseAsBoolean": "object",
-    "parseAsFloat": "object",
-    "parseAsHex": "object",
-    "parseAsIndex": "object",
-    "parseAsInteger": "object",
-    "parseAsIsoDate": "object",
-    "parseAsIsoDateTime": "object",
-    "parseAsJson": "function",
-    "parseAsNativeArrayOf": "function",
-    "parseAsNumberLiteral": "function",
-    "parseAsString": "object",
-    "parseAsStringEnum": "function",
-    "parseAsStringLiteral": "function",
-    "parseAsTimestamp": "object",
-    "throttle": "function",
-  },
-  "./testing": {
-    "isParserBijective": "function",
-    "testParseThenSerialize": "function",
-    "testSerializeThenParse": "function",
-  },
-}
-`
 
-it('has a stable exported API (dist)', async () => {
-  const manifest = await getPackageExportsManifest({
-    importMode: 'dist',
-    cwd: fileURLToPath(import.meta.url)
+const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+const distRoot = join(packageRoot, 'dist')
+const snapshotRoot = join(packageRoot, 'tests', 'snapshots')
+const entries = resolvePackageEntriesSync(packageRoot)
+const chunkSources = await loadChunkSources()
+
+async function loadChunkSources() {
+  const files = (await readdir(distRoot, { recursive: true }))
+    .map(file => file.split(sep).join('/'))
+    .filter(path => path.endsWith('.d.ts') || path.endsWith('.js'))
+    .sort()
+  const sources = await Promise.all(
+    files.map(
+      async path =>
+        [path, await readFile(join(distRoot, path), 'utf-8')] as const
+    )
+  )
+  const runtime = new Map<string, string>()
+  const dts = new Map<string, string>()
+  for (const [path, code] of sources) {
+    if (path.endsWith('.d.ts')) {
+      dts.set(`./${path.replace(/\.d\.ts$/, '.d.mts')}`, code)
+    } else {
+      runtime.set(`./${path}`, code)
+    }
+  }
+  return { runtime, dts }
+}
+
+// tsnapi expands declarations re-exported from shared chunks
+// by looking up chunk sources keyed by import specifier,
+// and parses each chunk in the language its file extension implies.
+// Adapting to the dist layout tsdown emits here requires two rewrites:
+// 1. Type chunks get a `.d.mts` key instead of the emitted `.js` specifier,
+//    to parse in declaration mode
+//    (a `.js` name means JavaScript to the parser,
+//    collapsing chunk-hosted declarations to a bare `export { name }`).
+// 2. Specifiers are resolved to dist-root-relative form (the exact map keys)
+//    to bypass tsnapi's match-by-basename fallback,
+//    which is ambiguous when dist files share a basename (eg: testing.js).
+// This shim could be upstreamed as a tsnapi option (see issue #1059).
+function canonicalizeSpecifiers(
+  code: string,
+  entryDir: string,
+  extension: string
+) {
+  return code.replace(
+    /(?<=from ")(\.[^"]+)\.js(?=")/g,
+    (_, specifier: string) => `./${posix.join(entryDir, specifier)}${extension}`
+  )
+}
+
+function distSource(map: Map<string, string>, key: string) {
+  const source = map.get(key)
+  if (source === undefined) {
+    // Fails loudly if the dist naming conventions (tsdown outExtensions)
+    // ever drift from the assumptions baked into loadChunkSources.
+    throw new Error(`No dist source found for ${key}`)
+  }
+  return source
+}
+
+function stemOf(entryName: string) {
+  return entryName === '.' ? 'index' : entryName.replace(/^\.\//, '')
+}
+
+function normalize(snapshot: string) {
+  return (snapshot.trim() || '/* no exports */') + '\n'
+}
+
+describe('public API', () => {
+  for (const entry of entries) {
+    const stem = stemOf(entry.name)
+    if (entry.runtime) {
+      const runtimeFile = entry.runtime
+      const path = relative(distRoot, runtimeFile).split(sep).join('/')
+      it(`${entry.name} (runtime)`, async () => {
+        const code = canonicalizeSpecifiers(
+          distSource(chunkSources.runtime, `./${path}`),
+          posix.dirname(path),
+          '.js'
+        )
+        const snapshot = await extractRuntime(path, code, {
+          chunkSources: chunkSources.runtime
+        })
+        await expect(normalize(snapshot)).toMatchFileSnapshot(
+          join(snapshotRoot, `${stem}.snapshot.js`)
+        )
+      })
+      it(`${entry.name} (import)`, async () => {
+        await expect(
+          import(pathToFileURL(runtimeFile).href)
+        ).resolves.toBeDefined()
+      })
+    }
+    if (entry.dts) {
+      const path = relative(distRoot, entry.dts).split(sep).join('/')
+      it(`${entry.name} (types)`, async () => {
+        const key = `./${path.replace(/\.d\.ts$/, '.d.mts')}`
+        const code = canonicalizeSpecifiers(
+          distSource(chunkSources.dts, key),
+          posix.dirname(path),
+          '.d.mts'
+        )
+        const snapshot = await extractDts(path, code, {
+          chunkSources: chunkSources.dts
+        })
+        await expect(normalize(snapshot)).toMatchFileSnapshot(
+          join(snapshotRoot, `${stem}.snapshot.d.ts`)
+        )
+      })
+    }
+  }
+
+  it('has no orphaned snapshots', async () => {
+    const expected = entries
+      .flatMap(entry => [
+        ...(entry.runtime ? [`${stemOf(entry.name)}.snapshot.js`] : []),
+        ...(entry.dts ? [`${stemOf(entry.name)}.snapshot.d.ts`] : [])
+      ])
+      .sort()
+    const snapshots = (await readdir(snapshotRoot, { recursive: true }))
+      .map(file => file.split(sep).join('/'))
+      .filter(
+        path => path.endsWith('.snapshot.js') || path.endsWith('.snapshot.d.ts')
+      )
+      .sort()
+    expect(snapshots).toEqual(expected)
   })
-  expect(manifest.exports).toMatchInlineSnapshot(exports)
 })

--- a/packages/nuqs/src/api.test.ts
+++ b/packages/nuqs/src/api.test.ts
@@ -1,8 +1,7 @@
 import { readdir, readFile } from 'node:fs/promises'
 import { join, posix, relative, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { extractDts, extractRuntime, resolvePackageEntriesSync } from 'tsnapi'
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 
 // Snapshots the public API of each package.json entry point (issue #1059),
 // as extracted from the built output in dist:
@@ -15,21 +14,68 @@ import { describe, expect, it } from 'vitest'
 // so changes to their shape don't surface here;
 // behavioral coverage for those lives in tests/*.test-d.ts.
 
+// -- Timing instrumentation --
+
+type Timing = { total: number; count: number; max: number }
+const timings = new Map<string, Timing>()
+
+function record(label: string, ms: number) {
+  const timing = timings.get(label) ?? { total: 0, count: 0, max: 0 }
+  timing.total += ms
+  timing.count += 1
+  timing.max = Math.max(timing.max, ms)
+  timings.set(label, timing)
+}
+
+async function timed<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
+  const start = performance.now()
+  try {
+    return await fn()
+  } finally {
+    record(label, performance.now() - start)
+  }
+}
+
+afterAll(() => {
+  const ms = (value: number) => value.toFixed(1).padStart(7)
+  const rows = [...timings.entries()].sort((a, b) => b[1].total - a[1].total)
+  const lines = rows.map(
+    ([label, { total, count, max }]) =>
+      `${ms(total)} ms  ${String(count).padStart(3)}×  ${ms(max)} ms  ${label}`
+  )
+  process.stdout.write(
+    `\napi.test.ts step timings (total | calls | max):\n${lines.join('\n')}\n\n`
+  )
+})
+
+// -- Module initialization (runs at collection time) --
+
+const { extractDts, extractRuntime, resolvePackageEntriesSync } = await timed(
+  'import tsnapi (incl. oxc-parser binding)',
+  () => import('tsnapi')
+)
+
 const packageRoot = fileURLToPath(new URL('..', import.meta.url))
 const distRoot = join(packageRoot, 'dist')
 const snapshotRoot = join(packageRoot, 'tests', 'snapshots')
-const entries = resolvePackageEntriesSync(packageRoot)
-const chunkSources = await loadChunkSources()
+const entries = await timed('resolvePackageEntriesSync', () =>
+  resolvePackageEntriesSync(packageRoot)
+)
+const chunkSources = await timed('loadChunkSources', loadChunkSources)
 
 async function loadChunkSources() {
-  const files = (await readdir(distRoot, { recursive: true }))
+  const files = (await timed('  readdir dist', () =>
+    readdir(distRoot, { recursive: true })
+  ))
     .map(file => file.split(sep).join('/'))
     .filter(path => path.endsWith('.d.ts') || path.endsWith('.js'))
     .sort()
-  const sources = await Promise.all(
-    files.map(
-      async path =>
-        [path, await readFile(join(distRoot, path), 'utf-8')] as const
+  const sources = await timed('  readFile dist sources', () =>
+    Promise.all(
+      files.map(
+        async path =>
+          [path, await readFile(join(distRoot, path), 'utf-8')] as const
+      )
     )
   )
   const runtime = new Map<string, string>()
@@ -126,42 +172,56 @@ describe('public API', () => {
       const runtimeFile = entry.runtime
       const path = relative(distRoot, runtimeFile).split(sep).join('/')
       it(`${entry.name} (runtime)`, async () => {
-        const code = canonicalizeSpecifiers(
-          distSource(chunkSources.runtime, `./${path}`),
-          posix.dirname(path),
-          '.js'
-        )
-        assertSpecifiersResolve(code, chunkSources.runtime, entry.name)
-        const snapshot = await extractRuntime(path, code, {
-          chunkSources: chunkSources.runtime
+        const code = await timed('canonicalize + assert (runtime)', () => {
+          const code = canonicalizeSpecifiers(
+            distSource(chunkSources.runtime, `./${path}`),
+            posix.dirname(path),
+            '.js'
+          )
+          assertSpecifiersResolve(code, chunkSources.runtime, entry.name)
+          return code
         })
+        const snapshot = await timed('extractRuntime', () =>
+          extractRuntime(path, code, {
+            chunkSources: chunkSources.runtime
+          })
+        )
         assertExtracted(snapshot, entry.name)
-        await expect(normalize(snapshot)).toMatchFileSnapshot(
-          join(snapshotRoot, `${stem}.snapshot.js`)
+        await timed('toMatchFileSnapshot (runtime)', () =>
+          expect(normalize(snapshot)).toMatchFileSnapshot(
+            join(snapshotRoot, `${stem}.snapshot.js`)
+          )
         )
       })
       it(`${entry.name} (import)`, async () => {
-        await expect(
-          import(pathToFileURL(runtimeFile).href)
-        ).resolves.toBeDefined()
+        await timed('import dist entry', () =>
+          expect(import(pathToFileURL(runtimeFile).href)).resolves.toBeDefined()
+        )
       })
     }
     if (entry.dts) {
       const path = relative(distRoot, entry.dts).split(sep).join('/')
       it(`${entry.name} (types)`, async () => {
-        const key = `./${path.replace(/\.d\.ts$/, '.d.mts')}`
-        const code = canonicalizeSpecifiers(
-          distSource(chunkSources.dts, key),
-          posix.dirname(path),
-          '.d.mts'
-        )
-        assertSpecifiersResolve(code, chunkSources.dts, entry.name)
-        const snapshot = await extractDts(path, code, {
-          chunkSources: chunkSources.dts
+        const code = await timed('canonicalize + assert (types)', () => {
+          const key = `./${path.replace(/\.d\.ts$/, '.d.mts')}`
+          const code = canonicalizeSpecifiers(
+            distSource(chunkSources.dts, key),
+            posix.dirname(path),
+            '.d.mts'
+          )
+          assertSpecifiersResolve(code, chunkSources.dts, entry.name)
+          return code
         })
+        const snapshot = await timed('extractDts', () =>
+          extractDts(path, code, {
+            chunkSources: chunkSources.dts
+          })
+        )
         assertExtracted(snapshot, entry.name)
-        await expect(normalize(snapshot)).toMatchFileSnapshot(
-          join(snapshotRoot, `${stem}.snapshot.d.ts`)
+        await timed('toMatchFileSnapshot (types)', () =>
+          expect(normalize(snapshot)).toMatchFileSnapshot(
+            join(snapshotRoot, `${stem}.snapshot.d.ts`)
+          )
         )
       })
     }

--- a/packages/nuqs/tests/snapshots/adapters/custom.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/custom.snapshot.d.ts
@@ -1,0 +1,21 @@
+// #region Types
+export type unstable_AdapterContext = AdapterProps & {
+  useAdapter: UseAdapterHook;
+};
+export type unstable_AdapterInterface = {
+  searchParams: URLSearchParams;
+  pathname?: string;
+  updateUrl: UpdateUrlFunction;
+  getSearchParamsSnapshot?: () => URLSearchParams;
+  rateLimitFactor?: number;
+  autoResetQueueOnUpdate?: boolean;
+};
+export type unstable_AdapterOptions = Pick<Options, "history" | "scroll" | "shallow">;
+export type unstable_UpdateUrlFunction = (_: URLSearchParams, _: Required<AdapterOptions>) => void;
+export type unstable_UseAdapterHook = (_: string[]) => AdapterInterface;
+// #endregion
+
+// #region Functions
+export declare function renderQueryString(_: URLSearchParams): string;
+export declare function unstable_createAdapterProvider(_: UseAdapterHook): AdapterProvider;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/custom.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/custom.snapshot.js
@@ -1,0 +1,4 @@
+// #region Functions
+export function renderQueryString(_) {}
+export function unstable_createAdapterProvider(_) {}
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/next.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/next.snapshot.d.ts
@@ -1,0 +1,3 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/next.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/next.snapshot.js
@@ -1,0 +1,3 @@
+// #region Variables
+export var NuqsAdapter /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/next/app.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/next/app.snapshot.d.ts
@@ -1,0 +1,8 @@
+// #region Functions
+export declare function NuqsAdapter({
+  children,
+  ...adapterProps
+}: AdapterProps & {
+  children: ReactNode;
+}): ReactElement;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/next/app.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/next/app.snapshot.js
@@ -1,0 +1,3 @@
+// #region Functions
+export function NuqsAdapter(_) {}
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/next/pages.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/next/pages.snapshot.d.ts
@@ -1,0 +1,3 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/next/pages.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/next/pages.snapshot.js
@@ -1,0 +1,3 @@
+// #region Variables
+export var NuqsAdapter /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/react-router.snapshot.d.ts
@@ -1,0 +1,4 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+export declare const useOptimisticSearchParams: () => URLSearchParams;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/react-router.snapshot.js
@@ -1,0 +1,4 @@
+// #region Variables
+export var NuqsAdapter /* const */
+export var useOptimisticSearchParams /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router/v6.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/react-router/v6.snapshot.d.ts
@@ -1,0 +1,4 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+export declare const useOptimisticSearchParams: () => URLSearchParams;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router/v6.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/react-router/v6.snapshot.js
@@ -1,0 +1,4 @@
+// #region Variables
+export var NuqsAdapter /* const */
+export var useOptimisticSearchParams /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router/v7.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/react-router/v7.snapshot.d.ts
@@ -1,0 +1,4 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+export declare const useOptimisticSearchParams: () => URLSearchParams;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router/v7.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/react-router/v7.snapshot.js
@@ -1,0 +1,4 @@
+// #region Variables
+export var NuqsAdapter /* const */
+export var useOptimisticSearchParams /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router/v8.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/react-router/v8.snapshot.d.ts
@@ -1,0 +1,4 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+export declare const useOptimisticSearchParams: () => URLSearchParams;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react-router/v8.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/react-router/v8.snapshot.js
@@ -1,0 +1,4 @@
+// #region Variables
+export var NuqsAdapter /* const */
+export var useOptimisticSearchParams /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/react.snapshot.d.ts
@@ -1,0 +1,11 @@
+// #region Functions
+export declare function enableHistorySync(): void;
+export declare function NuqsAdapter({
+  children,
+  fullPageNavigationOnShallowFalseUpdates,
+  ...adapterProps
+}: AdapterProps & {
+  children: ReactNode;
+  fullPageNavigationOnShallowFalseUpdates?: boolean;
+}): ReactElement;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/react.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/react.snapshot.js
@@ -1,0 +1,4 @@
+// #region Functions
+export function enableHistorySync() {}
+export function NuqsAdapter(_) {}
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/remix.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/remix.snapshot.d.ts
@@ -1,0 +1,4 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+export declare const useOptimisticSearchParams: () => URLSearchParams;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/remix.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/remix.snapshot.js
@@ -1,0 +1,4 @@
+// #region Variables
+export var NuqsAdapter /* const */
+export var useOptimisticSearchParams /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/tanstack-router.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/tanstack-router.snapshot.d.ts
@@ -1,0 +1,3 @@
+// #region Variables
+export declare const NuqsAdapter: AdapterProvider;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/tanstack-router.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/tanstack-router.snapshot.js
@@ -1,0 +1,3 @@
+// #region Variables
+export var NuqsAdapter /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/testing.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/adapters/testing.snapshot.d.ts
@@ -1,0 +1,27 @@
+// #region Types
+export type OnUrlUpdateFunction = (_: UrlUpdateEvent) => void;
+export type UrlUpdateEvent = {
+  searchParams: URLSearchParams;
+  queryString: string;
+  options: Required<AdapterOptions>;
+};
+// #endregion
+
+// #region Functions
+export declare function NuqsTestingAdapter({
+  resetUrlUpdateQueueOnMount,
+  autoResetQueueOnUpdate,
+  defaultOptions,
+  processUrlSearchParams,
+  rateLimitFactor,
+  hasMemory,
+  onUrlUpdate,
+  children,
+  searchParams: initialSearchParams
+}: TestingAdapterProps): ReactElement;
+export declare function withNuqsTestingAdapter(_?: Omit<TestingAdapterProps, "children">): ({
+  children
+}: {
+  children: ReactNode;
+}) => ReactElement;
+// #endregion

--- a/packages/nuqs/tests/snapshots/adapters/testing.snapshot.js
+++ b/packages/nuqs/tests/snapshots/adapters/testing.snapshot.js
@@ -1,0 +1,4 @@
+// #region Functions
+export function NuqsTestingAdapter(_) {}
+export function withNuqsTestingAdapter(_) {}
+// #endregion

--- a/packages/nuqs/tests/snapshots/debug.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/debug.snapshot.d.ts
@@ -1,0 +1,1 @@
+/* no exports */

--- a/packages/nuqs/tests/snapshots/debug.snapshot.js
+++ b/packages/nuqs/tests/snapshots/debug.snapshot.js
@@ -1,0 +1,1 @@
+/* no exports */

--- a/packages/nuqs/tests/snapshots/index.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/index.snapshot.d.ts
@@ -1,0 +1,128 @@
+// #region Types
+export type CreateLoaderOptions<P extends ParserMap> = LoaderOptions<P>;
+export type CreateSerializerOptions<Parsers extends ParserMap> = Pick<Options, "clearOnDefault"> & {
+  urlKeys?: UrlKeys<Parsers>;
+  processUrlSearchParams?: (_: URLSearchParams) => URLSearchParams;
+};
+export type CreateStandardSchemaV1Options<Parsers extends ParserMap, PartialOutput extends boolean = false> = CreateLoaderOptions<Parsers> & {
+  partialOutput?: PartialOutput;
+};
+export type GenericParser<T> = SingleParser<T> | MultiParser<T>;
+export type GenericParserBuilder<T> = SingleParserBuilder<T> | MultiParserBuilder<T>;
+export type HistoryOptions = "replace" | "push";
+export type inferParserType<Input> = Input extends GenericParserBuilder<any> ? inferSingleParserType<Input> : Input extends Record<string, GenericParserBuilder<any>> ? inferParserRecordType<Input> : never;
+export type LoaderFunction<Parsers extends ParserMap> = {
+  (_: LoaderInput, _?: LoaderFunctionOptions): inferParserType<Parsers>;
+  (_: Promise<LoaderInput>, _?: LoaderFunctionOptions): Promise<inferParserType<Parsers>>;
+};
+export type LoaderInput = URL | Request | URLSearchParams | Record<string, string | string[] | undefined> | string;
+/** @deprecated */
+export type LoaderOptions<Parsers extends ParserMap> = {
+  urlKeys?: UrlKeys<Parsers>;
+};
+export type MultiParser<T> = {
+  type: "multi";
+  parse: (_: ReadonlyArray<string>) => T | null;
+  serialize?: (_: T) => Array<string>;
+  eq?: (_: T, _: T) => boolean;
+};
+export type MultiParserBuilder<T> = Required<MultiParser<T>> & Options & {
+  withOptions<This>(this: This, _: Options): This;
+  withDefault(this: MultiParserBuilder<T>, _: NonNullable<T>): Omit<MultiParserBuilder<T>, "parseServerSide"> & {
+    readonly defaultValue: NonNullable<T>;
+    parseServerSide(_: string | string[] | undefined): NonNullable<T>;
+  };
+  parseServerSide(_: string | string[] | undefined): T | null;
+};
+export type Nullable<T> = { [K in keyof T]: T[K] | null } & {};
+export type Options = {
+  history?: HistoryOptions;
+  scroll?: boolean;
+  shallow?: boolean;
+  throttleMs?: number;
+  limitUrlUpdates?: LimitUrlUpdates;
+  startTransition?: TransitionStartFunction;
+  clearOnDefault?: boolean;
+};
+/** @deprecated */
+export type Parser<T> = SingleParser<T>;
+/** @deprecated */
+export type ParserBuilder<T> = SingleParserBuilder<T>;
+export type ParserMap = Record<string, ParserWithOptionalDefault<any>>;
+export type ParserWithOptionalDefault<T> = GenericParserBuilder<T> & {
+  defaultValue?: T;
+};
+export type SearchParams = Record<string, string | string[] | undefined>;
+export type SetValues<T extends UseQueryStatesKeysMap> = (_: Partial<Nullable<Values<T>>> | UpdaterFn<T> | null, _?: Options) => Promise<URLSearchParams>;
+export type SingleParser<T> = {
+  type?: "single";
+  parse: (_: string) => T | null;
+  serialize?: (_: T) => string;
+  eq?: (_: T, _: T) => boolean;
+};
+export type SingleParserBuilder<T> = Required<SingleParser<T>> & Options & {
+  withOptions<This>(this: This, _: Options): This;
+  withDefault(this: SingleParserBuilder<T>, _: NonNullable<T>): Omit<SingleParserBuilder<T>, "parseServerSide"> & {
+    readonly defaultValue: NonNullable<T>;
+    parseServerSide(_: string | string[] | undefined): NonNullable<T>;
+  };
+  parseServerSide(_: string | string[] | undefined): T | null;
+};
+export type UrlKeys<Parsers extends Record<string, any>> = Partial<Record<keyof Parsers, string>>;
+export type UseQueryStateOptions<T> = GenericParser<T> & Options;
+export type UseQueryStateReturn<Parsed, Default> = [Default extends undefined ? Parsed | null : Parsed, (value: null | Parsed | ((old: Default extends Parsed ? Parsed : Parsed | null) => Parsed | null), options?: Options) => Promise<URLSearchParams>];
+export type UseQueryStatesKeysMap<Map = any> = { [Key in keyof Map]: KeyMapValue<Map[Key]> } & {};
+export type UseQueryStatesOptions<KeyMap extends UseQueryStatesKeysMap> = Options & {
+  urlKeys: UrlKeys<KeyMap>;
+};
+export type UseQueryStatesReturn<T extends UseQueryStatesKeysMap> = [Values<T>, SetValues<T>];
+export type Values<T extends UseQueryStatesKeysMap> = { [K in keyof T]: T[K]["defaultValue"] extends NonNullable<ReturnType<T[K]["parse"]>> ? NonNullable<ReturnType<T[K]["parse"]>> : ReturnType<T[K]["parse"]> | null };
+// #endregion
+
+// #region Functions
+export declare function createLoader<Parsers extends ParserMap>(_: Parsers, {
+  urlKeys
+}?: CreateLoaderOptions<Parsers>): LoaderFunction<Parsers>;
+export declare function createMultiParser<T>(_: Omit<Require<MultiParser<T>, "parse" | "serialize">, "type">): MultiParserBuilder<T>;
+export declare function createParser<T>(_: Require<SingleParser<T>, "parse" | "serialize">): SingleParserBuilder<T>;
+export declare function createSerializer<Parsers extends ParserMap, BaseType extends Base = Base, Return = string>(_: Parsers, {
+  clearOnDefault,
+  urlKeys,
+  processUrlSearchParams
+}?: CreateSerializerOptions<Parsers>): SerializeFunction<Parsers, BaseType, Return>;
+export declare function createStandardSchemaV1<Parsers extends ParserMap, PartialOutput extends boolean = false>(_: Parsers, {
+  urlKeys,
+  partialOutput
+}?: CreateStandardSchemaV1Options<Parsers, PartialOutput>): StandardSchemaV1<MaybePartial<PartialOutput, inferParserType<Parsers>>>;
+export declare function debounce(_: number): LimitUrlUpdates;
+export declare function parseAsArrayOf<ItemType>(_: SingleParser<ItemType>, _?: string): SingleParserBuilder<ItemType[]>;
+export declare function parseAsJson<T>(_: ((_: unknown) => T | null) | StandardSchemaV1<T>): SingleParserBuilder<T>;
+export declare function parseAsNativeArrayOf<ItemType>(_: SingleParser<ItemType>): ReturnType<MultiParserBuilder<ItemType[]>["withDefault"]>;
+export declare function parseAsNumberLiteral<const Literal extends number>(_: readonly Literal[]): SingleParserBuilder<Literal>;
+export declare function parseAsStringEnum<Enum extends string>(_: Enum[]): SingleParserBuilder<Enum>;
+export declare function parseAsStringLiteral<const Literal extends string>(_: readonly Literal[]): SingleParserBuilder<Literal>;
+export declare function throttle(_: number): LimitUrlUpdates;
+export declare function useQueryState<T>(_: string, _: UseQueryStateOptions<T> & {
+  defaultValue: T;
+}): UseQueryStateReturn<NonNullable<ReturnType<typeof options.parse>>, typeof options.defaultValue>;
+export declare function useQueryState<T>(_: string, _: UseQueryStateOptions<T>): UseQueryStateReturn<NonNullable<ReturnType<typeof options.parse>>, undefined>;
+export declare function useQueryState(_: string, _: Options & {
+  defaultValue: string;
+} & { [K in keyof GenericParser<unknown>]?: never }): UseQueryStateReturn<string, typeof options.defaultValue>;
+export declare function useQueryState(_: string, _: Pick<UseQueryStateOptions<string>, keyof Options>): UseQueryStateReturn<string, undefined>;
+export declare function useQueryState(_: string): UseQueryStateReturn<string, undefined>;
+export declare function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(_: KeyMap, _?: Partial<UseQueryStatesOptions<KeyMap>>): UseQueryStatesReturn<KeyMap>;
+// #endregion
+
+// #region Variables
+export declare const defaultRateLimit: LimitUrlUpdates;
+export declare const parseAsBoolean: SingleParserBuilder<boolean>;
+export declare const parseAsFloat: SingleParserBuilder<number>;
+export declare const parseAsHex: SingleParserBuilder<number>;
+export declare const parseAsIndex: SingleParserBuilder<number>;
+export declare const parseAsInteger: SingleParserBuilder<number>;
+export declare const parseAsIsoDate: SingleParserBuilder<Date>;
+export declare const parseAsIsoDateTime: SingleParserBuilder<Date>;
+export declare const parseAsString: SingleParserBuilder<string>;
+export declare const parseAsTimestamp: SingleParserBuilder<Date>;
+// #endregion

--- a/packages/nuqs/tests/snapshots/index.snapshot.js
+++ b/packages/nuqs/tests/snapshots/index.snapshot.js
@@ -1,0 +1,30 @@
+// #region Functions
+export function createLoader(_, _) {}
+export function createMultiParser(_) {}
+export function createParser(_) {}
+export function createSerializer(_, _) {}
+export function createStandardSchemaV1(_, _) {}
+export function debounce(_) {}
+export function parseAsArrayOf(_, _) {}
+export function parseAsJson(_) {}
+export function parseAsNativeArrayOf(_) {}
+export function parseAsNumberLiteral(_) {}
+export function parseAsStringEnum(_) {}
+export function parseAsStringLiteral(_) {}
+export function throttle(_) {}
+export function useQueryState(_, _) {}
+export function useQueryStates(_, _) {}
+// #endregion
+
+// #region Variables
+export var defaultRateLimit /* const */
+export var parseAsBoolean /* const */
+export var parseAsFloat /* const */
+export var parseAsHex /* const */
+export var parseAsIndex /* const */
+export var parseAsInteger /* const */
+export var parseAsIsoDate /* const */
+export var parseAsIsoDateTime /* const */
+export var parseAsString /* const */
+export var parseAsTimestamp /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/server.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/server.snapshot.d.ts
@@ -1,0 +1,112 @@
+// #region Types
+export type CreateLoaderOptions<P extends ParserMap> = LoaderOptions<P>;
+export type CreateSerializerOptions<Parsers extends ParserMap> = Pick<Options, "clearOnDefault"> & {
+  urlKeys?: UrlKeys<Parsers>;
+  processUrlSearchParams?: (_: URLSearchParams) => URLSearchParams;
+};
+export type CreateStandardSchemaV1Options<Parsers extends ParserMap, PartialOutput extends boolean = false> = CreateLoaderOptions<Parsers> & {
+  partialOutput?: PartialOutput;
+};
+export type GenericParser<T> = SingleParser<T> | MultiParser<T>;
+export type GenericParserBuilder<T> = SingleParserBuilder<T> | MultiParserBuilder<T>;
+export type HistoryOptions = "replace" | "push";
+export type inferParserType<Input> = Input extends GenericParserBuilder<any> ? inferSingleParserType<Input> : Input extends Record<string, GenericParserBuilder<any>> ? inferParserRecordType<Input> : never;
+export type LoaderFunction<Parsers extends ParserMap> = {
+  (_: LoaderInput, _?: LoaderFunctionOptions): inferParserType<Parsers>;
+  (_: Promise<LoaderInput>, _?: LoaderFunctionOptions): Promise<inferParserType<Parsers>>;
+};
+export type LoaderInput = URL | Request | URLSearchParams | Record<string, string | string[] | undefined> | string;
+/** @deprecated */
+export type LoaderOptions<Parsers extends ParserMap> = {
+  urlKeys?: UrlKeys<Parsers>;
+};
+export type MultiParser<T> = {
+  type: "multi";
+  parse: (_: ReadonlyArray<string>) => T | null;
+  serialize?: (_: T) => Array<string>;
+  eq?: (_: T, _: T) => boolean;
+};
+export type MultiParserBuilder<T> = Required<MultiParser<T>> & Options & {
+  withOptions<This>(this: This, _: Options): This;
+  withDefault(this: MultiParserBuilder<T>, _: NonNullable<T>): Omit<MultiParserBuilder<T>, "parseServerSide"> & {
+    readonly defaultValue: NonNullable<T>;
+    parseServerSide(_: string | string[] | undefined): NonNullable<T>;
+  };
+  parseServerSide(_: string | string[] | undefined): T | null;
+};
+export type Nullable<T> = { [K in keyof T]: T[K] | null } & {};
+export type Options = {
+  history?: HistoryOptions;
+  scroll?: boolean;
+  shallow?: boolean;
+  throttleMs?: number;
+  limitUrlUpdates?: LimitUrlUpdates;
+  startTransition?: TransitionStartFunction;
+  clearOnDefault?: boolean;
+};
+export type Parser<T> = SingleParser<T>;
+export type ParserBuilder<T> = SingleParserBuilder<T>;
+export type ParserMap = Record<string, ParserWithOptionalDefault<any>>;
+export type ParserWithOptionalDefault<T> = GenericParserBuilder<T> & {
+  defaultValue?: T;
+};
+export type SearchParams = Record<string, string | string[] | undefined>;
+export type SingleParser<T> = {
+  type?: "single";
+  parse: (_: string) => T | null;
+  serialize?: (_: T) => string;
+  eq?: (_: T, _: T) => boolean;
+};
+export type SingleParserBuilder<T> = Required<SingleParser<T>> & Options & {
+  withOptions<This>(this: This, _: Options): This;
+  withDefault(this: SingleParserBuilder<T>, _: NonNullable<T>): Omit<SingleParserBuilder<T>, "parseServerSide"> & {
+    readonly defaultValue: NonNullable<T>;
+    parseServerSide(_: string | string[] | undefined): NonNullable<T>;
+  };
+  parseServerSide(_: string | string[] | undefined): T | null;
+};
+export type UrlKeys<Parsers extends Record<string, any>> = Partial<Record<keyof Parsers, string>>;
+// #endregion
+
+// #region Functions
+export declare function createLoader<Parsers extends ParserMap>(_: Parsers, {
+  urlKeys
+}?: CreateLoaderOptions<Parsers>): LoaderFunction<Parsers>;
+export declare function createMultiParser<T>(_: Omit<Require<MultiParser<T>, "parse" | "serialize">, "type">): MultiParserBuilder<T>;
+export declare function createParser<T>(_: Require<SingleParser<T>, "parse" | "serialize">): SingleParserBuilder<T>;
+export declare function createSearchParamsCache<Parsers extends ParserMap>(_: Parsers, {
+  urlKeys
+}?: {
+  urlKeys?: UrlKeys<Parsers>;
+}): CacheInterface<Parsers>;
+export declare function createSerializer<Parsers extends ParserMap, BaseType extends Base = Base, Return = string>(_: Parsers, {
+  clearOnDefault,
+  urlKeys,
+  processUrlSearchParams
+}?: CreateSerializerOptions<Parsers>): SerializeFunction<Parsers, BaseType, Return>;
+export declare function createStandardSchemaV1<Parsers extends ParserMap, PartialOutput extends boolean = false>(_: Parsers, {
+  urlKeys,
+  partialOutput
+}?: CreateStandardSchemaV1Options<Parsers, PartialOutput>): StandardSchemaV1<MaybePartial<PartialOutput, inferParserType<Parsers>>>;
+export declare function debounce(_: number): LimitUrlUpdates;
+export declare function parseAsArrayOf<ItemType>(_: SingleParser<ItemType>, _?: string): SingleParserBuilder<ItemType[]>;
+export declare function parseAsJson<T>(_: ((_: unknown) => T | null) | StandardSchemaV1<T>): SingleParserBuilder<T>;
+export declare function parseAsNativeArrayOf<ItemType>(_: SingleParser<ItemType>): ReturnType<MultiParserBuilder<ItemType[]>["withDefault"]>;
+export declare function parseAsNumberLiteral<const Literal extends number>(_: readonly Literal[]): SingleParserBuilder<Literal>;
+export declare function parseAsStringEnum<Enum extends string>(_: Enum[]): SingleParserBuilder<Enum>;
+export declare function parseAsStringLiteral<const Literal extends string>(_: readonly Literal[]): SingleParserBuilder<Literal>;
+export declare function throttle(_: number): LimitUrlUpdates;
+// #endregion
+
+// #region Variables
+export declare const defaultRateLimit: LimitUrlUpdates;
+export declare const parseAsBoolean: SingleParserBuilder<boolean>;
+export declare const parseAsFloat: SingleParserBuilder<number>;
+export declare const parseAsHex: SingleParserBuilder<number>;
+export declare const parseAsIndex: SingleParserBuilder<number>;
+export declare const parseAsInteger: SingleParserBuilder<number>;
+export declare const parseAsIsoDate: SingleParserBuilder<Date>;
+export declare const parseAsIsoDateTime: SingleParserBuilder<Date>;
+export declare const parseAsString: SingleParserBuilder<string>;
+export declare const parseAsTimestamp: SingleParserBuilder<Date>;
+// #endregion

--- a/packages/nuqs/tests/snapshots/server.snapshot.js
+++ b/packages/nuqs/tests/snapshots/server.snapshot.js
@@ -1,0 +1,29 @@
+// #region Functions
+export function createLoader(_, _) {}
+export function createMultiParser(_) {}
+export function createParser(_) {}
+export function createSearchParamsCache(_, _) {}
+export function createSerializer(_, _) {}
+export function createStandardSchemaV1(_, _) {}
+export function debounce(_) {}
+export function parseAsArrayOf(_, _) {}
+export function parseAsJson(_) {}
+export function parseAsNativeArrayOf(_) {}
+export function parseAsNumberLiteral(_) {}
+export function parseAsStringEnum(_) {}
+export function parseAsStringLiteral(_) {}
+export function throttle(_) {}
+// #endregion
+
+// #region Variables
+export var defaultRateLimit /* const */
+export var parseAsBoolean /* const */
+export var parseAsFloat /* const */
+export var parseAsHex /* const */
+export var parseAsIndex /* const */
+export var parseAsInteger /* const */
+export var parseAsIsoDate /* const */
+export var parseAsIsoDateTime /* const */
+export var parseAsString /* const */
+export var parseAsTimestamp /* const */
+// #endregion

--- a/packages/nuqs/tests/snapshots/testing.snapshot.d.ts
+++ b/packages/nuqs/tests/snapshots/testing.snapshot.d.ts
@@ -1,0 +1,8 @@
+// #region Functions
+export declare function isParserBijective<T>(_: SingleParserBuilder<T>, _: string, _: T): boolean;
+export declare function isParserBijective<T>(_: MultiParserBuilder<T>, _: Array<string>, _: T): boolean;
+export declare function testParseThenSerialize<T>(_: SingleParserBuilder<T>, _: string): boolean;
+export declare function testParseThenSerialize<T>(_: MultiParserBuilder<T>, _: Array<string>): boolean;
+export declare function testSerializeThenParse<T>(_: SingleParserBuilder<T>, _: T): boolean;
+export declare function testSerializeThenParse<T>(_: MultiParserBuilder<T>, _: T): boolean;
+// #endregion

--- a/packages/nuqs/tests/snapshots/testing.snapshot.js
+++ b/packages/nuqs/tests/snapshots/testing.snapshot.js
@@ -1,0 +1,5 @@
+// #region Functions
+export function isParserBijective(_, _, _) {}
+export function testParseThenSerialize(_, _) {}
+export function testSerializeThenParse(_, _) {}
+// #endregion

--- a/packages/nuqs/vitest.config.ts
+++ b/packages/nuqs/vitest.config.ts
@@ -24,11 +24,6 @@ const config: ViteUserConfig = defineConfig({
     env: {
       IS_REACT_ACT_ENVIRONMENT: 'true'
     },
-    server: {
-      deps: {
-        inline: ['vitest-package-exports']
-      }
-    },
     projects: [
       {
         extends: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   e2e:
-    '@playwright/test':
-      specifier: ^1.58.1
-      version: 1.58.1
     playwright:
       specifier: ^1.58.1
       version: 1.58.1
@@ -16,46 +13,6 @@ catalogs:
     knip:
       specifier: ^6.14.2
       version: 6.14.2
-  msw:
-    msw:
-      specifier: ^2.14.6
-      version: 2.14.6
-  next:
-    next:
-      specifier: 16.2.7
-      version: 16.2.7
-  react-router7:
-    '@react-router/dev':
-      specifier: ^7.18.0
-      version: 7.18.0
-    '@react-router/express':
-      specifier: ^7.18.0
-      version: 7.18.0
-    '@react-router/node':
-      specifier: ^7.18.0
-      version: 7.18.0
-    '@react-router/serve':
-      specifier: ^7.18.0
-      version: 7.18.0
-    react-router:
-      specifier: ^7.18.0
-      version: 7.18.0
-  react-router8:
-    '@react-router/dev':
-      specifier: ^8.0.0
-      version: 8.0.0
-    '@react-router/express':
-      specifier: ^8.0.0
-      version: 8.0.0
-    '@react-router/node':
-      specifier: ^8.0.0
-      version: 8.0.0
-    '@react-router/serve':
-      specifier: ^8.0.0
-      version: 8.0.0
-    react-router:
-      specifier: ^8.0.0
-      version: 8.0.0
   react19:
     '@types/react':
       specifier: ^19.2.10
@@ -66,17 +23,10 @@ catalogs:
     react:
       specifier: ^19.2.7
       version: 19.2.7
-    react-dom:
-      specifier: ^19.2.7
-      version: 19.2.7
   typescript:
     typescript:
       specifier: ^5.9.2
       version: 5.9.3
-  vite:
-    vite:
-      specifier: ^8.0.0
-      version: 8.0.16
   vitest:
     '@vitest/browser-playwright':
       specifier: ^4.1.0
@@ -100,7 +50,7 @@ importers:
         version: 20.4.1(@types/node@24.10.10)(typescript@5.9.3)
       knip:
         specifier: catalog:knip
-        version: 6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        version: 6.14.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -193,13 +143,13 @@ importers:
         version: 3.20.0
       fumadocs-core:
         specifier: 16.0.4
-        version: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       fumadocs-mdx:
         specifier: 13.0.2
-        version: 13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
+        version: 13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.0.4
-        version: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(tailwindcss@4.1.18)
+        version: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.7)
@@ -211,7 +161,7 @@ importers:
         version: 2.1.2
       next:
         specifier: catalog:next
-        version: 16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: workspace:*
         version: link:../nuqs
@@ -301,7 +251,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:next
-        version: 16.2.7(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: workspace:*
         version: link:../../nuqs
@@ -715,7 +665,7 @@ importers:
     dependencies:
       next:
         specifier: catalog:next
-        version: 16.2.7(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: latest
         version: 2.8.9(@remix-run/react@2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(next@16.2.7(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -850,10 +800,10 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^5.1.3
-        version: 5.1.3(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
+        version: 5.1.3(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.8(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(playwright@1.58.1)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.58.1)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8':
         specifier: catalog:vitest
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
@@ -865,7 +815,7 @@ importers:
         version: 4.5.3
       knip:
         specifier: catalog:knip
-        version: 6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        version: 6.14.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       playwright:
         specifier: catalog:e2e
         version: 1.58.1
@@ -880,7 +830,10 @@ importers:
         version: 12.0.0(jiti@2.7.0)
       tsdown:
         specifier: ^0.20.1
-        version: 0.20.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.17)(typescript@5.9.3)
+        version: 0.20.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3)
+      tsnapi:
+        specifier: ^1.0.0
+        version: 1.0.0(vitest@4.1.8)
       typescript:
         specifier: catalog:typescript
         version: 5.9.3
@@ -889,13 +842,10 @@ importers:
         version: 1.2.0(typescript@5.9.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
       vitest-browser-react:
         specifier: 2.0.4
         version: 2.0.4(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
-      vitest-package-exports:
-        specifier: ^1.1.2
-        version: 1.1.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1371,11 +1321,20 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -2240,6 +2199,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.7':
     resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
 
@@ -2470,8 +2435,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.138.0':
+    resolution: {integrity: sha512-hSYAD+F9W2Qh8SETMqBsQRx6YHvB4z+i/i36shlC7tfdZQauMs4vf3G/EQwKOkNlN7rkTiKINvsNmQb9q2MWcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.130.0':
     resolution: {integrity: sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.138.0':
+    resolution: {integrity: sha512-Ns5LLTp8cVyP8DsYqD482h0HE84xiGYRgtm7g4LtTinq209NAiMF768e/8r2NHaa0UMirS5mrT1m1VwiVmBi4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2482,8 +2459,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.138.0':
+    resolution: {integrity: sha512-Yka0m4YhKUHBIZufafSLAeO+DUrfHPtNXBlZSj7DxshquIl41x/a+i/MbRnbOy8heuLiYU1STa6h0FAAzT7Pbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.130.0':
     resolution: {integrity: sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.138.0':
+    resolution: {integrity: sha512-MWLUZZzmNRUqTWueZF27ncreaZ1wZ0gboWL2QMPxRQA2xgOmBPlGg2H9pAKJSPBlwEHcWa9TdWRiehAS+yls8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2494,8 +2483,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.138.0':
+    resolution: {integrity: sha512-Vae5tzsrzZ/lCDVCZUMi/vzSiiHEgcOEfsyIfWOHmjZ2ji+gT+n96T757yX5/f7/7JIJuiannAHJKV5ARaF6ng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.130.0':
     resolution: {integrity: sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
+    resolution: {integrity: sha512-qkU8wv5mYexrCw0X4DHFgxGbRScwGLIIKUkHXU7xXEiLoMnQzELak2gujxfa9GFrlEgPjbyLUDFHWm67Zs38ng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2506,8 +2507,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
+    resolution: {integrity: sha512-3HgULIvoDV7h2ZfVYzxQwOSOJnAjMwYmyUBzndNuLRGgBNI549ED0P6AGmN9y2TnSvrwJ+Q8zqdxqssMnGXitA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.130.0':
     resolution: {integrity: sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
+    resolution: {integrity: sha512-pIonbH2p0KLCwz4CNPCi0xGqci4numpMQDCLJwLfsrEky7NUuByKDFhCjzE0E7vR3aj/lBjyMoTskHBo/qSg8g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2520,8 +2534,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
+    resolution: {integrity: sha512-cT5L1Xz/5m6Ga1hD3922gLc+fePOauJZJdApPTI/2Vu0EmYo62uHG9V5Dq65hhgU9TW10oDi2840y9cGdd7BIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.130.0':
     resolution: {integrity: sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
+    resolution: {integrity: sha512-hKy/vvejKk3LNE/FsRbekWejLa046//TnLWtSo7ur29NIsNbSIvnOVYIirSVC7fsd6NO8UFzwDdcoZfCyBvSBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2534,8 +2562,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
+    resolution: {integrity: sha512-bh6tjNGq0v0b9GAMu0pTv/YpTqepCFy0TIOtQHm8+41fZwLXTaB6xiEWVUSarNCXqc5kyzYcH6EOfwW1sJxJOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.130.0':
     resolution: {integrity: sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
+    resolution: {integrity: sha512-HhOkddcClSTtTxY10f/mACblKcQdxWy4lYYwX12G23j+S5eiJ5y1kpo1r7kKng+2bdnCBO+lCDWOVVc9kVl9+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -2548,8 +2590,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
+    resolution: {integrity: sha512-5mi+wtbeJiEa4waGG88EcEGgJBBNJdDeIcayPPcrLNMXbCrgdtbb80q0Nrat7A8NglLUVzhuTAAp7K6PjmUO8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-x64-gnu@0.130.0':
     resolution: {integrity: sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
+    resolution: {integrity: sha512-ckbq3AMI7lI8AhQtE8KdqYRmzmzwKfCU12QN/PBKXO72PfWdvvZQN0hFShDX/XRNsPqjddLmvXaQMT3zfYtNlw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2562,8 +2618,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.138.0':
+    resolution: {integrity: sha512-JrCOzHO9BYEs5Xz5JHYBxSc/hYKxfXUj5QQb64sERSbkQot6+KEgMTOR2C9hLrhaqOui65OYcFyTTS+YxXDtnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-openharmony-arm64@0.130.0':
     resolution: {integrity: sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.138.0':
+    resolution: {integrity: sha512-eASMMfOOIfLHkWJRPSu8llByvVRM+c1M/lh18KjsjELM3y10+7B5iBbbrht9LdtsJXQ+mRuP/lJ7UWe3Ok3ehw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2573,8 +2642,19 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.138.0':
+    resolution: {integrity: sha512-BnTCO87Iwc57NufXS7vcrkrmpN+daeCeYr1+/xgPT6HjwNs0lBmJYeFrcOs4WkNN8yscdd6Rc4FxWh3+59hAFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.130.0':
     resolution: {integrity: sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
+    resolution: {integrity: sha512-+Zi47boD2wKNL0hOA47Vkwk6njMZ8sOsr4Geu/56EUtlooDh9crNOU41U6bXGS0UjC4Y72HtRA1iuB6qx1ARUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2585,8 +2665,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
+    resolution: {integrity: sha512-SYcV674Wi2WuoBefUFgf0PBMNlZe5IF0YZ0TnP7DK+EusMVpEWq6iz+7r64svjAb7vjthzlas0FUCSlz8YkqYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.130.0':
     resolution: {integrity: sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
+    resolution: {integrity: sha512-QZplnCxS4vPe4StAVBtvD2bW3pELlidf0Ek6iQ/HHiCjbEtrs5pFZZfLAoPhKLJyDzyxoGAdic9bSIYrJYTZcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -2599,6 +2691,9 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
@@ -4790,6 +4885,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
@@ -4984,6 +5082,9 @@ packages:
   '@vitest/pretty-format@4.1.8':
     resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
   '@vitest/runner@4.1.8':
     resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
@@ -4995,6 +5096,9 @@ packages:
 
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
@@ -5194,6 +5298,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   cacache@17.1.4:
     resolution: {integrity: sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==}
@@ -5948,10 +6056,6 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
-
-  find-up-simple@1.0.1:
-    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
-    engines: {node: '>=18'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -7477,6 +7581,10 @@ packages:
     resolution: {integrity: sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxc-parser@0.138.0:
+    resolution: {integrity: sha512-c25lvfpZ2+WY1yk6NkP0X0RTQg0ZxgSVaZHDa7lt6fEe1jwZjPWkRWvTyZ1xyaM7roVJMdtRCfbhUj/d4ims3Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
@@ -8691,6 +8799,15 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsnapi@1.0.0:
+    resolution: {integrity: sha512-Z6Kwtey0d0FDoRSfdUfU/ttwxXQU+cAHZQdt2yF5T0Twox4jxZF4wqix61dkwEJ/0ja7igytI+7wy8Wsv/oqsQ==}
+    hasBin: true
+    peerDependencies:
+      vitest: '>=4.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
+
   tsx@4.20.4:
     resolution: {integrity: sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==}
     engines: {node: '>=18.0.0'}
@@ -9077,9 +9194,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  vitest-package-exports@1.1.2:
-    resolution: {integrity: sha512-895iRrbcsZIDMhJSftGcQkuOPZcbCbHEQHXG0MnPKsSkpJhMRYuVtjA8dcjokyygJd/IQDDO8gyKo01AIkudHQ==}
 
   vitest@4.1.8:
     resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
@@ -9819,12 +9933,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -10402,6 +10532,27 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.2.7': {}
 
   '@next/swc-darwin-arm64@16.2.7':
@@ -10652,49 +10803,97 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.138.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.138.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-gnu@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-musl@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.138.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.130.0':
@@ -10704,13 +10903,29 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.138.0':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.130.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.130.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
     optional: true
 
   '@oxc-project/types@0.110.0': {}
@@ -10718,6 +10933,8 @@ snapshots:
   '@oxc-project/types@0.130.0': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@oxc-project/types@0.138.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
     optional: true
@@ -10767,9 +10984,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12483,9 +12700,9 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12495,7 +12712,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
@@ -12942,6 +13159,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.8
@@ -13149,6 +13371,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@5.1.3(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.2
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/browser-playwright@4.1.8(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(playwright@1.58.1)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(vitest@4.1.8)
@@ -13156,6 +13390,20 @@ snapshots:
       playwright: 1.58.1
       tinyrainbow: 3.1.0
       vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.8(playwright@1.58.1)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
+      playwright: 1.58.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13178,6 +13426,24 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
+
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)':
     dependencies:
@@ -13191,9 +13457,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -13213,7 +13479,19 @@ snapshots:
       msw: 2.14.6(@types/node@24.10.10)(typescript@5.9.3)
       vite: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0)
+
   '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
@@ -13234,6 +13512,12 @@ snapshots:
   '@vitest/utils@4.1.8':
     dependencies:
       '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -13454,6 +13738,8 @@ snapshots:
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
+
+  cac@7.0.0: {}
 
   cacache@17.1.4:
     dependencies:
@@ -13810,9 +14096,9 @@ snapshots:
 
   dotenv@17.2.3: {}
 
-  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
+  dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
     optionalDependencies:
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14309,8 +14595,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-up-simple@1.0.1: {}
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -14369,7 +14653,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@orama/orama': 3.1.18
@@ -14392,21 +14676,21 @@ snapshots:
       '@tanstack/react-router': 1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.7)
-      next: 16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)):
+  fumadocs-mdx@13.0.2(fumadocs-core@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.0.0
       chokidar: 4.0.3
       esbuild: 0.25.12
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      fumadocs-core: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       js-yaml: 4.1.1
       lru-cache: 11.2.5
       mdast-util-to-markdown: 2.1.2
@@ -14420,13 +14704,13 @@ snapshots:
       unist-util-visit: 5.0.0
       zod: 4.3.6
     optionalDependencies:
-      next: 16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       vite: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(tailwindcss@4.1.18):
+  fumadocs-ui@16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(tailwindcss@4.1.18):
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -14439,7 +14723,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      fumadocs-core: 16.0.4(@tanstack/react-router@1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       lodash.merge: 4.6.2
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       postcss-selector-parser: 7.1.1
@@ -14450,7 +14734,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@mixedbread/sdk'
@@ -14938,7 +15222,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knip@6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  knip@6.14.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
@@ -14946,7 +15230,7 @@ snapshots:
       jiti: 2.7.0
       minimist: 1.2.8
       oxc-parser: 0.130.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       picomatch: 4.0.4
       smol-toml: 1.6.1
       strip-json-comments: 5.0.3
@@ -16050,32 +16334,6 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@next/env': 16.2.7
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.9
-      caniuse-lite: 1.0.30001751
-      postcss: 8.4.31
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.7
-      '@next/swc-darwin-x64': 16.2.7
-      '@next/swc-linux-arm64-gnu': 16.2.7
-      '@next/swc-linux-arm64-musl': 16.2.7
-      '@next/swc-linux-x64-gnu': 16.2.7
-      '@next/swc-linux-x64-musl': 16.2.7
-      '@next/swc-win32-arm64-msvc': 16.2.7
-      '@next/swc-win32-x64-msvc': 16.2.7
-      '@playwright/test': 1.58.1
-      babel-plugin-react-compiler: 1.0.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.7
@@ -16086,32 +16344,6 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.7
-      '@next/swc-darwin-x64': 16.2.7
-      '@next/swc-linux-arm64-gnu': 16.2.7
-      '@next/swc-linux-arm64-musl': 16.2.7
-      '@next/swc-linux-x64-gnu': 16.2.7
-      '@next/swc-linux-x64-musl': 16.2.7
-      '@next/swc-win32-arm64-msvc': 16.2.7
-      '@next/swc-win32-x64-msvc': 16.2.7
-      '@playwright/test': 1.58.1
-      babel-plugin-react-compiler: 1.0.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@16.2.7(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@next/env': 16.2.7
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.9
-      caniuse-lite: 1.0.30001751
-      postcss: 8.4.31
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.7
       '@next/swc-darwin-x64': 16.2.7
@@ -16193,7 +16425,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/react': 2.17.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       '@tanstack/react-router': 1.158.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next: 16.2.7(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.58.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-router: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-router-dom: 6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
@@ -16311,7 +16543,32 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.130.0
       '@oxc-parser/binding-win32-x64-msvc': 0.130.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-parser@0.138.0:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.138.0
+      '@oxc-parser/binding-android-arm64': 0.138.0
+      '@oxc-parser/binding-darwin-arm64': 0.138.0
+      '@oxc-parser/binding-darwin-x64': 0.138.0
+      '@oxc-parser/binding-freebsd-x64': 0.138.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.138.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.138.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.138.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.138.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.138.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.138.0
+      '@oxc-parser/binding-linux-x64-musl': 0.138.0
+      '@oxc-parser/binding-openharmony-arm64': 0.138.0
+      '@oxc-parser/binding-wasm32-wasi': 0.138.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.138.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.138.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.138.0
+
+  oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -16329,7 +16586,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -17091,23 +17348,23 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.21.8(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3):
+  rolldown-plugin-dts@0.21.8(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-beta.4
       '@babel/parser': 8.0.0-beta.4
       '@babel/types': 8.0.0-beta.4
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       get-tsconfig: 4.14.0
       obug: 2.1.1
-      rolldown: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  rolldown@1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.110.0
       '@rolldown/pluginutils': 1.0.0-rc.1
@@ -17122,7 +17379,7 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
     transitivePeerDependencies:
@@ -17622,24 +17879,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.7):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 7.29.0
-
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
       '@babel/core': 7.29.7
-
-  styled-jsx@5.1.6(react@19.2.7):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.7
 
   supports-color@7.2.0:
     dependencies:
@@ -17744,7 +17989,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.20.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.17)(typescript@5.9.3):
+  tsdown@0.20.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -17754,16 +17999,15 @@ snapshots:
       import-without-cache: 0.2.5
       obug: 2.1.1
       picomatch: 4.0.4
-      rolldown: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      rolldown-plugin-dts: 0.21.8(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@5.9.3)
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      rolldown-plugin-dts: 0.21.8(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.4.2
-      unrun: 0.2.26(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      unrun: 0.2.26(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optionalDependencies:
-      publint: 0.3.17
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -17775,6 +18019,16 @@ snapshots:
       - vue-tsc
 
   tslib@2.8.1: {}
+
+  tsnapi@1.0.0(vitest@4.1.8):
+    dependencies:
+      '@vitest/utils': 4.1.9
+      cac: 7.0.0
+      magic-string: 0.30.21
+      oxc-parser: 0.138.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
 
   tsx@4.20.4:
     dependencies:
@@ -17944,9 +18198,9 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unrun@0.2.26(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  unrun@0.2.26(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
-      rolldown: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -18176,19 +18430,28 @@ snapshots:
       tsx: 4.20.4
       yaml: 2.9.0
 
+  vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.10.10
+      esbuild: 0.27.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
+
   vitest-browser-react@2.0.4(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.10
       '@types/react-dom': 19.2.3(@types/react@19.2.10)
-
-  vitest-package-exports@1.1.2:
-    dependencies:
-      find-up-simple: 1.0.1
-      pathe: 2.0.3
 
   vitest@4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0)):
     dependencies:
@@ -18215,6 +18478,35 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.10
       '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@24.10.10)(typescript@5.9.3))(playwright@1.58.1)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.20.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@types/node@24.10.10)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.10
+      '@vitest/browser-playwright': 4.1.8(playwright@1.58.1)(vite@8.0.16(@types/node@24.10.10)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
The runtime-exports snapshot couldn't detect changes to exported types, which matters for barrel-exposing files like `parsers.ts`. Its provider (vitest-package-exports) is now deprecated in favour of [tsnapi](https://github.com/antfu/tsnapi), which extends the same idea to type declarations: each entry point gets a committed `.snapshot.js` + `.snapshot.d.ts` pair under `packages/nuqs/tests/snapshots/`, so API changes show up as reviewable diffs.

tsnapi's vitest helper doesn't resolve the shared type chunks tsdown emits (nor its `.js` dts specifiers), so the test canonicalizes import specifiers and feeds tsnapi a hand-built chunk-sources map — chunk-hosted types keep their full declarations instead of collapsing to bare re-exports, and snapshots are immune to chunk-hash churn. This shim is a candidate for upstreaming as a tsnapi option.

The old test also import-executed every dist entry point as a side effect; that coverage is kept explicit with a per-entry dynamic-import test, plus guards against orphaned snapshots, unresolved re-exports, and entry points missing from tsnapi's enumeration.

Closes #1059.