### PR TITLE
ci: add bundle size comparison workflow for PRs

### DIFF
--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -1,15 +1,12 @@
 name: Post Bundle Size Comment
 
-# Runs after Bundle Size completes. Because this workflow is triggered by
-# workflow_run (not pull_request), it has pull-requests: write permission
-# even for PRs opened from forks — allowing it to post the size delta comment.
-#
-# workflow_run.pull_requests is empty for fork PRs, so the PR number travels
-# in the size-result artifact. Being attacker-controlled, it is validated as
-# an integer and cross-checked against the run's head SHA before posting.
+# Runs after Bundle Size completes. The triggering workflow is unprivileged and
+# may be modified by a fork PR, so its size reports are treated as hostile data.
+# A read-only job validates the reports and renders a bounded comment. Only a
+# separate job can write to pull requests, and it consumes that trusted output.
 on:
   workflow_run:
-    workflows: ["Bundle Size"]
+    workflows: ['Bundle Size']
     types: [completed]
 
 permissions: {}
@@ -19,64 +16,318 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  comment:
-    name: Post comment
+  prepare:
+    name: Validate reports and prepare comment
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-24.04-arm
     permissions:
       actions: read # Download artifacts from the unprivileged workflow.
+      pull-requests: read # Resolve the fork commit to exactly one PR.
+    outputs:
+      prNumber: ${{ steps.resolve.outputs.prNumber }}
+      shouldPost: ${{ steps.compare.outputs.shouldPost }}
+    steps:
+      - name: Resolve and validate PR
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # workflow_run.pull_requests and the base-repository commit lookup are
+          # empty for fork PRs. Query open PRs by the head owner/ref, then bind
+          # the full head repository and SHA below.
+          if ! [[ "$RUN_HEAD_REPOSITORY" =~ ^[^/]+/[^/]+$ ]]; then
+            echo "Invalid head repository: '$RUN_HEAD_REPOSITORY'"
+            exit 1
+          fi
+          HEAD_OWNER=${RUN_HEAD_REPOSITORY%%/*}
+          gh api --method GET --paginate --slurp \
+            "repos/$GH_REPO/pulls" \
+            -f state=open \
+            -f "head=$HEAD_OWNER:$RUN_HEAD_BRANCH" \
+            -F per_page=100 \
+            > /tmp/pulls.json
+
+          PR_NUMBER=$(
+            jq -er \
+              --arg baseRepo "$GH_REPO" \
+              --arg headRepo "$RUN_HEAD_REPOSITORY" \
+              --arg headRef "$RUN_HEAD_BRANCH" \
+              --arg headSha "$RUN_HEAD_SHA" \
+              '
+                add
+                | map(select(
+                    .base.repo.full_name == $baseRepo and
+                    .head.repo.full_name == $headRepo and
+                    .head.ref == $headRef and
+                    .head.sha == $headSha
+                  ))
+                | if length == 1 then
+                    .[0].number
+                  else
+                    error("Expected exactly one pull request for the workflow run")
+                  end
+              ' \
+              /tmp/pulls.json
+          )
+
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Resolved an invalid PR number: '$PR_NUMBER'"
+            exit 1
+          fi
+          printf 'prNumber=%s\n' "$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: base-size
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts/base
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: pr-size
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts/pr
+
+      - name: Validate reports and generate comparison
+        id: compare
+        run: |
+          node --input-type=module << 'EOF'
+          import {
+            appendFileSync,
+            mkdirSync,
+            readFileSync,
+            statSync,
+            writeFileSync
+          } from 'node:fs'
+
+          const MAX_REPORT_BYTES = 64 * 1024
+          const MAX_REPORT_ENTRIES = 20
+          const MAX_ENTRY_NAME_LENGTH = 200
+          const MAX_BUNDLE_BYTES = 100 * 1024 * 1024
+          const MAX_COMMENT_BYTES = 32 * 1024
+
+          function readReport(path, label) {
+            const stats = statSync(path)
+            if (!stats.isFile() || stats.size === 0 || stats.size > MAX_REPORT_BYTES) {
+              throw new TypeError(`${label} report has an invalid file size`)
+            }
+
+            const report = JSON.parse(readFileSync(path, 'utf8'))
+            if (
+              !Array.isArray(report) ||
+              report.length === 0 ||
+              report.length > MAX_REPORT_ENTRIES
+            ) {
+              throw new TypeError(`${label} report has an invalid entry count`)
+            }
+
+            const names = new Set()
+            return report.map((entry, index) => {
+              if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+                throw new TypeError(`${label} entry ${index} is not an object`)
+              }
+              if (
+                typeof entry.name !== 'string' ||
+                entry.name.length === 0 ||
+                entry.name.length > MAX_ENTRY_NAME_LENGTH
+              ) {
+                throw new TypeError(`${label} entry ${index} has an invalid name`)
+              }
+              if (names.has(entry.name)) {
+                throw new TypeError(`${label} report contains duplicate names`)
+              }
+              names.add(entry.name)
+
+              if (
+                !Number.isSafeInteger(entry.size) ||
+                entry.size < 0 ||
+                entry.size > MAX_BUNDLE_BYTES
+              ) {
+                throw new TypeError(`${label} entry ${index} has an invalid size`)
+              }
+              if (typeof entry.passed !== 'boolean') {
+                throw new TypeError(`${label} entry ${index} has an invalid status`)
+              }
+
+              return {
+                name: entry.name,
+                size: entry.size,
+                passed: entry.passed
+              }
+            })
+          }
+
+          // Render names as plain text rather than accepting Markdown from the
+          // untrusted artifacts. Current size-limit labels fit this allowlist.
+          function cell(value) {
+            const output = value.replace(/[^A-Za-z0-9 ()/_-]/g, '').slice(0, 80)
+            if (output.length === 0) {
+              throw new TypeError('Bundle name is empty after sanitization')
+            }
+            return output
+          }
+
+          function formatBytes(bytes) {
+            if (bytes < 1024) return `${bytes} B`
+            return `${(bytes / 1024).toFixed(2)} kB`
+          }
+
+          function formatDiff(diff) {
+            if (Math.abs(diff) < 10) return '—'
+            const sign = diff > 0 ? '+' : ''
+            const arrow = diff > 0 ? '⬆️' : '⬇️'
+            return `${arrow} ${sign}${formatBytes(diff)}`
+          }
+
+          const base = readReport('artifacts/base/size-limit.json', 'Base')
+          const pr = readReport('artifacts/pr/size-limit.json', 'PR')
+          const baseByName = new Map(base.map(entry => [entry.name, entry]))
+          const prByName = new Map(pr.map(entry => [entry.name, entry]))
+
+          let anyChange = false
+          const rows = []
+
+          for (const baseEntry of base) {
+            const prEntry = prByName.get(baseEntry.name)
+            if (!prEntry) {
+              anyChange = true
+              rows.push(
+                `| ⚠️ ${cell(baseEntry.name)} | ${formatBytes(baseEntry.size)} | n/a | Removed |`
+              )
+              continue
+            }
+
+            const diff = prEntry.size - baseEntry.size
+            if (Math.abs(diff) >= 10) anyChange = true
+            const status = prEntry.passed ? '✅' : '❌'
+            rows.push(
+              `| ${status} ${cell(baseEntry.name)} | ${formatBytes(baseEntry.size)} | ${formatBytes(prEntry.size)} | ${formatDiff(diff)} |`
+            )
+          }
+
+          for (const prEntry of pr) {
+            if (baseByName.has(prEntry.name)) continue
+            anyChange = true
+            const status = prEntry.passed ? '✅' : '❌'
+            rows.push(
+              `| ${status} ${cell(prEntry.name)} | n/a | ${formatBytes(prEntry.size)} | Added |`
+            )
+          }
+
+          if (!anyChange) {
+            appendFileSync(process.env.GITHUB_OUTPUT, 'shouldPost=false\n')
+            console.log('No meaningful size change (< 10 B). Skipping comment.')
+            process.exit(0)
+          }
+
+          const comment = [
+            '## Bundle size',
+            '',
+            '| | Base | PR | Δ |',
+            '|---|---|---|---|',
+            ...rows,
+            '',
+            '_Brotli-compressed. Limits are set in the `size-limit` config in `packages/nuqs/package.json`._',
+            ''
+          ].join('\n')
+
+          if (Buffer.byteLength(comment, 'utf8') > MAX_COMMENT_BYTES) {
+            throw new TypeError('Generated comment is too large')
+          }
+
+          mkdirSync('artifacts/prepared', { recursive: true })
+          writeFileSync('artifacts/prepared/comment.md', comment)
+          appendFileSync(process.env.GITHUB_OUTPUT, 'shouldPost=true\n')
+          console.log(comment)
+          EOF
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.compare.outputs.shouldPost == 'true'
+        with:
+          name: prepared-comment
+          path: artifacts/prepared/comment.md
+          if-no-files-found: error
+          retention-days: 1
+
+  post:
+    name: Post comment
+    needs: prepare
+    if: needs.prepare.outputs.shouldPost == 'true'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      actions: read # Download the validated comment from the prepare job.
       pull-requests: write # Create or update the bundle-size PR comment.
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: size-result
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ github.token }}
-          path: artifacts
+          name: prepared-comment
+          path: artifacts/prepared
+
       - name: Post PR comment
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.prepare.outputs.prNumber }}
+          RUN_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          PR_NUMBER=$(cat artifacts/pr-number 2>/dev/null || true)
-          if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
-            echo "Missing or invalid PR number in artifact — nothing to post."
-            exit 0
+          set -euo pipefail
+
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: '$PR_NUMBER'"
+            exit 1
           fi
 
-          PR_HEAD_SHA=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.head.sha' || true)
-          if [ "$PR_HEAD_SHA" != "$RUN_HEAD_SHA" ]; then
-            echo "PR #$PR_NUMBER head does not match the run head SHA — refusing to post."
-            exit 0
-          fi
+          validate_pr() {
+            gh api "repos/$GH_REPO/pulls/$PR_NUMBER" > /tmp/pr.json
+            jq -e \
+              --arg baseRepo "$GH_REPO" \
+              --arg headRepo "$RUN_HEAD_REPOSITORY" \
+              --arg headRef "$RUN_HEAD_BRANCH" \
+              --arg headSha "$RUN_HEAD_SHA" \
+              '
+                .state == "open" and
+                .base.repo.full_name == $baseRepo and
+                .head.repo.full_name == $headRepo and
+                .head.ref == $headRef and
+                .head.sha == $headSha
+              ' \
+              /tmp/pr.json \
+              > /dev/null
+          }
+
+          validate_pr
 
           MARKER="<!-- bundle-size-comment -->"
+          {
+            printf '%s\n' "$MARKER"
+            cat artifacts/prepared/comment.md
+          } > /tmp/full-comment.md
 
-          # Look up the existing comment across all pages;
-          # sed reads the whole stream to avoid a pipefail on early exit.
+          # Only update a comment owned by the GitHub Actions bot. An attacker-
+          # authored marker comment must never be selected as trusted output.
           EXISTING=$(gh api --paginate \
             "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
-            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
-            | sed -n 1p)
+            --jq '.[] | select(
+              .user.login == "github-actions[bot]" and
+              (.body | startswith("<!-- bundle-size-comment -->"))
+            ) | .id' \
+            | sed -n '1p')
 
-          # Build full comment in a temp file to avoid shell quoting issues
-          if [ -f "artifacts/skip" ]; then
-            if [ -z "$EXISTING" ]; then
-              echo "No meaningful size change — skipping comment."
-              exit 0
-            fi
-            # A previous comment exists: update it rather than leave a stale delta.
-            printf '%s\n## Bundle size\n\nNo significant size change.\n' "$MARKER" > /tmp/full-comment.md
-          elif [ -f "artifacts/comment.md" ]; then
-            printf '%s\n' "$MARKER" > /tmp/full-comment.md
-            cat artifacts/comment.md >> /tmp/full-comment.md
-          else
-            echo "Artifact files missing — nothing to post."
-            exit 0
-          fi
+          # Re-check immediately before using the write-scoped token so a push
+          # between preparation and posting cannot attach a stale result.
+          validate_pr
 
           if [ -n "$EXISTING" ]; then
             gh api \

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -8,16 +8,25 @@ on:
     workflows: ["Bundle Size"]
     types: [completed]
 
-permissions:
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: bundle-size-comment-${{ github.event.workflow_run.pull_requests[0].number }}
+  cancel-in-progress: true
 
 jobs:
   comment:
     name: Post comment
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0]
     runs-on: ubuntu-24.04-arm
+    permissions:
+      actions: read # Download artifacts from the unprivileged workflow.
+      pull-requests: write # Create or update the bundle-size PR comment.
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: size-result
           run-id: ${{ github.event.workflow_run.id }}
@@ -27,18 +36,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           if [ -f "artifacts/skip" ]; then
             echo "No meaningful size change — skipping comment."
             exit 0
           fi
 
-          if [ ! -f "artifacts/comment.md" ] || [ ! -f "artifacts/pr-number.txt" ]; then
+          if [ ! -f "artifacts/comment.md" ]; then
             echo "Artifact files missing — nothing to post."
             exit 0
           fi
 
-          PR_NUMBER=$(cat artifacts/pr-number.txt)
           MARKER="<!-- bundle-size-comment -->"
 
           # Build full comment in a temp file to avoid shell quoting issues

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -1,0 +1,66 @@
+name: Post Bundle Size Comment
+
+# Runs after Bundle Size completes. Because this workflow is triggered by
+# workflow_run (not pull_request), it has pull-requests: write permission
+# even for PRs opened from forks — allowing it to post the size delta comment.
+on:
+  workflow_run:
+    workflows: ["Bundle Size"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post comment
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: size-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ -f "artifacts/skip" ]; then
+            echo "No meaningful size change — skipping comment."
+            exit 0
+          fi
+
+          if [ ! -f "artifacts/comment.md" ] || [ ! -f "artifacts/pr-number.txt" ]; then
+            echo "Artifact files missing — nothing to post."
+            exit 0
+          fi
+
+          PR_NUMBER=$(cat artifacts/pr-number.txt)
+          MARKER="<!-- bundle-size-comment -->"
+
+          # Build full comment in a temp file to avoid shell quoting issues
+          printf '%s\n' "$MARKER" > /tmp/full-comment.md
+          cat artifacts/comment.md >> /tmp/full-comment.md
+
+          # Update existing comment if present, otherwise create a new one
+          EXISTING=$(gh api \
+            "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+            2>/dev/null | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            gh api \
+              --method PATCH \
+              "repos/$GH_REPO/issues/comments/$EXISTING" \
+              -F body=@/tmp/full-comment.md
+            echo "Updated comment $EXISTING on PR #$PR_NUMBER."
+          else
+            gh api \
+              --method POST \
+              "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+              -F body=@/tmp/full-comment.md
+            echo "Posted new comment on PR #$PR_NUMBER."
+          fi

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -3,6 +3,10 @@ name: Post Bundle Size Comment
 # Runs after Bundle Size completes. Because this workflow is triggered by
 # workflow_run (not pull_request), it has pull-requests: write permission
 # even for PRs opened from forks — allowing it to post the size delta comment.
+#
+# workflow_run.pull_requests is empty for fork PRs, so the PR number travels
+# in the size-result artifact. Being attacker-controlled, it is validated as
+# an integer and cross-checked against the run's head SHA before posting.
 on:
   workflow_run:
     workflows: ["Bundle Size"]
@@ -11,7 +15,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: bundle-size-comment-${{ github.event.workflow_run.pull_requests[0].number }}
+  group: bundle-size-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
@@ -19,8 +23,7 @@ jobs:
     name: Post comment
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0]
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-24.04-arm
     permissions:
       actions: read # Download artifacts from the unprivileged workflow.
@@ -36,29 +39,44 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ -f "artifacts/skip" ]; then
-            echo "No meaningful size change — skipping comment."
+          PR_NUMBER=$(cat artifacts/pr-number 2>/dev/null || true)
+          if ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "Missing or invalid PR number in artifact — nothing to post."
             exit 0
           fi
 
-          if [ ! -f "artifacts/comment.md" ]; then
-            echo "Artifact files missing — nothing to post."
+          PR_HEAD_SHA=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.head.sha' || true)
+          if [ "$PR_HEAD_SHA" != "$RUN_HEAD_SHA" ]; then
+            echo "PR #$PR_NUMBER head does not match the run head SHA — refusing to post."
             exit 0
           fi
 
           MARKER="<!-- bundle-size-comment -->"
 
-          # Build full comment in a temp file to avoid shell quoting issues
-          printf '%s\n' "$MARKER" > /tmp/full-comment.md
-          cat artifacts/comment.md >> /tmp/full-comment.md
-
-          # Update existing comment if present, otherwise create a new one
-          EXISTING=$(gh api \
+          # Look up the existing comment across all pages;
+          # sed reads the whole stream to avoid a pipefail on early exit.
+          EXISTING=$(gh api --paginate \
             "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
             --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
-            2>/dev/null | head -1)
+            | sed -n 1p)
+
+          # Build full comment in a temp file to avoid shell quoting issues
+          if [ -f "artifacts/skip" ]; then
+            if [ -z "$EXISTING" ]; then
+              echo "No meaningful size change — skipping comment."
+              exit 0
+            fi
+            # A previous comment exists: update it rather than leave a stale delta.
+            printf '%s\n## Bundle size\n\nNo significant size change.\n' "$MARKER" > /tmp/full-comment.md
+          elif [ -f "artifacts/comment.md" ]; then
+            printf '%s\n' "$MARKER" > /tmp/full-comment.md
+            cat artifacts/comment.md >> /tmp/full-comment.md
+          else
+            echo "Artifact files missing — nothing to post."
+            exit 0
+          fi
 
           if [ -n "$EXISTING" ]; then
             gh api \

--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -2,7 +2,6 @@ name: Bundle Size
 
 on:
   pull_request:
-    types: [opened, synchronize]
     paths:
       - "packages/nuqs/src/**"
       - "packages/nuqs/package.json"
@@ -20,11 +19,11 @@ jobs:
     name: Measure (base)
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
@@ -36,7 +35,9 @@ jobs:
       - name: Generate size report
         # size-limit --json exits non-zero if a limit is exceeded,
         # but we still want the JSON output for the diff table.
-        run: pnpm run build:size-json --filter nuqs || true
+        run: |
+          pnpm --filter nuqs run build:size-json || true
+          test -s packages/nuqs/size.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: base-size
@@ -47,10 +48,10 @@ jobs:
     name: Measure (PR)
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
@@ -60,7 +61,9 @@ jobs:
       - name: Build package
         run: pnpm build --filter nuqs
       - name: Generate size report
-        run: pnpm run build:size-json --filter nuqs || true
+        run: |
+          pnpm --filter nuqs run build:size-json || true
+          test -s packages/nuqs/size.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-size
@@ -80,6 +83,15 @@ jobs:
         with:
           name: pr-size
           path: artifacts/pr
+      - name: Record PR number
+        # workflow_run.pull_requests is empty for fork PRs, so the privileged
+        # comment workflow reads the PR number from the artifact instead,
+        # and validates it against the run's head SHA before posting.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p artifacts/result
+          printf '%s' "$PR_NUMBER" > artifacts/result/pr-number
       - name: Generate comparison
         run: |
           node --input-type=module << 'EOF'
@@ -122,13 +134,13 @@ jobs:
             const prEntry = pr.find(entry => entry.name === baseEntry.name)
             if (!prEntry) {
               anyChange = true
-              rows += `| ⚠️ ${cell(baseEntry.name)} | ${formatBytes(baseEntry.brotli)} | n/a | Removed |\n`
+              rows += `| ⚠️ ${cell(baseEntry.name)} | ${formatBytes(baseEntry.size)} | n/a | Removed |\n`
               continue
             }
-            const baseSize = Number(baseEntry.brotli)
-            const prSize = Number(prEntry.brotli)
+            const baseSize = Number(baseEntry.size)
+            const prSize = Number(prEntry.size)
             if (!Number.isFinite(baseSize) || !Number.isFinite(prSize)) {
-              throw new TypeError(`Invalid Brotli size for ${cell(baseEntry.name)}`)
+              throw new TypeError(`Invalid size for ${cell(baseEntry.name)}`)
             }
             const diff = prSize - baseSize
             if (Math.abs(diff) >= 10) anyChange = true

--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -20,12 +20,12 @@ jobs:
     name: Measure (base)
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: pnpm
@@ -37,7 +37,7 @@ jobs:
         # size-limit --json exits non-zero if a limit is exceeded,
         # but we still want the JSON output for the diff table.
         run: pnpm run build:size-json --filter nuqs || true
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: base-size
           path: packages/nuqs/size.json
@@ -47,11 +47,11 @@ jobs:
     name: Measure (PR)
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: pnpm
@@ -61,14 +61,10 @@ jobs:
         run: pnpm build --filter nuqs
       - name: Generate size report
         run: pnpm run build:size-json --filter nuqs || true
-      - name: Save PR number
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-size
-          path: |
-            packages/nuqs/size.json
-            pr-number.txt
+          path: packages/nuqs/size.json
           retention-days: 1
 
   compare:
@@ -76,27 +72,41 @@ jobs:
     needs: [measure-base, measure-pr]
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: base-size
           path: artifacts/base
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: pr-size
           path: artifacts/pr
       - name: Generate comparison
         run: |
           node --input-type=module << 'EOF'
-          import { readFileSync, writeFileSync } from 'fs'
-          import { mkdirSync } from 'fs'
+          import { mkdirSync, readFileSync, writeFileSync } from 'fs'
 
           const base = JSON.parse(readFileSync('artifacts/base/size.json', 'utf8'))
           const pr = JSON.parse(readFileSync('artifacts/pr/size.json', 'utf8'))
-          const prNumber = readFileSync('artifacts/pr/pr-number.txt', 'utf8').trim()
+
+          if (!Array.isArray(base) || !Array.isArray(pr)) {
+            throw new TypeError('Expected both size reports to contain arrays')
+          }
+
+          function cell(value) {
+            return String(value)
+              .replace(/[\r\n]+/g, ' ')
+              .replace(/\|/g, '\\|')
+              .replace(/`/g, '\\`')
+              .replace(/[<>]/g, '')
+              .replace(/@/g, '@\u200b')
+              .slice(0, 80)
+          }
 
           function formatBytes(bytes) {
-            if (bytes < 1024) return `${bytes} B`
-            return `${(bytes / 1024).toFixed(2)} kB`
+            const value = Number(bytes)
+            if (!Number.isFinite(value)) return 'n/a'
+            if (value < 1024) return `${value} B`
+            return `${(value / 1024).toFixed(2)} kB`
           }
 
           function formatDiff(diff) {
@@ -108,17 +118,25 @@ jobs:
 
           let anyChange = false
           let rows = ''
-          for (const prEntry of pr) {
-            const baseEntry = base.find(b => b.name === prEntry.name)
-            if (!baseEntry) continue
-            const diff = prEntry.brotli - baseEntry.brotli
+          for (const baseEntry of base) {
+            const prEntry = pr.find(entry => entry.name === baseEntry.name)
+            if (!prEntry) {
+              anyChange = true
+              rows += `| ⚠️ ${cell(baseEntry.name)} | ${formatBytes(baseEntry.brotli)} | n/a | Removed |\n`
+              continue
+            }
+            const baseSize = Number(baseEntry.brotli)
+            const prSize = Number(prEntry.brotli)
+            if (!Number.isFinite(baseSize) || !Number.isFinite(prSize)) {
+              throw new TypeError(`Invalid Brotli size for ${cell(baseEntry.name)}`)
+            }
+            const diff = prSize - baseSize
             if (Math.abs(diff) >= 10) anyChange = true
-            const status = prEntry.passed ? '✅' : '❌'
-            rows += `| ${status} ${prEntry.name} | ${formatBytes(baseEntry.brotli)} | ${formatBytes(prEntry.brotli)} | ${formatDiff(diff)} |\n`
+            const status = prEntry.passed === true ? '✅' : '❌'
+            rows += `| ${status} ${cell(baseEntry.name)} | ${formatBytes(baseSize)} | ${formatBytes(prSize)} | ${formatDiff(diff)} |\n`
           }
 
           mkdirSync('artifacts/result', { recursive: true })
-          writeFileSync('artifacts/result/pr-number.txt', prNumber)
 
           if (!anyChange) {
             writeFileSync('artifacts/result/skip', '1')
@@ -137,7 +155,7 @@ jobs:
             console.log(comment)
           }
           EOF
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: size-result
           path: artifacts/result/

--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -3,9 +3,9 @@ name: Bundle Size
 on:
   pull_request:
     paths:
-      - "packages/nuqs/src/**"
-      - "packages/nuqs/package.json"
-      - "packages/nuqs/tsdown.config.ts"
+      - 'packages/nuqs/src/**'
+      - 'packages/nuqs/package.json'
+      - 'packages/nuqs/tsdown.config.ts'
 
 concurrency:
   group: bundle-size-${{ github.event.pull_request.number }}
@@ -38,10 +38,12 @@ jobs:
         run: |
           pnpm --filter nuqs run build:size-json || true
           test -s packages/nuqs/size.json
+          mv packages/nuqs/size.json packages/nuqs/size-limit.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: base-size
-          path: packages/nuqs/size.json
+          path: packages/nuqs/size-limit.json
+          if-no-files-found: error
           retention-days: 1
 
   measure-pr:
@@ -64,111 +66,10 @@ jobs:
         run: |
           pnpm --filter nuqs run build:size-json || true
           test -s packages/nuqs/size.json
+          mv packages/nuqs/size.json packages/nuqs/size-limit.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-size
-          path: packages/nuqs/size.json
-          retention-days: 1
-
-  compare:
-    name: Compare
-    needs: [measure-base, measure-pr]
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: base-size
-          path: artifacts/base
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: pr-size
-          path: artifacts/pr
-      - name: Record PR number
-        # workflow_run.pull_requests is empty for fork PRs, so the privileged
-        # comment workflow reads the PR number from the artifact instead,
-        # and validates it against the run's head SHA before posting.
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          mkdir -p artifacts/result
-          printf '%s' "$PR_NUMBER" > artifacts/result/pr-number
-      - name: Generate comparison
-        run: |
-          node --input-type=module << 'EOF'
-          import { mkdirSync, readFileSync, writeFileSync } from 'fs'
-
-          const base = JSON.parse(readFileSync('artifacts/base/size.json', 'utf8'))
-          const pr = JSON.parse(readFileSync('artifacts/pr/size.json', 'utf8'))
-
-          if (!Array.isArray(base) || !Array.isArray(pr)) {
-            throw new TypeError('Expected both size reports to contain arrays')
-          }
-
-          function cell(value) {
-            return String(value)
-              .replace(/[\r\n]+/g, ' ')
-              .replace(/\|/g, '\\|')
-              .replace(/`/g, '\\`')
-              .replace(/[<>]/g, '')
-              .replace(/@/g, '@\u200b')
-              .slice(0, 80)
-          }
-
-          function formatBytes(bytes) {
-            const value = Number(bytes)
-            if (!Number.isFinite(value)) return 'n/a'
-            if (value < 1024) return `${value} B`
-            return `${(value / 1024).toFixed(2)} kB`
-          }
-
-          function formatDiff(diff) {
-            if (Math.abs(diff) < 10) return '—'
-            const sign = diff > 0 ? '+' : ''
-            const arrow = diff > 0 ? '⬆️' : '⬇️'
-            return `${arrow} ${sign}${formatBytes(diff)}`
-          }
-
-          let anyChange = false
-          let rows = ''
-          for (const baseEntry of base) {
-            const prEntry = pr.find(entry => entry.name === baseEntry.name)
-            if (!prEntry) {
-              anyChange = true
-              rows += `| ⚠️ ${cell(baseEntry.name)} | ${formatBytes(baseEntry.size)} | n/a | Removed |\n`
-              continue
-            }
-            const baseSize = Number(baseEntry.size)
-            const prSize = Number(prEntry.size)
-            if (!Number.isFinite(baseSize) || !Number.isFinite(prSize)) {
-              throw new TypeError(`Invalid size for ${cell(baseEntry.name)}`)
-            }
-            const diff = prSize - baseSize
-            if (Math.abs(diff) >= 10) anyChange = true
-            const status = prEntry.passed === true ? '✅' : '❌'
-            rows += `| ${status} ${cell(baseEntry.name)} | ${formatBytes(baseSize)} | ${formatBytes(prSize)} | ${formatDiff(diff)} |\n`
-          }
-
-          mkdirSync('artifacts/result', { recursive: true })
-
-          if (!anyChange) {
-            writeFileSync('artifacts/result/skip', '1')
-            console.log('No meaningful size change (< 10 B). Skipping comment.')
-          } else {
-            const comment = [
-              '## Bundle size',
-              '',
-              '| | Base | PR | Δ |',
-              '|---|---|---|---|',
-              rows.trimEnd(),
-              '',
-              '_Brotli-compressed. Limits are set in the `size-limit` config in `packages/nuqs/package.json`._',
-            ].join('\n')
-            writeFileSync('artifacts/result/comment.md', comment)
-            console.log(comment)
-          }
-          EOF
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: size-result
-          path: artifacts/result/
+          path: packages/nuqs/size-limit.json
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -1,0 +1,144 @@
+name: Bundle Size
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "packages/nuqs/src/**"
+      - "packages/nuqs/package.json"
+      - "packages/nuqs/tsdown.config.ts"
+
+concurrency:
+  group: bundle-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  measure-base:
+    name: Measure (base)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          ref: ${{ github.base_ref }}
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs...
+      - name: Build package
+        run: pnpm build --filter nuqs
+      - name: Generate size report
+        # size-limit --json exits non-zero if a limit is exceeded,
+        # but we still want the JSON output for the diff table.
+        run: pnpm run build:size-json --filter nuqs || true
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: base-size
+          path: packages/nuqs/size.json
+          retention-days: 1
+
+  measure-pr:
+    name: Measure (PR)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs...
+      - name: Build package
+        run: pnpm build --filter nuqs
+      - name: Generate size report
+        run: pnpm run build:size-json --filter nuqs || true
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: pr-size
+          path: |
+            packages/nuqs/size.json
+            pr-number.txt
+          retention-days: 1
+
+  compare:
+    name: Compare
+    needs: [measure-base, measure-pr]
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: base-size
+          path: artifacts/base
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: pr-size
+          path: artifacts/pr
+      - name: Generate comparison
+        run: |
+          node --input-type=module << 'EOF'
+          import { readFileSync, writeFileSync } from 'fs'
+          import { mkdirSync } from 'fs'
+
+          const base = JSON.parse(readFileSync('artifacts/base/size.json', 'utf8'))
+          const pr = JSON.parse(readFileSync('artifacts/pr/size.json', 'utf8'))
+          const prNumber = readFileSync('artifacts/pr/pr-number.txt', 'utf8').trim()
+
+          function formatBytes(bytes) {
+            if (bytes < 1024) return `${bytes} B`
+            return `${(bytes / 1024).toFixed(2)} kB`
+          }
+
+          function formatDiff(diff) {
+            if (Math.abs(diff) < 10) return '—'
+            const sign = diff > 0 ? '+' : ''
+            const arrow = diff > 0 ? '⬆️' : '⬇️'
+            return `${arrow} ${sign}${formatBytes(diff)}`
+          }
+
+          let anyChange = false
+          let rows = ''
+          for (const prEntry of pr) {
+            const baseEntry = base.find(b => b.name === prEntry.name)
+            if (!baseEntry) continue
+            const diff = prEntry.brotli - baseEntry.brotli
+            if (Math.abs(diff) >= 10) anyChange = true
+            const status = prEntry.passed ? '✅' : '❌'
+            rows += `| ${status} ${prEntry.name} | ${formatBytes(baseEntry.brotli)} | ${formatBytes(prEntry.brotli)} | ${formatDiff(diff)} |\n`
+          }
+
+          mkdirSync('artifacts/result', { recursive: true })
+          writeFileSync('artifacts/result/pr-number.txt', prNumber)
+
+          if (!anyChange) {
+            writeFileSync('artifacts/result/skip', '1')
+            console.log('No meaningful size change (< 10 B). Skipping comment.')
+          } else {
+            const comment = [
+              '## Bundle size',
+              '',
+              '| | Base | PR | Δ |',
+              '|---|---|---|---|',
+              rows.trimEnd(),
+              '',
+              '_Brotli-compressed. Limits are set in the `size-limit` config in `packages/nuqs/package.json`._',
+            ].join('\n')
+            writeFileSync('artifacts/result/comment.md', comment)
+            console.log(comment)
+          }
+          EOF
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: size-result
+          path: artifacts/result/
+          retention-days: 1

--- a/packages/nuqs/src/index.ts
+++ b/packages/nuqs/src/index.ts
@@ -25,3 +25,6 @@ export {
 } from './standard-schema'
 export * from './useQueryState'
 export * from './useQueryStates'
+
+export const __bundleSizeCanary =
+  'q7Xv9kM2pLzR4wTb8nJdY3fGh6sCa1eWi5uHo0NgKrPmZxQtSjVyBl'

--- a/packages/nuqs/src/index.ts
+++ b/packages/nuqs/src/index.ts
@@ -25,6 +25,3 @@ export {
 } from './standard-schema'
 export * from './useQueryState'
 export * from './useQueryStates'
-
-export const __bundleSizeCanary =
-  'q7Xv9kM2pLzR4wTb8nJdY3fGh6sCa1eWi5uHo0NgKrPmZxQtSjVyBl'


### PR DESCRIPTION
From @wasihussain914 in https://github.com/wasihussain914/nuqs/commit/d3b1daf22d8ff6a6eae49e8e7917cd8cd1a8bad6

Two workflows implement the pattern requested in #1071:

- size-compare.yml: triggers on pull_request (paths: packages/nuqs/src/**,
  package.json, tsdown.config.ts). Builds both the base branch and the PR
  branch in parallel, runs \pnpm run build:size-json\ on each, then compares
  brotli sizes in a third job and uploads the diff table as an artifact.
  No write permissions needed — safe for fork PRs.

- size-comment.yml: triggers on workflow_run completion of the Bundle Size
  workflow. Downloads the diff artifact and posts (or updates) a single
  \<!-- bundle-size-comment -->\ comment on the PR using pull-requests:write.
  The comment is skipped entirely when the delta is under 10 bytes to avoid
  noise on documentation-only PRs.

All action refs are pinned to SHA hashes consistent with the rest of the
repo. The Node.js comparison script runs inline using \--input-type=module\
so no extra dependencies or checkout steps are needed in the compare job.

Closes #1071.