### PR TITLE
feat: add `required` parser option for loaders

### DIFF
--- a/packages/docs/content/docs/server-side.mdx
+++ b/packages/docs/content/docs/server-side.mdx
@@ -234,6 +234,33 @@ loadSearchParams('?count=banana', { strict: true })
 // [nuqs] Error while parsing query `banana` for key `count`
 ```
 
+<SinceVersion v="2.10.0">
+
+### Required params
+
+<FeatureSupportMatrix introducedInVersion='2.10.0' />
+
+You can mark individual parsers as `required{:ts}`, so that the loader throws
+if the key resolves to `null{:ts}`: either the param is missing from the URL,
+or it failed to parse, and there is no [default value](/docs/basic-usage#default-values)
+to fall back to. A `defaultValue{:ts}` always satisfies the requirement, even
+when the param itself is absent from the URL.
+
+```ts
+const loadSearchParams = createLoader({
+  count: parseAsInteger.withOptions({ required: true })
+})
+
+// Throws: `count` is missing from the URL and has no default value
+loadSearchParams('')
+// [nuqs] Missing required query param `count`
+
+// Works fine: `count` is present and parses successfully
+loadSearchParams('?count=1')
+```
+
+</SinceVersion>
+
 ## Cache
 
 <FeatureSupportMatrix introducedInVersion='1.13.0' support={{ supported: true, frameworks: ['Next.js (app router)']}} />

--- a/packages/nuqs/src/defs.ts
+++ b/packages/nuqs/src/defs.ts
@@ -87,6 +87,17 @@ export type Options = {
    * changes (prefer explicit URLs whose meaning don't change).
    */
   clearOnDefault?: boolean
+
+  /**
+   * Whether the parser is required to resolve to a non-null value
+   * when using a loader created with `createLoader`.
+   *
+   * A `defaultValue` on the parser counts as satisfying this requirement,
+   * even if the param itself is absent from the URL. The loader only throws
+   * when there is neither a value in the URL (or it failed to parse) nor a
+   * `defaultValue` to fall back to.
+   */
+  required?: boolean
 }
 
 export type Nullable<T> = {

--- a/packages/nuqs/src/loader.test.ts
+++ b/packages/nuqs/src/loader.test.ts
@@ -225,6 +225,61 @@ describe('loader', () => {
     })
   })
 
+  describe('required', () => {
+    it('throws when a required param is missing from the URL and has no default', () => {
+      const load = createLoader({
+        count: parseAsInteger.withOptions({ required: true })
+      })
+      expect(() => load('')).toThrow(
+        '[nuqs] Missing required query param `count`'
+      )
+    })
+    it('does not throw when a required param is missing but has a default', () => {
+      const load = createLoader({
+        count: parseAsInteger.withOptions({ required: true }).withDefault(0)
+      })
+      const result = load('')
+      expect(result).toEqual({ count: 0 })
+    })
+    it('does not throw when a required param is present and parses successfully', () => {
+      const load = createLoader({
+        count: parseAsInteger.withOptions({ required: true })
+      })
+      const result = load('?count=42')
+      expect(result).toEqual({ count: 42 })
+    })
+    it('throws when a required param is present but fails to parse and has no default', () => {
+      const load = createLoader({
+        test: createParser({
+          parse: () => null,
+          serialize: String
+        }).withOptions({ required: true })
+      })
+      expect(() => load('?test=will-be-null')).toThrow(
+        '[nuqs] Missing required query param `test`'
+      )
+    })
+    it('does not throw for non-required params that are missing or unparseable', () => {
+      const load = createLoader({
+        a: parseAsInteger,
+        b: parseAsInteger.withOptions({ required: true })
+      })
+      const result = load('?b=1')
+      expect(result).toEqual({ a: null, b: 1 })
+    })
+    it('strict error takes precedence over required when both apply', () => {
+      const load = createLoader({
+        test: createParser({
+          parse: () => null,
+          serialize: String
+        }).withOptions({ required: true })
+      })
+      expect(() => load('?test=will-be-null', { strict: true })).toThrow(
+        '[nuqs] Failed to parse query `will-be-null` for key `test` (got null)'
+      )
+    })
+  })
+
   describe('multi-parser', () => {
     it('supports multi-parsers', () => {
       const load = createLoader({

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -103,26 +103,30 @@ export function createLoader<Parsers extends ParserMap>(
           : searchParams.get(urlKey)
       if (isAbsentFromUrl(query)) {
         result[key] = parser.defaultValue ?? null
-        continue
-      }
-      let parsedValue
-      try {
-        // we have properly narrowed `query` here, but TS doesn't keep track of that
-        parsedValue = parser.parse(query as string & Array<string>)
-      } catch (error) {
-        if (strict) {
+      } else {
+        let parsedValue
+        try {
+          // we have properly narrowed `query` here, but TS doesn't keep track of that
+          parsedValue = parser.parse(query as string & Array<string>)
+        } catch (error) {
+          if (strict) {
+            throw new Error(
+              `[nuqs] Error while parsing query \`${query}\` for key \`${key}\`: ${error}`
+            )
+          }
+          parsedValue = null
+        }
+        if (strict && parsedValue === null) {
           throw new Error(
-            `[nuqs] Error while parsing query \`${query}\` for key \`${key}\`: ${error}`
+            `[nuqs] Failed to parse query \`${query}\` for key \`${key}\` (got null)`
           )
         }
-        parsedValue = null
+        result[key] = parsedValue ?? parser.defaultValue ?? null
       }
-      if (strict && query && parsedValue === null) {
-        throw new Error(
-          `[nuqs] Failed to parse query \`${query}\` for key \`${key}\` (got null)`
-        )
+
+      if (parser.required && result[key] === null) {
+        throw new Error(`[nuqs] Missing required query param \`${key}\``)
       }
-      result[key] = parsedValue ?? parser.defaultValue ?? null
     }
     return result
   }


### PR DESCRIPTION
## Summary
- Parsers can opt into `withOptions({ required: true })` so `createLoader`/`loadSearchParams` throws when a key resolves to `null` (missing from the URL, or failed to parse) and there is no `defaultValue` to fall back to. A `defaultValue` always satisfies the requirement, even when the param itself is absent from the URL.
- Adds test coverage for the new option, including interaction with `strict` mode.
- Documents the new option in the server-side usage docs, gated behind `<SinceVersion v="2.10.0">` until released.

Closes #1404

## Test plan
- [x] `vitest run --project unit src/loader.test.ts` passes (26/26)
- [x] Typecheck clean on `loader.ts`