### PR TITLE
chore: fix docs build warnings

### DIFF
--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -19,9 +19,6 @@ const config = {
   // The changelog page imports the IO-free changelog codec straight from the
   // `scripts` workspace as raw TypeScript; transpile it as part of the build.
   transpilePackages: ['scripts'],
-  experimental: {
-    isolatedDevBuild: true
-  },
   redirects: async () => {
     return [
       {

--- a/packages/docs/src/app/layout.tsx
+++ b/packages/docs/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { type ReactNode } from 'react'
 import { TopBanner } from './banners'
 import { Favicon } from '../components/favicon'
 import { ResponsiveHelper } from '../components/responsive-helpers'
+import { getBaseUrl } from '../lib/url'
 import { cn } from '../lib/utils'
 import './globals.css'
 
@@ -17,6 +18,7 @@ const inter = Inter({
 })
 
 export const metadata = {
+  metadataBase: new URL(getBaseUrl() || 'http://localhost:3000'),
   title: {
     template: '%s | nuqs',
     default: 'nuqs'

--- a/packages/nuqs/tsdown.config.ts
+++ b/packages/nuqs/tsdown.config.ts
@@ -7,14 +7,16 @@ const commonConfig = {
   format: ['esm'],
   dts: true,
   outDir: 'dist',
-  external: [
-    'next',
-    'react',
-    '@remix-run/react',
-    'react-router-dom',
-    'react-router',
-    '@tanstack/react-router'
-  ],
+  deps: {
+    neverBundle: [
+      'next',
+      'react',
+      '@remix-run/react',
+      'react-router-dom',
+      'react-router',
+      '@tanstack/react-router'
+    ]
+  },
   outExtensions() {
     return {
       js: '.js',


### PR DESCRIPTION
## Summary
- migrate tsdown externals to `deps.neverBundle`
- remove the obsolete Next.js `isolatedDevBuild` experimental option
- configure `metadataBase` for social image URL resolution

## Verification
- `pnpm --filter nuqs build:size-json`
- `GITHUB_TOKEN="$(gh auth token)" pnpm --filter docs... build`

The build completes successfully with the targeted tsdown, Next.js config, and `metadataBase` warnings removed. Existing missing per-page OG image notices are intentionally out of scope.