### PR TITLE
fix: support multi-value search params in createSearchParamsCache

### DIFF
--- a/packages/nuqs/src/cache.test.ts
+++ b/packages/nuqs/src/cache.test.ts
@@ -193,6 +193,11 @@ describe('cache', () => {
         compareSearchParams({ q: 'x', empty: undefined }, { q: 'x' })
       ).toBe(false)
     })
+    it('rejects an absent key vs a key with an undefined value', () => {
+      expect(
+        compareSearchParams({ q: 'x' }, { q: 'x', empty: undefined })
+      ).toBe(false)
+    })
     it('accepts both values being undefined', () => {
       expect(compareSearchParams({ q: undefined }, { q: undefined })).toBe(true)
     })

--- a/packages/nuqs/src/cache.test.ts
+++ b/packages/nuqs/src/cache.test.ts
@@ -163,10 +163,38 @@ describe('cache', () => {
       const array = ['a', 'b']
       expect(compareSearchParams({ x: array }, { x: array })).toBe(true)
     })
-    it('does not do deep comparison', () => {
+    it('does a deep comparison of array values', () => {
       expect(compareSearchParams({ x: ['a', 'b'] }, { x: ['a', 'b'] })).toBe(
+        true
+      )
+    })
+    it('rejects different array values', () => {
+      expect(
+        compareSearchParams({ tag: ['a', 'b'] }, { tag: ['a', 'c'] })
+      ).toBe(false)
+    })
+    it('rejects different array lengths', () => {
+      expect(compareSearchParams({ tag: ['a'] }, { tag: ['a', 'b'] })).toBe(
         false
       )
+    })
+    it('rejects an array compared to a string', () => {
+      expect(compareSearchParams({ tag: ['a'] }, { tag: 'a' })).toBe(false)
+    })
+    it('accepts equal strings', () => {
+      expect(compareSearchParams({ q: 'x' }, { q: 'x' })).toBe(true)
+    })
+    it('accepts the same object reference', () => {
+      const p = { q: 'x' }
+      expect(compareSearchParams(p, p)).toBe(true)
+    })
+    it('rejects a key with an undefined value vs an absent key', () => {
+      expect(
+        compareSearchParams({ q: 'x', empty: undefined }, { q: 'x' })
+      ).toBe(false)
+    })
+    it('accepts both values being undefined', () => {
+      expect(compareSearchParams({ q: undefined }, { q: undefined })).toBe(true)
     })
   })
 })

--- a/packages/nuqs/src/cache.ts
+++ b/packages/nuqs/src/cache.ts
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import type { SearchParams, UrlKeys } from './defs'
+import { compareQuery } from './lib/compare'
 import { error } from './lib/errors'
 import { createLoader, type LoaderFunctionOptions } from './loader'
 import type { inferParserType, ParserMap } from './parsers'
@@ -144,7 +145,7 @@ export function compareSearchParams(a: SearchParams, b: SearchParams): boolean {
     return false
   }
   for (const key in a) {
-    if (a[key] !== b[key]) {
+    if (!compareQuery(a[key] ?? null, b[key] ?? null)) {
       return false
     }
   }


### PR DESCRIPTION
compareSearchParams compared string[] values with !==, so equal-content arrays from different sources are never equal. Next.js can hand distinct-but-equal searchParams objects to different consumers in the same request (e.g. generateMetadata and the page), so any second parse() call on a multi-value param (?tag=a&tag=b) threw a spurious NUQS-501 "different inputs" error.

Fixes it by reusing the existing compareQuery helper (already used elsewhere for string[] value comparison) for a deep, element-wise comparison instead of reference equality.

Note: this means `createSearchParamsCache` now supports deep-comparison of arrays of search params, which it didn't before.