### PR TITLE
test: run repro-1358 spec on react-router v8

### DIFF
--- a/packages/e2e/react-router/v8/app/routes.ts
+++ b/packages/e2e/react-router/v8/app/routes.ts
@@ -64,6 +64,8 @@ export default [
     route('/repro-1099/useQueryStates', './routes/repro-1099.useQueryStates.tsx'),
     route('/repro-1293/a',              './routes/repro-1293.a.tsx'),
     route('/repro-1293/b',              './routes/repro-1293.b.tsx'),
+    route('/repro-1358/a',              './routes/repro-1358.a.tsx'),
+    route('/repro-1358/b',              './routes/repro-1358.b.tsx'),
     route('/repro-1365',                './routes/repro-1365.tsx'),
     route('/repro-1444',                './routes/repro-1444.tsx'),
   ])

--- a/packages/e2e/react-router/v8/app/routes/repro-1358.a.tsx
+++ b/packages/e2e/react-router/v8/app/routes/repro-1358.a.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteA } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteA otherPageHref="/repro-1358/b" />
+}

--- a/packages/e2e/react-router/v8/app/routes/repro-1358.b.tsx
+++ b/packages/e2e/react-router/v8/app/routes/repro-1358.b.tsx
@@ -1,0 +1,5 @@
+import { Repro1358RouteB } from 'e2e-shared/specs/repro-1358'
+
+export default function Page() {
+  return <Repro1358RouteB otherPageHref="/repro-1358/a" />
+}

--- a/packages/e2e/react-router/v8/specs/shared/repro-1358.spec.ts
+++ b/packages/e2e/react-router/v8/specs/shared/repro-1358.spec.ts
@@ -1,0 +1,5 @@
+import { testRepro1358 } from 'e2e-shared/specs/repro-1358.spec.ts'
+
+testRepro1358({
+  path: '/repro-1358'
+})


### PR DESCRIPTION
The repro-1358 regression guard (stale derived state leaking across route
navigations) ran on react-router v6 and v7 but not v8, the newest supported
major. This mirrors the existing v7 fixtures and spec wiring onto v8 so a
v8-specific regression here wouldn't ship undetected.