### PR TITLE
fix: preserve hash fragment in createSerializer bases

### DIFF
--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -249,4 +249,37 @@ describe('serializer', () => {
       expect(result).toBe('?a=1&foo=bar&z=1')
     })
   })
+  describe('hash preservation', () => {
+    it('keeps the hash with a string base and existing search', () => {
+      const serialize = createSerializer(parsers)
+      const result = serialize('/path?a=1#section', {})
+      expect(result).toBe('/path?a=1#section')
+    })
+    it('keeps the hash with a string base when adding a value', () => {
+      const serialize = createSerializer(parsers)
+      const result = serialize('/path#section', { str: 'foo' })
+      expect(result).toBe('/path?str=foo#section')
+    })
+    it('keeps the hash with a URL base', () => {
+      const serialize = createSerializer(parsers)
+      const url = new URL('https://example.com/path#section')
+      const result = serialize(url, { str: 'foo' })
+      expect(result).toBe('https://example.com/path?str=foo#section')
+    })
+    it('keeps a hash containing a ? character intact', () => {
+      const serialize = createSerializer(parsers)
+      const result = serialize('/p#frag?x', {})
+      expect(result).toBe('/p#frag?x')
+    })
+    it('keeps the hash when clearing all params with a global null', () => {
+      const serialize = createSerializer(parsers)
+      const result = serialize('/path?str=foo#section', null)
+      expect(result).toBe('/path#section')
+    })
+    it('leaves paths without a hash unchanged', () => {
+      const serialize = createSerializer(parsers)
+      const result = serialize('/path', {})
+      expect(result).toBe('/path')
+    })
+  })
 })

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -67,9 +67,9 @@ export function createSerializer<
     arg1BaseOrValues: BaseType | Values,
     arg2values: Values | null = {}
   ) {
-    let [base, search] = isBase<BaseType>(arg1BaseOrValues)
+    let [base, search, hash] = isBase<BaseType>(arg1BaseOrValues)
       ? splitBase(arg1BaseOrValues)
-      : ['', new URLSearchParams()]
+      : ['', new URLSearchParams(), '']
     const values = isBase(arg1BaseOrValues) ? arg2values : arg1BaseOrValues
     if (values === null) {
       for (const key in parsers) {
@@ -79,7 +79,7 @@ export function createSerializer<
       if (processUrlSearchParams) {
         search = processUrlSearchParams(search)
       }
-      return (base + renderQueryString(search)) as Return
+      return (base + renderQueryString(search) + hash) as Return
     }
     for (const key in parsers) {
       const parser = parsers[key]
@@ -106,7 +106,7 @@ export function createSerializer<
     if (processUrlSearchParams) {
       search = processUrlSearchParams(search)
     }
-    return base + renderQueryString(search)
+    return base + renderQueryString(search) + hash
   }
   return serialize
 }
@@ -121,14 +121,17 @@ function isBase<BaseType>(base: any): base is BaseType {
 
 function splitBase<BaseType extends Base>(base: BaseType) {
   if (typeof base === 'string') {
-    const [path = '', ...search] = base.split('?')
-    return [path, new URLSearchParams(search.join('?'))] as const
+    const [pathAndSearch = '', ...hashParts] = base.split('#')
+    const hash = hashParts.length ? '#' + hashParts.join('#') : ''
+    const [path = '', ...search] = pathAndSearch.split('?')
+    return [path, new URLSearchParams(search.join('?')), hash] as const
   } else if (base instanceof URLSearchParams) {
-    return ['', new URLSearchParams(base)] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
+    return ['', new URLSearchParams(base), ''] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
   } else {
     return [
       base.origin + base.pathname,
-      new URLSearchParams(base.searchParams)
+      new URLSearchParams(base.searchParams),
+      base.hash
     ] as const
   }
 }


### PR DESCRIPTION
URL bases silently dropped the #hash fragment, and string bases folded it into the last query param value (later percent-encoded), corrupting links built off anchored pages such as pagination or share links.

Threads the hash through createSerializer's base-splitting logic so it survives both string and URL bases, and is preserved when clearing all params via a global null.