### PR TITLE
ci: pass ISR token and dispatch inputs via env in nextjs-release workflows

### DIFF
--- a/.github/workflows/analyse-nextjs-release.yml
+++ b/.github/workflows/analyse-nextjs-release.yml
@@ -42,9 +42,9 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install --filter scripts...
+        run: pnpm install --frozen-lockfile --ignore-scripts --filter scripts...
       - name: Check for changes in app router
-        run: ./next-release-analyser.ts --version "${{ env.VERSION }}"
+        run: ./next-release-analyser.ts --version "$VERSION"
         working-directory: packages/scripts
         env:
           MAILPACE_API_TOKEN: ${{ secrets.MAILPACE_API_TOKEN }}

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -50,9 +50,9 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Install Next.js version ${{ env.VERSION }}
-        run: pnpm add --filter e2e-next --filter nuqs --config.minimumReleaseAgeExclude=next "next@${{ env.VERSION }}"
+        run: pnpm add --filter e2e-next --filter nuqs --config.minimumReleaseAgeExclude=next "next@$VERSION"
       - name: Run cacheComponents codemod
         if: ${{ matrix.cache-components }}
         run: pnpm run cacheComponents:codemod
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter docs...
       - name: Install Next.js version ${{ env.VERSION }}
-        run: pnpm add --filter docs --filter nuqs "next@${{ env.VERSION }}"
+        run: pnpm add --filter docs --filter nuqs "next@$VERSION"
       # TURBO_TOKEN/TURBO_TEAM are intentionally omitted below: these steps
       # execute an arbitrary, caller-supplied Next.js version, so a compromised
       # release must not be able to exfiltrate or poison the shared Turborepo
@@ -132,7 +132,15 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Invalidate ISR cache for GitHub Actions status on landing page
-        run: curl -s "https://nuqs.dev/api/isr?tag=github-actions-status&token=${{ secrets.ISR_TOKEN }}"
+        run: |
+          set -euo pipefail
+          : "${ISR_TOKEN:?secret is empty or unset; cannot bust the ISR cache}"
+          curl -fsSL "https://nuqs.dev/api/isr?tag=github-actions-status&token=$ISR_TOKEN"
+        env:
+          # Passed via env and read as $ISR_TOKEN at runtime, so the literal
+          # secret never appears in the workflow YAML text (same stance as
+          # release-finalize.yml).
+          ISR_TOKEN: ${{ secrets.ISR_TOKEN }}
 
   notify:
     name: Notify on Slack


### PR DESCRIPTION
These two workflows drifted from the env-var secret/input pattern the rest of the CI pipeline already uses and documents: `ISR_TOKEN` was interpolated straight into a curl command line instead of passed via `env:`, and the `workflow_dispatch` `version` input was templated into run scripts via `${{ env.VERSION }}` instead of read as `$VERSION`. Neither is currently exploitable (both workflows require write access to trigger), this is defense-in-depth consistency with the maintainer's own stance already applied elsewhere (see `release-finalize.yml`). Also brings both installs in line with the rest of the repo's `--frozen-lockfile` (and `--ignore-scripts` for the scripts-only job) convention.

There is no local execution path for these workflows; a post-merge `workflow_dispatch` of both is the real verification.

Closes nothing (internal hardening, no linked issue).