### PR TITLE
fix: honor call > parser > global precedence for limitUrlUpdates

### DIFF
--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -876,6 +876,119 @@ describe('useQueryStates: update sequencing', () => {
   })
 })
 
+describe('limitUrlUpdates precedence', () => {
+  it('call-level throttle overrides global debounce', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(
+      () =>
+        useQueryStates(
+          { test: parseAsString },
+          { limitUrlUpdates: debounce(300) }
+        ),
+      {
+        wrapper: withNuqsTestingAdapter({
+          onUrlUpdate
+        })
+      }
+    )
+    let p: Promise<URLSearchParams> | undefined = undefined
+    await act(async () => {
+      p = result.current[1]({ test: 'pass' }, { limitUrlUpdates: throttle(50) })
+      await waitForNextTick()
+    })
+    // A real throttle flushes on the next tick.
+    // A debounce would still be waiting out its timer.
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?test=pass')
+    await expect(p).resolves.toEqual(new URLSearchParams('?test=pass'))
+  })
+
+  it('parser-level throttle overrides global debounce', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(
+      () =>
+        useQueryStates(
+          {
+            test: parseAsString.withOptions({
+              limitUrlUpdates: throttle(50)
+            })
+          },
+          { limitUrlUpdates: debounce(300) }
+        ),
+      {
+        wrapper: withNuqsTestingAdapter({
+          onUrlUpdate
+        })
+      }
+    )
+    let p: Promise<URLSearchParams> | undefined = undefined
+    await act(async () => {
+      p = result.current[1]({ test: 'pass' })
+      await waitForNextTick()
+    })
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?test=pass')
+    await expect(p).resolves.toEqual(new URLSearchParams('?test=pass'))
+  })
+
+  it('parser-level debounce timeMs overrides global debounce timeMs', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(
+      () =>
+        useQueryStates(
+          {
+            test: parseAsString.withOptions({
+              limitUrlUpdates: debounce(50)
+            })
+          },
+          { limitUrlUpdates: debounce(500) }
+        ),
+      {
+        wrapper: withNuqsTestingAdapter({
+          onUrlUpdate
+        })
+      }
+    )
+    let p: Promise<URLSearchParams> | undefined = undefined
+    await act(async () => {
+      p = result.current[1]({ test: 'pass' })
+      // Past the parser's 50ms debounce.
+      // Short of the global 500ms one.
+      await new Promise(resolve => setTimeout(resolve, 150))
+    })
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?test=pass')
+    await expect(p).resolves.toEqual(new URLSearchParams('?test=pass'))
+  })
+
+  it('parser-level debounce alone still debounces (no global set)', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(
+      () =>
+        useQueryStates({
+          test: parseAsString.withOptions({
+            limitUrlUpdates: debounce(100)
+          })
+        }),
+      {
+        wrapper: withNuqsTestingAdapter({
+          onUrlUpdate
+        })
+      }
+    )
+    let p: Promise<URLSearchParams> | undefined = undefined
+    await act(async () => {
+      p = result.current[1]({ test: 'pass' })
+      await waitForNextTick()
+    })
+    // Still pending: the debounce timer hasn't elapsed yet.
+    expect(onUrlUpdate).not.toHaveBeenCalled()
+    await expect(p).resolves.toEqual(new URLSearchParams('?test=pass'))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?test=pass')
+  })
+})
+
 describe('useQueryStates: adapter defaults', () => {
   it('should use adapter default value for `shallow` when provided', async () => {
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -333,16 +333,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
               startTransition
           }
         }
-        if (
-          callOptions?.limitUrlUpdates?.method === 'debounce' ||
-          limitUrlUpdates?.method === 'debounce' ||
-          parser.limitUrlUpdates?.method === 'debounce'
-        ) {
+        const resolvedLimitUrlUpdates =
+          callOptions.limitUrlUpdates ??
+          parser.limitUrlUpdates ??
+          limitUrlUpdates
+        if (resolvedLimitUrlUpdates?.method === 'debounce') {
           const timeMs =
-            callOptions?.limitUrlUpdates?.timeMs ??
-            limitUrlUpdates?.timeMs ??
-            parser.limitUrlUpdates?.timeMs ??
-            defaultRateLimit.timeMs
+            resolvedLimitUrlUpdates.timeMs ?? defaultRateLimit.timeMs
           const debouncedPromise = debounceController.push(
             update,
             timeMs,
@@ -357,9 +354,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           }
         } else {
           const timeMs =
-            callOptions?.limitUrlUpdates?.timeMs ??
-            parser?.limitUrlUpdates?.timeMs ??
-            limitUrlUpdates?.timeMs ??
+            resolvedLimitUrlUpdates?.timeMs ??
             callOptions.throttleMs ??
             parser.throttleMs ??
             throttleMs


### PR DESCRIPTION
The debounce-vs-throttle branch decision and its timeMs resolution each checked call, parser, and global limitUrlUpdates options in inconsistent orders. A global debounce() could silently win over a call- or parser-level throttle(), and timeMs could resolve from the wrong source in a debounce-vs-debounce case.

This contradicted the documented call > parser > global precedence (the same precedence already used for history/shallow/scroll/startTransition). The fix resolves a single limit object from call ?? parser ?? global and reads both method and timeMs off it.

Observable behavior change: multi-level configs that set limitUrlUpdates at more than one level will now follow the documented precedence, where before the global setting could take priority regardless of call/parser intent.