### PR TITLE
doc: fix stale build/test guidance and document the fast test loop

### DIFF
--- a/.agents/docs/quality-standards.md
+++ b/.agents/docs/quality-standards.md
@@ -179,10 +179,13 @@ Enable debug logs when investigating:
 localStorage.setItem('debug', 'nuqs')
 ```
 
-Use prefixes:
+Use prefixes (see `packages/nuqs/src/lib/debug-messages.ts` for the full catalog):
 
-- `[nuqs]` — Single-key hook operations
-- `[nuq+]` — Multi-key hook operations
+- `[nuq+ …]` — hook-level (useQueryStates) messages
+- `[nuqs gtq]` — global throttle queue
+- `[nuqs dq]` / `[nuqs dqc]` — debounce queue / controller
+- `[nuqs <adapter>]` — adapter URL updates (e.g. `[nuqs react]`)
+- `[nuqs]` — everything else (queue reset, safe-parse, key isolation)
 
 Capture debug output for:
 

--- a/.agents/docs/testing.md
+++ b/.agents/docs/testing.md
@@ -12,25 +12,46 @@ pnpm test
 
 This takes **5-10 minutes** and includes:
 
-- Build (tsup)
+- Build (tsdown)
 - Unit tests
 - Type-level tests
 - End-to-end tests
 
 Do not time out the full suite.
 
+### Fast Inner Loop
+
+For quick iteration, run these directly against `packages/nuqs` instead of the
+full suite:
+
+```bash
+pnpm --filter nuqs test:unit    # vitest, Node-only, seconds
+pnpm --filter nuqs test:types   # type-level tests
+pnpm --filter nuqs test:browser # needs `playwright install chromium`
+pnpm --filter nuqs test:size    # bundle size budget
+```
+
+Run `pnpm --filter nuqs build` once first: `api.test.ts`, type-level tests
+and the size budget read `dist/`.
+
+Reserve the full `pnpm test` for pre-push validation.
+
 ## Test Categories
 
 ### Unit Tests
 
-**Where:** `packages/nuqs/tests/*.test.ts`
+**Where:** `packages/nuqs/src/**/*.test.ts(x)` (colocated with the source; `tests/` holds type-level tests and their fixtures)
 
-Test hooks with `NuqsTestingAdapter`:
+**Browser tests:** `packages/nuqs/src/**/*.browser.test.ts(x)` — use `vitest-browser-react` and `withNuqsTestingAdapter` (see `src/useQueryStates.browser.test.tsx`):
 
 ```ts
-import { NuqsTestingAdapter } from 'nuqs/adapters/testing'
-import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook } from 'vitest-browser-react'
+import { withNuqsTestingAdapter, type OnUrlUpdateFunction } from './adapters/testing'
 ```
+
+Outside the package, import the adapter from the public entry point
+`nuqs/adapters/testing` instead of the relative path.
 
 Coverage:
 
@@ -46,7 +67,7 @@ Coverage:
 Add type tests when updating type definitions:
 
 ```ts
-import { expectType, expectAssignable } from 'tsd'
+import { assertType, describe, expectTypeOf, it } from 'vitest'
 ```
 
 Coverage:
@@ -145,17 +166,17 @@ describe('parseAsCustomType', () => {
 ### Testing Hook Behavior
 
 ```ts
-it('updates state and URL together', () => {
-  const { result } = renderHook(() => useQueryState('key', parseAsInteger), {
-    wrapper: NuqsTestingAdapter
+it('updates state and URL together', async () => {
+  const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+  const useTestHook = () => useQueryState('key', parseAsInteger)
+  const { result, act } = await renderHook(useTestHook, {
+    wrapper: withNuqsTestingAdapter({ onUrlUpdate })
   })
 
-  act(() => {
-    result.current[1](42)
-  })
+  await act(() => result.current[1](42))
 
   expect(result.current[0]).toBe(42)
-  // Verify URL updated via NuqsTestingAdapter
+  expect(onUrlUpdate).toHaveBeenCalledOnce()
 })
 ```
 
@@ -183,10 +204,13 @@ afterEach(() => {
 })
 ```
 
-Debug output:
+Debug output (see `packages/nuqs/src/lib/debug-messages.ts` for the full catalog):
 
-- `[nuqs]` — Single-key operations
-- `[nuq+]` — Multi-key operations
+- `[nuq+ …]` — hook-level (useQueryStates) messages
+- `[nuqs gtq]` — global throttle queue
+- `[nuqs dq]` / `[nuqs dqc]` — debounce queue / controller
+- `[nuqs <adapter>]` — adapter URL updates (e.g. `[nuqs react]`)
+- `[nuqs]` — everything else (queue reset, safe-parse, key isolation)
 
 ## CI/CD Integration
 

--- a/.agents/docs/testing.md
+++ b/.agents/docs/testing.md
@@ -19,7 +19,7 @@ This takes **5-10 minutes** and includes:
 
 Do not time out the full suite.
 
-### Fast Inner Loop
+### Fast Agentic Loop
 
 For quick iteration, run these directly against `packages/nuqs` instead of the
 full suite:
@@ -34,8 +34,6 @@ pnpm --filter nuqs test:size    # bundle size budget
 Run `pnpm --filter nuqs build` once first: `api.test.ts`, type-level tests
 and the size budget read `dist/`.
 
-Reserve the full `pnpm test` for pre-push validation.
-
 ## Test Categories
 
 ### Unit Tests
@@ -47,7 +45,10 @@ Reserve the full `pnpm test` for pre-push validation.
 ```ts
 import { describe, expect, it, vi } from 'vitest'
 import { renderHook } from 'vitest-browser-react'
-import { withNuqsTestingAdapter, type OnUrlUpdateFunction } from './adapters/testing'
+import {
+  withNuqsTestingAdapter,
+  type OnUrlUpdateFunction
+} from './adapters/testing'
 ```
 
 Outside the package, import the adapter from the public entry point

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Refer to: [README.md](README.md) & [CONTRIBUTING.md](CONTRIBUTING.md) for author
 - **Package manager:** `pnpm`
 - **Build:** `pnpm build`
 - **Test suite:** `pnpm test` (5-10 minutes; includes build + unit + typing + e2e)
+- **Fast checks:** `pnpm --filter nuqs test:unit` (seconds, Node-only) / `pnpm --filter nuqs test:types` for quick iteration (both need `pnpm --filter nuqs build` first)
 - **Development:** `pnpm dev --filter <package-name>...` (triple dots start dependencies' dev script too)
 
 ---
@@ -82,7 +83,7 @@ In server or Node environments (e.g. when using `nuqs/server`), set the `DEBUG` 
 DEBUG=nuqs pnpm dev
 ```
 
-Log lines are prefixed with `[nuq+]`
+Hook-level logs are prefixed with `[nuq+ …]`; internal subsystems use `[nuqs <subsystem>]` (see `packages/nuqs/src/lib/debug-messages.ts` for the catalog).
 
 Encourage debug logs in issue reports and include them in reproduction scripts.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,13 @@ node --run setup:hooks
 This monorepo contains:
 
 - The source code for the `nuqs` NPM package, in [`packages/nuqs`](./packages/nuqs).
-- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>
+- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. Copy [`packages/docs/.env.example`](./packages/docs/.env.example) to `.env.local` for the env vars local docs dev needs.
 - Test benches for [end-to-end tests](./packages/e2e) for each supported framework, driven by Playwright
 - Examples of integration with other tools.
 
-When running `next dev`, this will:
+When running `pnpm dev`, this will:
 
-- Build the library and watch for changes using [`tsup`](https://tsup.egoist.dev/)
+- Build the library and watch for changes using [`tsdown`](https://tsdown.dev)
 - Start the docs app, which will be available at <http://localhost:3000>.
 - Start the end-to-end test benches:
   - http://localhost:3001 - [Next.js](./packages/e2e/next)
@@ -58,6 +58,11 @@ run the end-to-end tests against the test bench apps (which uses the built libra
 When proposing changes or fixing a bug, adding tests (unit or in the
 appropriate e2e test environment) can help tremendously to validate and
 understand the changes.
+
+For a fast inner loop, run `pnpm --filter nuqs test:unit` (seconds, Node-only)
+or `pnpm --filter nuqs test:types` instead of the full suite — both need the
+library built first (`pnpm --filter nuqs build`). Reserve `pnpm test` for
+pre-push validation.
 
 ## Opening issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thanks for your help! 🙏
 
 1. Fork and clone the repository
 2. Install dependencies with `pnpm install`
-3. Start the development environment with `pnpm dev`
+3. Start the development environment with `pnpm dev --filter <package-name>...`
 
 ## Git hooks (optional)
 
@@ -48,6 +48,10 @@ When running `pnpm dev`, this will:
   - http://localhost:4000 - [tRPC](./packages/examples/trpc)
   - http://localhost:4001 - [Next.js - App router](./packages/examples/next-app)
 
+Since this will start a lot of processes, you may want to run `pnpm dev --filter <package-name>...`
+to only start the packages you are working on (eg: `pnpm dev --filter docs...`).
+The triple dots `...` will also start any dependencies of the package you specify.
+
 ## Testing
 
 You can run the complete integration test suite with `pnpm test` from the root of the repository.
@@ -59,10 +63,11 @@ When proposing changes or fixing a bug, adding tests (unit or in the
 appropriate e2e test environment) can help tremendously to validate and
 understand the changes.
 
-For a fast inner loop, run `pnpm --filter nuqs test:unit` (seconds, Node-only)
-or `pnpm --filter nuqs test:types` instead of the full suite — both need the
-library built first (`pnpm --filter nuqs build`). Reserve `pnpm test` for
-pre-push validation.
+For a fast inner loop, run:
+
+- `pnpm --filter nuqs build`
+- `pnpm --filter nuqs test:unit`
+- `pnpm --filter nuqs test:types`
 
 ## Opening issues
 
@@ -79,10 +84,10 @@ Make sure your changes:
 2. Pass linting checks: `pnpm lint`
 3. Have relevant documentation additions / updates (in the `packages/docs/content` and the README.md file).
 
-This repository uses [`semantic-release`](https://semantic-release.gitbook.io/semantic-release/)
-to automatically publish new versions of the package to NPM.
-To do this, the Git history follows the
-[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+for commit messages. Any bumping keywords (fix, feat, perf, etc) should be reserved to changes
+in the `nuqs` package itself (enforced in CI).
+For example, fixes in the docs are named `doc: fix <whatever>`.
 
 Pull requests should target the `next` branch.
 

--- a/README.md
+++ b/README.md
@@ -888,21 +888,17 @@ Here's an example using Testing Library and Vitest:
 ```tsx
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { NuqsTestingAdapter, type UrlUpdateEvent } from 'nuqs/adapters/testing'
+import { withNuqsTestingAdapter, type OnUrlUpdateFunction } from 'nuqs/adapters/testing'
 import { describe, expect, it, vi } from 'vitest'
 import { CounterButton } from './counter-button'
 
 it('should increment the count when clicked', async () => {
   const user = userEvent.setup()
-  const onUrlUpdate = vi.fn<[UrlUpdateEvent]>()
+  const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
   render(<CounterButton />, {
     // Setup the test by passing initial search params / querystring,
     // and give it a function to call on URL updates
-    wrapper: ({ children }) => (
-      <NuqsTestingAdapter searchParams="?count=42" onUrlUpdate={onUrlUpdate}>
-        {children}
-      </NuqsTestingAdapter>
-    )
+    wrapper: withNuqsTestingAdapter({ searchParams: '?count=42', onUrlUpdate })
   })
   // Initial state assertions: there's a clickable button displaying the count
   const button = screen.getByRole('button')
@@ -912,9 +908,10 @@ it('should increment the count when clicked', async () => {
   // Assert changes in the state and in the (mocked) URL
   expect(button).toHaveTextContent('count is 43')
   expect(onUrlUpdate).toHaveBeenCalledOnce()
-  expect(onUrlUpdate.mock.calls[0][0].queryString).toBe('?count=43')
-  expect(onUrlUpdate.mock.calls[0][0].searchParams.get('count')).toBe('43')
-  expect(onUrlUpdate.mock.calls[0][0].options.history).toBe('push')
+  const event = onUrlUpdate.mock.calls[0]![0]!
+  expect(event.queryString).toBe('?count=43')
+  expect(event.searchParams.get('count')).toBe('43')
+  expect(event.options.history).toBe('push')
 })
 ```
 
@@ -922,8 +919,15 @@ See [#259](https://github.com/47ng/nuqs/issues/259) for more testing-related dis
 
 ## Debugging
 
-You can enable debug logs in the browser by setting the `debug` item in localStorage
-to `nuqs`, and reload the page.
+You can enable debug logs in the browser by importing the `nuqs/debug`
+entry point once anywhere in your app (it keeps the log messages out of your
+bundle otherwise), then setting the `debug` item in localStorage to `nuqs`,
+and reload the page.
+
+```ts
+// Once, anywhere in your app:
+import 'nuqs/debug'
+```
 
 ```js
 // In your devtools:
@@ -933,8 +937,10 @@ localStorage.setItem('debug', 'nuqs')
 > Note: unlike the `debug` package, this will not work with wildcards, but
 > you can combine it: `localStorage.setItem('debug', '*,nuqs')`
 
-Log lines will be prefixed with `[nuqs]` for `useQueryState` and `[nuq+]` for
-`useQueryStates`, along with other internal debug logs.
+Log lines are prefixed with `[nuq+ …]` for hook-level messages, and
+`[nuqs <subsystem>]` for internal subsystems (throttle & debounce queues,
+adapters), along with other internal debug logs — see
+`packages/nuqs/src/lib/debug-messages.ts` for the full catalog.
 
 User timings markers are also recorded, for advanced performance analysis using
 your browser's devtools.

--- a/packages/docs/.env.example
+++ b/packages/docs/.env.example
@@ -1,0 +1,12 @@
+# GitHub API token (classic, public_repo read scope is enough).
+# Used at build time for: landing-page contributors & CI status, /stats star
+# history, changelog, last-modified dates. Without it, local builds hit
+# unauthenticated GitHub rate limits.
+GITHUB_TOKEN=
+
+# Shared secret for the ISR cache-invalidation endpoint (src/app/api/isr).
+# Only needed to test that endpoint locally; leave empty otherwise.
+ISR_TOKEN=
+
+# Optional: ISO date for the conference countdown banner.
+NEXT_PUBLIC_CONFERENCE_COUNTDOWN_DATE=


### PR DESCRIPTION
The contributor and agent docs drifted from the repo: they named tsup as the build tool (it's tsdown), pointed test authors at `tests/*.test.ts` (unit tests are colocated under `src/`), showed imports that don't resolve (`@testing-library/react` in agent docs, `tsd`), and described a debug-prefix scheme that doesn't match `debug-messages.ts`. This actively misdirects contributors and coding agents.

The seconds-fast `test:unit` / `test:types` loop was also undocumented, so every iteration paid the 5-10 minute full suite. And the docs app reads `GITHUB_TOKEN` at build time with no `.env.example`, so local docs builds hit opaque GitHub rate-limit failures.

The second commit brings the README in line: the testing example now matches the canonical docs page (`withNuqsTestingAdapter`, Vitest v2 `vi.fn<OnUrlUpdateFunction>` typing), the debug legend matches the real prefix scheme, and the debugging section now mentions the `import 'nuqs/debug'` opt-in required since 2.9.0.

Note: `packages/docs/content/docs/debugging.mdx` has the same staleness (old `[nuq+]` claim, no `nuqs/debug` mention) — left for a follow-up as it was out of scope here.