### PR TITLE
ref: drop URL.canParse feature detection

### DIFF
--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -154,7 +154,7 @@ function extractSearchParams(input: LoaderInput): URLSearchParams {
       return searchParams
     }
     if (typeof input === 'string') {
-      if (URL.hasOwnProperty('canParse') && URL.canParse(input)) {
+      if (URL.canParse(input)) {
         return new URL(input).searchParams
       }
       return new URLSearchParams(input)


### PR DESCRIPTION
`URL.canParse` is Baseline widely available across all supported runtimes, so the `hasOwnProperty` guard that fell back to `new URLSearchParams` is no longer needed.