### PR TITLE
fix(key-isolation): unwatched keys leaking through filterSearchParams

### DIFF
--- a/packages/nuqs/src/adapters/lib/key-isolation.test.ts
+++ b/packages/nuqs/src/adapters/lib/key-isolation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { applyChange, filterSearchParams } from './key-isolation'
+
+describe('applyChange', () => {
+  it('returns the same instance when watched keys are unchanged', () => {
+    const oldValue = new URLSearchParams('keep=5&other=1')
+    const newValue = new URLSearchParams('keep=5&other=2')
+    const result = applyChange(newValue, ['keep'], false)(oldValue)
+    expect(result).toBe(oldValue)
+  })
+
+  it('returns the filtered new value when watched keys changed', () => {
+    const oldValue = new URLSearchParams('keep=5')
+    const newValue = new URLSearchParams('a=1&b=2&c=3&d=4&keep=6&e=6')
+    const result = applyChange(newValue, ['keep'], false)(oldValue)
+    expect(result.toString()).toBe('keep=6')
+  })
+})
+
+describe('filterSearchParams', () => {
+  it('removes unwatched keys without leaking entries past a deleted key', () => {
+    const search = new URLSearchParams('a=1&b=2&c=3&d=4&keep=5&e=6')
+    const filtered = filterSearchParams(search, ['keep'], false)
+    expect(filtered.toString()).toBe('keep=5')
+  })
+
+  it('leaves the original untouched when copying', () => {
+    const search = new URLSearchParams('a=1&b=2&c=3&d=4&keep=5&e=6')
+    const filtered = filterSearchParams(search, ['keep'], true)
+    expect(filtered.toString()).toBe('keep=5')
+    expect(search.toString()).toBe('a=1&b=2&c=3&d=4&keep=5&e=6')
+  })
+
+  it('returns the same instance untouched when no keys are watched', () => {
+    const search = new URLSearchParams('a=1&b=2')
+    const filtered = filterSearchParams(search, [], false)
+    expect(filtered).toBe(search)
+    expect(filtered.toString()).toBe('a=1&b=2')
+  })
+
+  it('keeps all values of a multi-value watched key and drops unwatched ones', () => {
+    const search = new URLSearchParams('tag=a&x=1&tag=b')
+    const filtered = filterSearchParams(search, ['tag'], false)
+    expect(filtered.getAll('tag')).toEqual(['a', 'b'])
+    expect(filtered.has('x')).toBe(false)
+  })
+})

--- a/packages/nuqs/src/adapters/lib/key-isolation.ts
+++ b/packages/nuqs/src/adapters/lib/key-isolation.ts
@@ -32,7 +32,7 @@ export function filterSearchParams(
     return search
   }
   const filtered = copy ? new URLSearchParams(search) : search
-  for (const key of search.keys()) {
+  for (const key of Array.from(search.keys())) {
     if (!keys.includes(key)) {
       filtered.delete(key)
     }


### PR DESCRIPTION
URLSearchParams iterators are live: deleting the current entry while iterating shifts the index, so the entry right after every deleted key is skipped and survives the filter.

filterSearchParams hit this whenever it mutates the same object it iterates (copy: false), which is the case in the react adapter's getSnapshot and in the react-router popstate handler. Unwatched keys leaked into a hook's filtered snapshot, breaking key isolation between hooks and causing unrelated key changes to trigger re-renders.

Fix: snapshot the keys with Array.from before deleting, detaching iteration from the live collection.