### PR TITLE
fix: refresh useQueryStates options and defaults

### DIFF
--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -282,6 +282,59 @@ describe('useQueryStates: referential equality', () => {
     expect(result.current[0].obj).toBe(nextDefault)
   })
 
+  it('keeps inline structured defaults stable until they change', async () => {
+    const objectParser = parseAsJson<{ value: string }>(
+      value => value as { value: string }
+    )
+    const arrayParser = parseAsArrayOf(objectParser)
+    const useTestHook = ({ value }: { value: string } = { value: 'initial' }) =>
+      useQueryStates({
+        obj: objectParser.withDefault({ value }),
+        arr: arrayParser.withDefault([{ value }])
+      })
+    const { result, rerender } = await renderHook(useTestHook, {
+      initialProps: { value: 'initial' },
+      wrapper: withNuqsTestingAdapter()
+    })
+    const [initialState] = result.current
+
+    await rerender({ value: 'initial' })
+    const [equalState] = result.current
+
+    expect(equalState).toBe(initialState)
+    expect(equalState.obj).toBe(initialState.obj)
+    expect(equalState.arr).toBe(initialState.arr)
+    expect(equalState.arr[0]).toBe(initialState.arr[0])
+
+    await rerender({ value: 'next' })
+    const [nextState] = result.current
+
+    expect(nextState).not.toBe(initialState)
+    expect(nextState.obj).not.toBe(initialState.obj)
+    expect(nextState.arr).not.toBe(initialState.arr)
+    expect(nextState.arr[0]).not.toBe(initialState.arr[0])
+  })
+
+  it('uses referential equality when a parser has no eq function', async () => {
+    const parser = {
+      parse: (value: string) => JSON.parse(value) as { value: string },
+      serialize: JSON.stringify
+    }
+    const useTestHook = () =>
+      useQueryStates({
+        obj: { ...parser, defaultValue: { value: 'default' } }
+      })
+    const { result, rerender } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter()
+    })
+    const [initialState] = result.current
+
+    await rerender()
+
+    expect(result.current[0]).not.toBe(initialState)
+    expect(result.current[0].obj).not.toBe(initialState.obj)
+  })
+
   it('should use the latest default when another hook clears the value', async () => {
     const useTestHook = (
       { defaultValue }: { defaultValue: string } = {
@@ -530,6 +583,89 @@ describe('useQueryStates: clearOnDefault', () => {
 
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('push')
+  })
+
+  it('follows hook-level clearOnDefault changes', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = (
+      { clearOnDefault }: { clearOnDefault: boolean } = {
+        clearOnDefault: true
+      }
+    ) =>
+      useQueryStates(
+        {
+          test: parseAsString.withDefault('default')
+        },
+        { clearOnDefault }
+      )
+    const { result, rerender, act } = await renderHook(useTestHook, {
+      initialProps: { clearOnDefault: true },
+      wrapper: withNuqsTestingAdapter({
+        searchParams: '?test=initial',
+        onUrlUpdate
+      })
+    })
+
+    await rerender({ clearOnDefault: false })
+    await act(() => result.current[1]({ test: 'default' }))
+
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?test=default')
+  })
+
+  it('does not expose parser config from a discarded render to its setter', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const never = new Promise<void>(() => {})
+    function TestComponent() {
+      const [defaultValue, setDefaultValue] = useState('committed')
+      const [{ test }, setQuery] = useQueryStates(
+        {
+          test: parseAsString.withDefault(defaultValue)
+        },
+        {
+          urlKeys: { test: defaultValue }
+        }
+      )
+      if (defaultValue === 'speculative') {
+        throw never
+      }
+      return (
+        <>
+          <button
+            onClick={() => {
+              React.startTransition(() => setDefaultValue('speculative'))
+            }}
+          >
+            Suspend
+          </button>
+          <button
+            onClick={() => {
+              setQuery(current => ({ test: `${current.test}!` }))
+            }}
+          >
+            Update
+          </button>
+          <div>value: {test}</div>
+        </>
+      )
+    }
+    const user = userEvent.setup()
+    await render(
+      <React.Suspense fallback={<div>loading</div>}>
+        <TestComponent />
+      </React.Suspense>,
+      {
+        wrapper: withNuqsTestingAdapter({ onUrlUpdate })
+      }
+    )
+
+    await user.click(page.getByRole('button', { name: 'Suspend' }))
+    await user.click(page.getByRole('button', { name: 'Update' }))
+
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe(
+      '?committed=committed!'
+    )
   })
 })
 

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -336,6 +336,22 @@ describe('useQueryStates: referential equality', () => {
     expect(result.current[0].obj).not.toBe(initialState.obj)
   })
 
+  it('supports defaults that cannot be JSON serialized', async () => {
+    const parser = createParser({
+      parse: BigInt,
+      serialize: String
+    }).withDefault(0n)
+    const useTestHook = () => useQueryStates({ value: parser })
+
+    const { result, rerender } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter()
+    })
+
+    expect(result.current[0].value).toBe(0n)
+    await rerender()
+    expect(result.current[0].value).toBe(0n)
+  })
+
   it('should use the latest default when another hook clears the value', async () => {
     const useTestHook = (
       { defaultValue }: { defaultValue: string } = {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -316,7 +316,7 @@ describe('useQueryStates: referential equality', () => {
     expect(nextState.arr[0]).not.toBe(initialState.arr[0])
   })
 
-  it('uses parser referential equality for structured defaults', async () => {
+  it('does not have referential stability for structured defaults passed inline without an eq function', async () => {
     const parser = createParser({
       parse: (value: string) => JSON.parse(value) as { value: string },
       serialize: JSON.stringify

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -320,9 +320,11 @@ describe('useQueryStates: referential equality', () => {
     const parser = createParser({
       parse: (value: string) => JSON.parse(value) as { value: string },
       serialize: JSON.stringify
+      // no eq function provided
     })
     const useTestHook = () =>
       useQueryStates({
+        // inline default object
         obj: parser.withDefault({ value: 'default' })
       })
     const { result, rerender } = await renderHook(useTestHook, {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -255,6 +255,56 @@ describe('useQueryStates: referential equality', () => {
     expect(state.multi).toBe(defaults.multi)
     expect(state.multi[0]).toBe(defaults.multi[0])
   })
+
+  it('should update when an object default changes', async () => {
+    const initialDefault = { value: 'initial' }
+    const nextDefault = { value: 'next' }
+    const useTestHook = (
+      {
+        defaultValue
+      }: {
+        defaultValue: typeof initialDefault
+      } = { defaultValue: initialDefault }
+    ) =>
+      useQueryStates({
+        obj: parseAsJson<typeof initialDefault>(
+          x => x as typeof initialDefault
+        ).withDefault(defaultValue)
+      })
+    const { result, rerender } = await renderHook(useTestHook, {
+      initialProps: { defaultValue: initialDefault },
+      wrapper: withNuqsTestingAdapter()
+    })
+
+    expect(result.current[0].obj).toBe(initialDefault)
+    await rerender({ defaultValue: nextDefault })
+
+    expect(result.current[0].obj).toBe(nextDefault)
+  })
+
+  it('should use the latest default when another hook clears the value', async () => {
+    const useTestHook = (
+      { defaultValue }: { defaultValue: string } = {
+        defaultValue: 'initial'
+      }
+    ) => ({
+      withDefault: useQueryStates({
+        test: parseAsString.withDefault(defaultValue)
+      }),
+      withoutDefault: useQueryState('test', parseAsString)
+    })
+    const { result, rerender, act } = await renderHook(useTestHook, {
+      initialProps: { defaultValue: 'initial' },
+      wrapper: withNuqsTestingAdapter()
+    })
+
+    await rerender({ defaultValue: 'next' })
+    await act(() => result.current.withoutDefault[1]('value'))
+    expect(result.current.withDefault[0].test).toBe('value')
+    await act(() => result.current.withoutDefault[1](null))
+
+    expect(result.current.withDefault[0].test).toBe('next')
+  })
 })
 
 describe('useQueryStates: rendering & bail-out', () => {
@@ -457,6 +507,26 @@ describe('useQueryStates: clearOnDefault', () => {
     )
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('')
+  })
+
+  it('follows parser option changes', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    type Props = { history: 'push' | 'replace' }
+    const useTestHook = ({ history }: Props = { history: 'replace' }) =>
+      useQueryStates({
+        test: parseAsString.withOptions({ history })
+      })
+    const initialProps: Props = { history: 'replace' }
+    const { result, rerender, act } = await renderHook(useTestHook, {
+      initialProps,
+      wrapper: withNuqsTestingAdapter({ onUrlUpdate })
+    })
+
+    await rerender({ history: 'push' })
+    await act(() => result.current[1]({ test: 'pass' }))
+
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('push')
   })
 })
 

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -18,6 +18,7 @@ import {
 } from './adapters/testing'
 import { debounce, throttle } from './lib/queues/rate-limiting'
 import {
+  createParser,
   parseAsArrayOf,
   parseAsInteger,
   parseAsJson,
@@ -315,14 +316,14 @@ describe('useQueryStates: referential equality', () => {
     expect(nextState.arr[0]).not.toBe(initialState.arr[0])
   })
 
-  it('uses referential equality when a parser has no eq function', async () => {
-    const parser = {
+  it('uses parser referential equality for structured defaults', async () => {
+    const parser = createParser({
       parse: (value: string) => JSON.parse(value) as { value: string },
       serialize: JSON.stringify
-    }
+    })
     const useTestHook = () =>
       useQueryStates({
-        obj: { ...parser, defaultValue: { value: 'default' } }
+        obj: parser.withDefault({ value: 'default' })
       })
     const { result, rerender } = await renderHook(useTestHook, {
       wrapper: withNuqsTestingAdapter()

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -587,7 +587,7 @@ describe('useQueryStates: clearOnDefault', () => {
     type Props = { history: 'push' | 'replace' }
     const useTestHook = ({ history }: Props = { history: 'replace' }) =>
       useQueryStates({
-        test: parseAsString.withOptions({ history })
+        defaultValue: parseAsString.withOptions({ history })
       })
     const initialProps: Props = { history: 'replace' }
     const { result, rerender, act } = await renderHook(useTestHook, {
@@ -596,7 +596,7 @@ describe('useQueryStates: clearOnDefault', () => {
     })
 
     await rerender({ history: 'push' })
-    await act(() => result.current[1]({ test: 'pass' }))
+    await act(() => result.current[1]({ defaultValue: 'pass' }))
 
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('push')

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -304,6 +304,9 @@ describe('useQueryStates: referential equality', () => {
     await act(() => result.current.withoutDefault[1](null))
 
     expect(result.current.withDefault[0].test).toBe('next')
+
+    await rerender({ defaultValue: 'latest' })
+    expect(result.current.withDefault[0].test).toBe('latest')
   })
 })
 

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -94,8 +94,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const updateKeyMapRef = useRef(keyMap)
   const previousKeyMap = updateKeyMapRef.current
   const updateKeyMap =
-    JSON.stringify(previousKeyMap, omitDefaultValue) ===
-      JSON.stringify(keyMap, omitDefaultValue) &&
+    JSON.stringify(Object.entries(previousKeyMap), omitDefaultValue) ===
+      JSON.stringify(Object.entries(keyMap), omitDefaultValue) &&
     Object.entries(keyMap).every(([key, parser]) => {
       const previousDefault = previousKeyMap[key]?.defaultValue
       return (

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -88,6 +88,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   } = options
 
   type V = NullableValues<KeyMap>
+  const keyMapRef = useRef(keyMap)
+  keyMapRef.current = keyMap
   const stateKeys = Object.keys(keyMap).join(',')
   const resolvedUrlKeys = useMemo(
     () =>
@@ -115,17 +117,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // render and skip the reconcile (#1273). A genuine `<Activity>` reveal keeps
   // the same pathname, so it still reconciles.
   const committedPathnameRef = useRef<string | null>(null)
-  const defaultValues = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.keys(keyMap).map(key => [key, keyMap[key]!.defaultValue ?? null])
-      ) as Values<KeyMap>,
-    [
-      Object.values(keyMap)
-        .map(({ defaultValue }) => defaultValue)
-        .join(',')
-    ]
-  )
   const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
   const [internalState, setInternalState] = useState<V>(
     () => parseMap(keyMap, urlKeys, initialSearchParams, queuedQueries).state
@@ -237,19 +228,15 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           query
         }: CrossHookSyncPayload) => {
           setInternalState(currentState => {
-            const { defaultValue } = keyMap[stateKey]!
             const urlKey = resolvedUrlKeys[stateKey]!
-            const nextValue = state ?? defaultValue ?? null
-            const currentValue = currentState[stateKey] ?? defaultValue ?? null
-
-            if (Object.is(currentValue, nextValue)) {
+            if (Object.is(currentState[stateKey] ?? null, state)) {
               debug(
                 2,
                 hookId,
                 stateKeys,
                 urlKey,
                 state,
-                defaultValue,
+                keyMapRef.current[stateKey]?.defaultValue,
                 stateRef.current
               )
               // bail out by returning the current state
@@ -259,7 +246,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             // for the subsequent setState to pick it up.
             stateRef.current = {
               ...stateRef.current,
-              [stateKey as keyof KeyMap]: nextValue
+              [stateKey as keyof KeyMap]: state
             }
             queryRef.current[urlKey] = query
             debug(
@@ -268,7 +255,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
               stateKeys,
               urlKey,
               state,
-              defaultValue,
+              keyMapRef.current[stateKey]?.defaultValue,
               stateRef.current
             )
             return stateRef.current
@@ -296,12 +283,12 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const update = useCallback<SetValues<KeyMap>>(
     (stateUpdater, callOptions = {}) => {
       const nullMap = Object.fromEntries(
-        Object.keys(keyMap).map(key => [key, null])
+        Object.keys(keyMapRef.current).map(key => [key, null])
       ) as Nullable<KeyMap>
       const newState: Partial<Nullable<KeyMap>> =
         typeof stateUpdater === 'function'
           ? (stateUpdater(
-              applyDefaultValues(stateRef.current, defaultValues)
+              applyDefaultValues(stateRef.current, keyMapRef.current)
             ) ?? nullMap)
           : (stateUpdater ?? nullMap)
       debug(6, hookId, stateKeys, newState)
@@ -312,7 +299,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         (p: Promise<URLSearchParams>) => Promise<URLSearchParams>
       > = []
       for (let [stateKey, value] of Object.entries(newState)) {
-        const parser = keyMap[stateKey]
+        const parser = keyMapRef.current[stateKey]
         const urlKey = resolvedUrlKeys[stateKey]!
         if (!parser || value === undefined) {
           continue
@@ -398,15 +385,17 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       adapter.updateUrl,
       adapter.getSearchParamsSnapshot,
       adapter.rateLimitFactor,
-      processUrlSearchParams,
-      defaultValues
+      processUrlSearchParams
     ]
   )
 
-  const outputState = useMemo(
-    () => applyDefaultValues(internalState, defaultValues),
-    [internalState, defaultValues]
+  const outputStateRef = useRef<Values<KeyMap> | null>(null)
+  const outputState = applyDefaultValues(
+    internalState,
+    keyMap,
+    outputStateRef.current
   )
+  outputStateRef.current = outputState
   return [outputState, update]
 }
 
@@ -471,9 +460,19 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
 
 function applyDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
   state: NullableValues<KeyMap>,
-  defaults: Partial<Values<KeyMap>>
+  keyMap: KeyMap,
+  cachedState?: Values<KeyMap> | null
 ) {
-  return Object.fromEntries(
-    Object.keys(state).map(key => [key, state[key] ?? defaults[key] ?? null])
+  const outputState = Object.fromEntries(
+    Object.keys(state).map(key => [
+      key,
+      state[key] ?? keyMap[key]?.defaultValue ?? null
+    ])
   ) as Values<KeyMap>
+  const stateKeys = Object.keys(state)
+  return cachedState &&
+    stateKeys.length === Object.keys(cachedState).length &&
+    stateKeys.every(key => Object.is(outputState[key], cachedState[key]))
+    ? cachedState
+    : outputState
 }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -59,8 +59,6 @@ export type UseQueryStatesReturn<T extends UseQueryStatesKeysMap> = [
 // by hoisting it out of the function scope.
 // Otherwise useEffect loops go brrrr
 const defaultUrlKeys = {}
-const objectIds = new WeakMap<object, number>()
-let nextObjectId = 0
 
 /**
  * Synchronise multiple query string arguments to React state in Next.js
@@ -91,42 +89,28 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
   type V = NullableValues<KeyMap>
   const stateKeys = Object.keys(keyMap).join(',')
+  const updateKeyMapRef = useRef(keyMap)
+  const previousKeyMap = updateKeyMapRef.current
+  const updateKeyMap =
+    JSON.stringify(previousKeyMap) === JSON.stringify(keyMap) &&
+    Object.entries(keyMap).every(([key, parser]) => {
+      const previousDefault = previousKeyMap[key]?.defaultValue
+      return (
+        Object.is(previousDefault, parser.defaultValue) ||
+        (previousDefault !== undefined &&
+          parser.defaultValue !== undefined &&
+          parser.eq?.(previousDefault, parser.defaultValue) === true)
+      )
+    })
+      ? previousKeyMap
+      : keyMap
+  updateKeyMapRef.current = updateKeyMap
   const resolvedUrlKeys = useMemo(
     () =>
       Object.fromEntries(
         Object.keys(keyMap).map(key => [key, urlKeys[key] ?? key])
       ),
     [stateKeys, JSON.stringify(urlKeys)]
-  )
-  const configurationKey = JSON.stringify(
-    Object.entries(keyMap).map(([key, parser]) => [
-      key,
-      resolvedUrlKeys[key],
-      getObjectId(parser.serialize),
-      getObjectId(parser.eq),
-      parser.history,
-      parser.scroll,
-      parser.shallow,
-      parser.throttleMs,
-      getObjectId(parser.startTransition),
-      parser.clearOnDefault,
-      parser.limitUrlUpdates?.method,
-      parser.limitUrlUpdates?.timeMs
-    ])
-  )
-  // This cache only invalidates the memo. The published value is created from
-  // the current render, never read back from this ref.
-  const defaultValuesRef = useRef({ keyMap, version: 0 })
-  if (!hasSameDefaultValues(defaultValuesRef.current.keyMap, keyMap)) {
-    defaultValuesRef.current = {
-      keyMap,
-      version: defaultValuesRef.current.version + 1
-    }
-  }
-  const defaultValuesVersion = defaultValuesRef.current.version
-  const defaultValues = useMemo(
-    () => collectDefaultValues(keyMap),
-    [defaultValuesVersion]
   )
   const adapter = useAdapter(Object.values(resolvedUrlKeys))
   const initialSearchParams = adapter.searchParams
@@ -310,18 +294,15 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     }
   }, [stateKeys, resolvedUrlKeys])
 
-  // Parser and URL key share this callback's render generation. React discards
-  // a new callback with an abandoned render, leaving the committed one intact.
   const update = useCallback<SetValues<KeyMap>>(
     (stateUpdater, callOptions = {}) => {
       const nullMap = Object.fromEntries(
-        Object.keys(keyMap).map(key => [key, null])
+        Object.keys(updateKeyMap).map(key => [key, null])
       ) as Nullable<KeyMap>
       const newState: Partial<Nullable<KeyMap>> =
         typeof stateUpdater === 'function'
-          ? (stateUpdater(
-              applyDefaultValues(stateRef.current, defaultValues)
-            ) ?? nullMap)
+          ? (stateUpdater(applyDefaultValues(stateRef.current, updateKeyMap)) ??
+            nullMap)
           : (stateUpdater ?? nullMap)
       debug(6, hookId, stateKeys, newState)
       let returnedPromise: Promise<URLSearchParams> | undefined = undefined
@@ -331,9 +312,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         (p: Promise<URLSearchParams>) => Promise<URLSearchParams>
       > = []
       for (let [stateKey, value] of Object.entries(newState)) {
-        const parser = keyMap[stateKey]
+        const parser = updateKeyMap[stateKey]
         const urlKey = resolvedUrlKeys[stateKey]
-        const defaultValue = defaultValues[stateKey]
         if (!parser || urlKey === undefined || value === undefined) {
           continue
         }
@@ -342,8 +322,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             parser.clearOnDefault ??
             clearOnDefault) &&
           value !== null &&
-          defaultValue !== null &&
-          (parser.eq ?? ((a, b) => a === b))(value, defaultValue)
+          parser.defaultValue !== undefined &&
+          (parser.eq ?? ((a, b) => a === b))(value, parser.defaultValue)
         ) {
           value = null
         }
@@ -406,6 +386,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       return returnedPromise ?? globalPromise
     },
     [
+      stateKeys,
       history,
       shallow,
       scroll,
@@ -414,68 +395,26 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       limitUrlUpdates?.timeMs,
       startTransition,
       clearOnDefault,
+      updateKeyMap,
+      resolvedUrlKeys,
       adapter.updateUrl,
       adapter.getSearchParamsSnapshot,
       adapter.rateLimitFactor,
-      processUrlSearchParams,
-      configurationKey,
-      defaultValues
+      processUrlSearchParams
     ]
   )
 
-  const outputState = useMemo(
-    () => applyDefaultValues(internalState, defaultValues),
-    [internalState, defaultValues]
+  const outputStateRef = useRef<Values<KeyMap> | null>(null)
+  const outputState = applyDefaultValues(
+    internalState,
+    keyMap,
+    outputStateRef.current
   )
+  outputStateRef.current = outputState
   return [outputState, update]
 }
 
 // --
-
-function getObjectId(value: object | undefined) {
-  if (value === undefined) {
-    return null
-  }
-  const existing = objectIds.get(value)
-  if (existing !== undefined) {
-    return existing
-  }
-  const id = nextObjectId++
-  objectIds.set(value, id)
-  return id
-}
-
-function collectDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
-  keyMap: KeyMap
-) {
-  return Object.fromEntries(
-    Object.entries(keyMap).map(([key, parser]) => [
-      key,
-      parser.defaultValue ?? null
-    ])
-  ) as Values<KeyMap>
-}
-
-function hasSameDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
-  previous: KeyMap,
-  keyMap: KeyMap
-) {
-  const keys = Object.keys(keyMap)
-  return (
-    keys.length === Object.keys(previous).length &&
-    keys.every(key => {
-      const parser = keyMap[key]
-      const previousValue = previous[key]?.defaultValue ?? null
-      const value = parser?.defaultValue ?? null
-      return (
-        Object.is(previousValue, value) ||
-        (previousValue !== null &&
-          value !== null &&
-          parser?.eq?.(previousValue, value) === true)
-      )
-    })
-  )
-}
 
 function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   keyMap: KeyMap,
@@ -514,6 +453,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
       ? null
       : // we have properly narrowed `query` here, but TS doesn't keep track of that
         safeParse(parser.parse, query as string & Array<string>, urlKey)
+
     out[stateKey as keyof KeyMap] = value ?? null
     if (cachedQuery) {
       cachedQuery[urlKey] = query
@@ -535,9 +475,30 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
 
 function applyDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
   state: NullableValues<KeyMap>,
-  defaults: Values<KeyMap>
+  keyMap: KeyMap,
+  cachedState?: Values<KeyMap> | null
 ) {
-  return Object.fromEntries(
-    Object.keys(state).map(key => [key, state[key] ?? defaults[key] ?? null])
+  const outputState = Object.fromEntries(
+    Object.keys(state).map(key => [
+      key,
+      state[key] ?? keyMap[key]?.defaultValue ?? null
+    ])
   ) as Values<KeyMap>
+  const stateKeys = Object.keys(state)
+  return cachedState &&
+    stateKeys.length === Object.keys(cachedState).length &&
+    stateKeys.every(key => {
+      if (Object.is(outputState[key], cachedState[key])) {
+        return true
+      }
+      const parser = keyMap[key]
+      return (
+        state[key] == null &&
+        outputState[key] != null &&
+        cachedState[key] != null &&
+        parser?.eq?.(outputState[key], cachedState[key]) === true
+      )
+    })
+    ? cachedState
+    : outputState
 }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -99,11 +99,14 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       JSON.stringify(Object.entries(keyMap), omitDefaultValue) &&
     Object.entries(keyMap).every(([key, parser]) => {
       const previousDefault = cachedKeyMap[key]?.defaultValue
+      const currentDefault = parser.defaultValue
+      if (Object.is(previousDefault, currentDefault)) {
+        return true
+      }
       return (
-        Object.is(previousDefault, parser.defaultValue) ||
-        (previousDefault !== undefined &&
-          parser.defaultValue !== undefined &&
-          parser.eq?.(previousDefault, parser.defaultValue) === true)
+        previousDefault !== undefined &&
+        currentDefault !== undefined &&
+        parser.eq?.(previousDefault, currentDefault) === true
       )
     })
       ? cachedKeyMap

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -59,6 +59,8 @@ export type UseQueryStatesReturn<T extends UseQueryStatesKeysMap> = [
 // by hoisting it out of the function scope.
 // Otherwise useEffect loops go brrrr
 const defaultUrlKeys = {}
+const objectIds = new WeakMap<object, number>()
+let nextObjectId = 0
 
 /**
  * Synchronise multiple query string arguments to React state in Next.js
@@ -88,8 +90,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   } = options
 
   type V = NullableValues<KeyMap>
-  const keyMapRef = useRef(keyMap)
-  keyMapRef.current = keyMap
   const stateKeys = Object.keys(keyMap).join(',')
   const resolvedUrlKeys = useMemo(
     () =>
@@ -97,6 +97,36 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         Object.keys(keyMap).map(key => [key, urlKeys[key] ?? key])
       ),
     [stateKeys, JSON.stringify(urlKeys)]
+  )
+  const configurationKey = JSON.stringify(
+    Object.entries(keyMap).map(([key, parser]) => [
+      key,
+      resolvedUrlKeys[key],
+      getObjectId(parser.serialize),
+      getObjectId(parser.eq),
+      parser.history,
+      parser.scroll,
+      parser.shallow,
+      parser.throttleMs,
+      getObjectId(parser.startTransition),
+      parser.clearOnDefault,
+      parser.limitUrlUpdates?.method,
+      parser.limitUrlUpdates?.timeMs
+    ])
+  )
+  // This cache only invalidates the memo. The published value is created from
+  // the current render, never read back from this ref.
+  const defaultValuesRef = useRef({ keyMap, version: 0 })
+  if (!hasSameDefaultValues(defaultValuesRef.current.keyMap, keyMap)) {
+    defaultValuesRef.current = {
+      keyMap,
+      version: defaultValuesRef.current.version + 1
+    }
+  }
+  const defaultValuesVersion = defaultValuesRef.current.version
+  const defaultValues = useMemo(
+    () => collectDefaultValues(keyMap),
+    [defaultValuesVersion]
   )
   const adapter = useAdapter(Object.values(resolvedUrlKeys))
   const initialSearchParams = adapter.searchParams
@@ -236,7 +266,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
                 stateKeys,
                 urlKey,
                 state,
-                keyMapRef.current[stateKey]?.defaultValue,
+                keyMap[stateKey]?.defaultValue,
                 stateRef.current
               )
               // bail out by returning the current state
@@ -255,7 +285,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
               stateKeys,
               urlKey,
               state,
-              keyMapRef.current[stateKey]?.defaultValue,
+              keyMap[stateKey]?.defaultValue,
               stateRef.current
             )
             return stateRef.current
@@ -280,15 +310,17 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     }
   }, [stateKeys, resolvedUrlKeys])
 
+  // Parser and URL key share this callback's render generation. React discards
+  // a new callback with an abandoned render, leaving the committed one intact.
   const update = useCallback<SetValues<KeyMap>>(
     (stateUpdater, callOptions = {}) => {
       const nullMap = Object.fromEntries(
-        Object.keys(keyMapRef.current).map(key => [key, null])
+        Object.keys(keyMap).map(key => [key, null])
       ) as Nullable<KeyMap>
       const newState: Partial<Nullable<KeyMap>> =
         typeof stateUpdater === 'function'
           ? (stateUpdater(
-              applyDefaultValues(stateRef.current, keyMapRef.current)
+              applyDefaultValues(stateRef.current, defaultValues)
             ) ?? nullMap)
           : (stateUpdater ?? nullMap)
       debug(6, hookId, stateKeys, newState)
@@ -299,9 +331,10 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         (p: Promise<URLSearchParams>) => Promise<URLSearchParams>
       > = []
       for (let [stateKey, value] of Object.entries(newState)) {
-        const parser = keyMapRef.current[stateKey]
-        const urlKey = resolvedUrlKeys[stateKey]!
-        if (!parser || value === undefined) {
+        const parser = keyMap[stateKey]
+        const urlKey = resolvedUrlKeys[stateKey]
+        const defaultValue = defaultValues[stateKey]
+        if (!parser || urlKey === undefined || value === undefined) {
           continue
         }
         if (
@@ -309,8 +342,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             parser.clearOnDefault ??
             clearOnDefault) &&
           value !== null &&
-          parser.defaultValue !== undefined &&
-          (parser.eq ?? ((a, b) => a === b))(value, parser.defaultValue)
+          defaultValue !== null &&
+          (parser.eq ?? ((a, b) => a === b))(value, defaultValue)
         ) {
           value = null
         }
@@ -373,7 +406,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       return returnedPromise ?? globalPromise
     },
     [
-      stateKeys,
       history,
       shallow,
       scroll,
@@ -381,25 +413,69 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       limitUrlUpdates?.method,
       limitUrlUpdates?.timeMs,
       startTransition,
-      resolvedUrlKeys,
+      clearOnDefault,
       adapter.updateUrl,
       adapter.getSearchParamsSnapshot,
       adapter.rateLimitFactor,
-      processUrlSearchParams
+      processUrlSearchParams,
+      configurationKey,
+      defaultValues
     ]
   )
 
-  const outputStateRef = useRef<Values<KeyMap> | null>(null)
-  const outputState = applyDefaultValues(
-    internalState,
-    keyMap,
-    outputStateRef.current
+  const outputState = useMemo(
+    () => applyDefaultValues(internalState, defaultValues),
+    [internalState, defaultValues]
   )
-  outputStateRef.current = outputState
   return [outputState, update]
 }
 
 // --
+
+function getObjectId(value: object | undefined) {
+  if (value === undefined) {
+    return null
+  }
+  const existing = objectIds.get(value)
+  if (existing !== undefined) {
+    return existing
+  }
+  const id = nextObjectId++
+  objectIds.set(value, id)
+  return id
+}
+
+function collectDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
+  keyMap: KeyMap
+) {
+  return Object.fromEntries(
+    Object.entries(keyMap).map(([key, parser]) => [
+      key,
+      parser.defaultValue ?? null
+    ])
+  ) as Values<KeyMap>
+}
+
+function hasSameDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
+  previous: KeyMap,
+  keyMap: KeyMap
+) {
+  const keys = Object.keys(keyMap)
+  return (
+    keys.length === Object.keys(previous).length &&
+    keys.every(key => {
+      const parser = keyMap[key]
+      const previousValue = previous[key]?.defaultValue ?? null
+      const value = parser?.defaultValue ?? null
+      return (
+        Object.is(previousValue, value) ||
+        (previousValue !== null &&
+          value !== null &&
+          parser?.eq?.(previousValue, value) === true)
+      )
+    })
+  )
+}
 
 function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   keyMap: KeyMap,
@@ -438,7 +514,6 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
       ? null
       : // we have properly narrowed `query` here, but TS doesn't keep track of that
         safeParse(parser.parse, query as string & Array<string>, urlKey)
-
     out[stateKey as keyof KeyMap] = value ?? null
     if (cachedQuery) {
       cachedQuery[urlKey] = query
@@ -460,19 +535,9 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
 
 function applyDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
   state: NullableValues<KeyMap>,
-  keyMap: KeyMap,
-  cachedState?: Values<KeyMap> | null
+  defaults: Values<KeyMap>
 ) {
-  const outputState = Object.fromEntries(
-    Object.keys(state).map(key => [
-      key,
-      state[key] ?? keyMap[key]?.defaultValue ?? null
-    ])
+  return Object.fromEntries(
+    Object.keys(state).map(key => [key, state[key] ?? defaults[key] ?? null])
   ) as Values<KeyMap>
-  const stateKeys = Object.keys(state)
-  return cachedState &&
-    stateKeys.length === Object.keys(cachedState).length &&
-    stateKeys.every(key => Object.is(outputState[key], cachedState[key]))
-    ? cachedState
-    : outputState
 }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -59,6 +59,7 @@ export type UseQueryStatesReturn<T extends UseQueryStatesKeysMap> = [
 // by hoisting it out of the function scope.
 // Otherwise useEffect loops go brrrr
 const defaultUrlKeys = {}
+// Defaults may not be JSON-serializable and are compared with parser eq below.
 const omitDefaultValue = (key: string, value: unknown) =>
   key === 'defaultValue' ? undefined : value
 
@@ -91,13 +92,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
   type V = NullableValues<KeyMap>
   const stateKeys = Object.keys(keyMap).join(',')
-  const updateKeyMapRef = useRef(keyMap)
-  const previousKeyMap = updateKeyMapRef.current
-  const updateKeyMap =
-    JSON.stringify(Object.entries(previousKeyMap), omitDefaultValue) ===
+  const cachedKeyMapRef = useRef(keyMap)
+  const cachedKeyMap = cachedKeyMapRef.current
+  const stableKeyMap =
+    JSON.stringify(Object.entries(cachedKeyMap), omitDefaultValue) ===
       JSON.stringify(Object.entries(keyMap), omitDefaultValue) &&
     Object.entries(keyMap).every(([key, parser]) => {
-      const previousDefault = previousKeyMap[key]?.defaultValue
+      const previousDefault = cachedKeyMap[key]?.defaultValue
       return (
         Object.is(previousDefault, parser.defaultValue) ||
         (previousDefault !== undefined &&
@@ -105,9 +106,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           parser.eq?.(previousDefault, parser.defaultValue) === true)
       )
     })
-      ? previousKeyMap
+      ? cachedKeyMap
       : keyMap
-  updateKeyMapRef.current = updateKeyMap
+  cachedKeyMapRef.current = stableKeyMap
   const resolvedUrlKeys = useMemo(
     () =>
       Object.fromEntries(
@@ -300,11 +301,11 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const update = useCallback<SetValues<KeyMap>>(
     (stateUpdater, callOptions = {}) => {
       const nullMap = Object.fromEntries(
-        Object.keys(updateKeyMap).map(key => [key, null])
+        Object.keys(stableKeyMap).map(key => [key, null])
       ) as Nullable<KeyMap>
       const newState: Partial<Nullable<KeyMap>> =
         typeof stateUpdater === 'function'
-          ? (stateUpdater(applyDefaultValues(stateRef.current, updateKeyMap)) ??
+          ? (stateUpdater(applyDefaultValues(stateRef.current, stableKeyMap)) ??
             nullMap)
           : (stateUpdater ?? nullMap)
       debug(6, hookId, stateKeys, newState)
@@ -315,7 +316,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         (p: Promise<URLSearchParams>) => Promise<URLSearchParams>
       > = []
       for (let [stateKey, value] of Object.entries(newState)) {
-        const parser = updateKeyMap[stateKey]
+        const parser = stableKeyMap[stateKey]
         const urlKey = resolvedUrlKeys[stateKey]
         if (!parser || urlKey === undefined || value === undefined) {
           continue
@@ -398,7 +399,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       limitUrlUpdates?.timeMs,
       startTransition,
       clearOnDefault,
-      updateKeyMap,
+      stableKeyMap,
       resolvedUrlKeys,
       adapter.updateUrl,
       adapter.getSearchParamsSnapshot,
@@ -408,8 +409,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   )
 
   const outputState = useMemo(
-    () => applyDefaultValues(internalState, updateKeyMap),
-    [internalState, updateKeyMap]
+    () => applyDefaultValues(internalState, stableKeyMap),
+    [internalState, stableKeyMap]
   )
   return [outputState, update]
 }

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -59,6 +59,8 @@ export type UseQueryStatesReturn<T extends UseQueryStatesKeysMap> = [
 // by hoisting it out of the function scope.
 // Otherwise useEffect loops go brrrr
 const defaultUrlKeys = {}
+const omitDefaultValue = (key: string, value: unknown) =>
+  key === 'defaultValue' ? undefined : value
 
 /**
  * Synchronise multiple query string arguments to React state in Next.js
@@ -92,7 +94,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const updateKeyMapRef = useRef(keyMap)
   const previousKeyMap = updateKeyMapRef.current
   const updateKeyMap =
-    JSON.stringify(previousKeyMap) === JSON.stringify(keyMap) &&
+    JSON.stringify(previousKeyMap, omitDefaultValue) ===
+      JSON.stringify(keyMap, omitDefaultValue) &&
     Object.entries(keyMap).every(([key, parser]) => {
       const previousDefault = previousKeyMap[key]?.defaultValue
       return (
@@ -404,13 +407,10 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     ]
   )
 
-  const outputStateRef = useRef<Values<KeyMap> | null>(null)
-  const outputState = applyDefaultValues(
-    internalState,
-    keyMap,
-    outputStateRef.current
+  const outputState = useMemo(
+    () => applyDefaultValues(internalState, updateKeyMap),
+    [internalState, updateKeyMap]
   )
-  outputStateRef.current = outputState
   return [outputState, update]
 }
 
@@ -475,30 +475,12 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
 
 function applyDefaultValues<KeyMap extends UseQueryStatesKeysMap>(
   state: NullableValues<KeyMap>,
-  keyMap: KeyMap,
-  cachedState?: Values<KeyMap> | null
+  keyMap: KeyMap
 ) {
-  const outputState = Object.fromEntries(
+  return Object.fromEntries(
     Object.keys(state).map(key => [
       key,
       state[key] ?? keyMap[key]?.defaultValue ?? null
     ])
   ) as Values<KeyMap>
-  const stateKeys = Object.keys(state)
-  return cachedState &&
-    stateKeys.length === Object.keys(cachedState).length &&
-    stateKeys.every(key => {
-      if (Object.is(outputState[key], cachedState[key])) {
-        return true
-      }
-      const parser = keyMap[key]
-      return (
-        state[key] == null &&
-        outputState[key] != null &&
-        cachedState[key] != null &&
-        parser?.eq?.(outputState[key], cachedState[key]) === true
-      )
-    })
-    ? cachedState
-    : outputState
 }


### PR DESCRIPTION
## Summary

- Use the current `useQueryStates` defaults and state updater function options after each re-render.
- Keep output object references stable when the parser configuration and defaults do not change.
- Prevent discarded renders from changing the configuration of existing state updater functions.
- Keep `null` as the synchronised internal value. Apply the current defaults only to the returned state.
- Ensure support for non-JSON defaults and dynamic state keys.

## Scope

This change refreshes serializable parser options and defaults. Changes visible only through function identity, such as `parse`, `serialize`, `eq`, or parser-level `startTransition`, remain out of scope. Changing parser functions alone does not reparse unchanged URL text.