### PR TITLE
doc: remove stale SinceVersion gates for 2.9.0

### DIFF
--- a/packages/docs/CLAUDE.md
+++ b/packages/docs/CLAUDE.md
@@ -1,0 +1,39 @@
+# Docs authoring
+
+nuqs.dev deploys to production from `next`, so docs for a feature can go live
+before the feature ships on npm. Gate any documentation for an unreleased
+feature behind `<SinceVersion>` so it stays hidden in production until its
+version reaches npm's `latest`, while still showing (with a cue) on preview and
+local. See [#1454](https://github.com/47ng/nuqs/pull/1454) for the mechanism.
+
+## Gating unreleased content
+
+Wrap the new content in `<SinceVersion v="x.y.z">`, where `x.y.z` is the nuqs
+version the feature ships in:
+
+```mdx
+<SinceVersion v="2.10.0">
+
+## My new feature
+
+...
+
+</SinceVersion>
+```
+
+Use `disclaimer="inline"` to gate a single inline fragment or list item without
+breaking its host list:
+
+```mdx
+- <SinceVersion v="2.10.0" disclaimer="inline">[New adapter](#new-adapter)</SinceVersion>
+```
+
+Rules:
+
+- Gate the content in **both** `<HumanContent>` (HTML) and `<LLMContent>`
+  (`.md` for LLMs) wherever it appears in each.
+- In `<LLMContent>`, the opening and closing tags must sit on their **own
+  lines** — the Markdown stripper matches them line-by-line.
+- Once the version reaches npm's `latest`, the gate is a no-op: unwrap it,
+  keeping the inner content. Preview builds log a `[SinceVersion]` warning
+  naming each stale gate.

--- a/packages/docs/CLAUDE.md
+++ b/packages/docs/CLAUDE.md
@@ -9,7 +9,7 @@ local. See [#1454](https://github.com/47ng/nuqs/pull/1454) for the mechanism.
 ## Gating unreleased content
 
 Wrap the new content in `<SinceVersion v="x.y.z">`, where `x.y.z` is the nuqs
-version the feature ships in:
+version the feature ships in (ask the user which one to use):
 
 ```mdx
 <SinceVersion v="2.10.0">

--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -23,7 +23,7 @@ wrapping it with a `NuqsAdapter{:ts}` context provider:
 - <Remix className='inline mr-1.5' role="presentation" /> [Remix](#remix)
 - <ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v6](#react-router-v6)
 - <ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v7](#react-router-v7)
-- <SinceVersion v="2.9.0" disclaimer="inline"><ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v8](#react-router-v8)</SinceVersion>
+- <ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v8](#react-router-v8)
 - <TanStackRouter className='inline mr-1.5 not-prose' role="presentation"/> [TanStack Router](#tanstack-router)
 </HumanContent>
 
@@ -34,9 +34,7 @@ wrapping it with a `NuqsAdapter{:ts}` context provider:
 - [Remix](#remix)
 - [React Router v6](#react-router-v6)
 - [React Router v7](#react-router-v7)
-<SinceVersion v="2.9.0">
 - [React Router v8](#react-router-v8)
-</SinceVersion>
 - [TanStack Router](#tanstack-router)
 </LLMContent>
 
@@ -169,7 +167,7 @@ export default function App() {
   no longer receives security updates. The `nuqs/adapters/remix` adapter will be
   removed in nuqs@3.0.0.
 
-  Remix has converged into React Router. Migrate to [React Router v7](#react-router-v7)<SinceVersion v="2.9.0" disclaimer="inline"> or [v8](#react-router-v8)</SinceVersion> and use the appropriate adapter below.
+  Remix has converged into React Router. Migrate to [React Router v7](#react-router-v7) or [v8](#react-router-v8) and use the appropriate adapter below.
 
 </Callout>
 
@@ -213,10 +211,10 @@ export function ReactRouter() {
 
   - `nuqs/adapters/react-router/v6`
   - `nuqs/adapters/react-router/v7`
-  - <SinceVersion v="2.9.0" disclaimer='inline'>`nuqs/adapters/react-router/v8`</SinceVersion>
+  - `nuqs/adapters/react-router/v8`
 
   The main difference is where the React Router hooks are imported from:
-  `react-router-dom` for v6, and `react-router` for v7<SinceVersion v="2.9.0" disclaimer='inline'> & v8</SinceVersion>.
+  `react-router-dom` for v6, and `react-router` for v7 & v8.
 </Callout>
 
 <Callout type="warn" title="Deprecation notice">
@@ -225,7 +223,7 @@ export function ReactRouter() {
   and no longer receives security updates. The `nuqs/adapters/react-router/v6`
   adapter will be removed in nuqs@3.0.0.
 
-  Upgrade to [React Router v7](#react-router-v7)<SinceVersion v="2.9.0" disclaimer="inline"> or [v8](#react-router-v8)</SinceVersion> and use the
+  Upgrade to [React Router v7](#react-router-v7) or [v8](#react-router-v8) and use the
   appropriate adapter below.
 
 </Callout>
@@ -247,8 +245,6 @@ export default function App() {
   )
 }
 ```
-
-<SinceVersion v="2.9.0">
 
 ## <HumanContent><ReactRouter className='inline mr-2 -mt-1' role="presentation"/></HumanContent>React Router v8 [#react-router-v8]
 
@@ -277,8 +273,6 @@ export default function App() {
   of implementation won't require changing your import.
 
 </Callout>
-
-</SinceVersion>
 
 ## <HumanContent><TanStackRouter className='inline mr-2 -mt-1 not-prose' role="presentation"/></HumanContent>TanStack Router [#tanstack-router]
 

--- a/packages/docs/content/docs/installation.mdx
+++ b/packages/docs/content/docs/installation.mdx
@@ -37,7 +37,7 @@ npm install nuqs
 - <Remix className='inline mr-1.5' role="presentation" /> [Remix](/docs/adapters#remix): `@remix-run/react@^2`
 - <ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v6](/docs/adapters#react-router-v6): `react-router-dom@^6`
 - <ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v7](/docs/adapters#react-router-v7): `react-router@^7`
-- <SinceVersion v="2.9.0" disclaimer="inline"><ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v8](/docs/adapters#react-router-v8): `react-router@^8`</SinceVersion>
+- <ReactRouter className='inline mr-1.5' role="presentation" /> [React Router v8](/docs/adapters#react-router-v8): `react-router@^8`
 - <TanStackRouter className='inline mr-1.5 not-prose' role="presentation"/> [TanStack Router](/docs/adapters#tanstack-router): `@tanstack/react-router@^1`
 </HumanContent>
 
@@ -47,9 +47,7 @@ npm install nuqs
 - [Remix](/docs/adapters#remix): `@remix-run/react@^2`
 - [React Router v6](/docs/adapters#react-router-v6): `react-router-dom@^6`
 - [React Router v7](/docs/adapters#react-router-v7): `react-router@^7`
-<SinceVersion v="2.9.0">
 - [React Router v8](/docs/adapters#react-router-v8): `react-router@^8`
-</SinceVersion>
 - [TanStack Router](/docs/adapters#tanstack-router): `@tanstack/react-router@^1`
 </LLMContent>
 

--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -404,7 +404,6 @@ adapter prop:
 </NuqsAdapter>
 ```
 
-<SinceVersion v="2.9.0">
 <Callout title="Don't break the Back button" type="warn">
 Setting `history: 'push'{:ts}` globally will add a new entry to the navigation
 history for **every** search param update across your whole app, which is likely
@@ -414,7 +413,6 @@ Prefer opting into `history: 'push'{:ts}` on a per-hook or per-call basis, only
 where the search params contribute to a navigation-like experience (eg: tabs,
 modals).
 </Callout>
-</SinceVersion>
 
 ### Processing `URLSearchParams`
 


### PR DESCRIPTION
The 2.9.0 gated features have shipped to the published GA, so their `<SinceVersion v="2.9.0">` wrappers are now no-ops. This unwraps them in the adapters, installation and options pages, keeping the inner content, for both the HTML and LLM (`.md`) variants.

Also adds a `packages/docs/CLAUDE.md` so agents fence future unreleased docs behind `<SinceVersion>` rather than shipping them to production early. See #1454 for the gating mechanism.

The `SinceVersion` component and its `stripUnreleased` plumbing stay — they remain the gate for future unreleased features.

Verified on the Vercel preview: all three pages render cleanly in both `/docs/*` (HTML) and `/llms/*` (`.md`), with the previously-gated content present and no leftover gate markup.