### PR TITLE
doc: document debug import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,13 @@ For detailed development guidelines organized by task, see:
 
 ## Debugging
 
-Enable debug logs in the browser console:
+Import the opt-in debug bundle once in client-side code:
+
+```ts
+import 'nuqs/debug'
+```
+
+Then enable debug logs in the browser console and reload the page:
 
 ```js
 localStorage.setItem('debug', 'nuqs')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ For detailed development guidelines organized by task, see:
 
 ## Debugging
 
-Import the opt-in debug bundle once in client-side code:
+Import the opt-in debug bundle once in each runtime where logs are needed:
 
 ```ts
 import 'nuqs/debug'

--- a/README.md
+++ b/README.md
@@ -922,13 +922,13 @@ See [#259](https://github.com/47ng/nuqs/issues/259) for more testing-related dis
 
 ## Debugging
 
-You can enable debug logs in the browser by importing the `nuqs/debug` entry
-point once from client-side code loaded by your app (it keeps the log messages
-out of your bundle otherwise), then setting the `debug` item in localStorage to
-`nuqs`, and reload the page.
+Start by importing the `nuqs/debug` entry point once in your app. This keeps the
+log messages out of your bundles unless you opt in. In frameworks with separate
+client and server bundles, import it in each runtime where you want logs. Then
+set the `debug` item in localStorage to `nuqs`, and reload the page.
 
 ```ts
-// Once, from client-side code loaded by your app:
+// Once in your app:
 import 'nuqs/debug'
 ```
 

--- a/README.md
+++ b/README.md
@@ -888,7 +888,10 @@ Here's an example using Testing Library and Vitest:
 ```tsx
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { withNuqsTestingAdapter, type OnUrlUpdateFunction } from 'nuqs/adapters/testing'
+import {
+  withNuqsTestingAdapter,
+  type OnUrlUpdateFunction
+} from 'nuqs/adapters/testing'
 import { describe, expect, it, vi } from 'vitest'
 import { CounterButton } from './counter-button'
 
@@ -919,13 +922,13 @@ See [#259](https://github.com/47ng/nuqs/issues/259) for more testing-related dis
 
 ## Debugging
 
-You can enable debug logs in the browser by importing the `nuqs/debug`
-entry point once anywhere in your app (it keeps the log messages out of your
-bundle otherwise), then setting the `debug` item in localStorage to `nuqs`,
-and reload the page.
+You can enable debug logs in the browser by importing the `nuqs/debug` entry
+point once from client-side code loaded by your app (it keeps the log messages
+out of your bundle otherwise), then setting the `debug` item in localStorage to
+`nuqs`, and reload the page.
 
 ```ts
-// Once, anywhere in your app:
+// Once, from client-side code loaded by your app:
 import 'nuqs/debug'
 ```
 

--- a/packages/docs/content/docs/debugging.mdx
+++ b/packages/docs/content/docs/debugging.mdx
@@ -32,8 +32,8 @@ queues and adapters.
 
 Debug logs apply in any Node environment: server-side rendering (SSR), React
 Server Components (RSC), or when using `nuqs/server`. Importing `nuqs/debug`
-from a server entry point, such as a Next.js root layout, installs the server log
-sink. Importing `nuqs/server` also wires it in automatically.
+from a server entry point, such as a Next.js root layout, brings the debug logs
+into your server bundle.
 
 Enable logs by setting the `DEBUG` environment variable so it contains `nuqs`:
 

--- a/packages/docs/content/docs/debugging.mdx
+++ b/packages/docs/content/docs/debugging.mdx
@@ -5,12 +5,12 @@ description: Enabling debug logs and user timings markers
 
 ## Browser
 
-You can enable debug logs in the browser by importing the `nuqs/debug` entry
-point once from client-side code loaded by your app. This keeps the log messages
-out of your bundle unless you opt in.
+Start by importing the `nuqs/debug` entry point once in your app. This keeps the
+log messages out of your bundles unless you opt in. In frameworks with separate
+client and server bundles, import it in each runtime where you want logs.
 
 ```ts
-// Once, from client-side code loaded by your app:
+// Once in your app:
 import 'nuqs/debug'
 ```
 
@@ -31,8 +31,10 @@ queues and adapters.
 ## Server (Node.js)
 
 Debug logs apply in any Node environment: server-side rendering (SSR), React
-Server Components (RSC), or when using `nuqs/server`. Hooks like
-`useQueryState` and `useQueryStates` can run on the server in these contexts.
+Server Components (RSC), or when using `nuqs/server`. Importing `nuqs/debug`
+from a server entry point, such as a Next.js root layout, installs the server log
+sink. Importing `nuqs/server` also wires it in automatically.
+
 Enable logs by setting the `DEBUG` environment variable so it contains `nuqs`:
 
 ```bash

--- a/packages/docs/content/docs/debugging.mdx
+++ b/packages/docs/content/docs/debugging.mdx
@@ -5,16 +5,25 @@ description: Enabling debug logs and user timings markers
 
 ## Browser
 
-You can enable debug logs in the browser by setting the `debug` item in localStorage
-to `nuqs`, and reload the page.
+You can enable debug logs in the browser by importing the `nuqs/debug` entry
+point once from client-side code loaded by your app. This keeps the log messages
+out of your bundle unless you opt in.
+
+```ts
+// Once, from client-side code loaded by your app:
+import 'nuqs/debug'
+```
+
+Then set the `debug` item in localStorage to `nuqs`, and reload the page.
 
 ```js
 // In your devtools:
 localStorage.setItem('debug', 'nuqs')
 ```
 
-Log lines for both `useQueryState` and `useQueryStates` will be prefixed with
-`[nuq+]`, along with other internal debug logs.
+Log lines are prefixed with `[nuq+ …]` for hook-level messages, and
+`[nuqs <subsystem>]` for internal subsystems such as the throttle and debounce
+queues and adapters.
 
 > Note: unlike the `debug` package, this will not work with wildcards, but
 > you can combine it: `localStorage.setItem('debug', '*,nuqs')`


### PR DESCRIPTION
## Summary

- document the required `import 'nuqs/debug'` browser opt-in on the debugging page
- clarify that the import must be reachable from client-side code
- align the README and contributor agent guidance with the same setup

The `nuqs/debug` entry point became required when debug messages were split out of the core client bundle in #1176, but the dedicated debugging page retained the old localStorage-only instructions.

## Verification

- `pnpm exec prettier --check AGENTS.md README.md`
- `pnpm --filter docs exec prettier --check content/docs/debugging.mdx`
- `pnpm --filter nuqs build`
- `pnpm --filter docs build` compiled and type-checked successfully, then stopped during prerendering `/blog/2025` because the local GitHub API request returned 401