### PR TITLE
fix: preserve credentials in URL serializer bases

### DIFF
--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -73,13 +73,38 @@ describe('serializer', () => {
     const result = serialize(url, { str: 'foo' })
     expect(result).toBe('https://example.com/path?bar=egg&str=foo')
   })
-  it('preserves credentials in a URL base', () => {
+  it('preserves credentials in string and URL bases', () => {
     const serialize = createSerializer(parsers)
-    const url = new URL('https://user:password@example.com/path?bar=egg')
-    const result = serialize(url, { str: 'foo' })
-    expect(result).toBe(
-      'https://user:password@example.com/path?bar=egg&str=foo'
-    )
+    const base = 'https://user:password@example.com/path?bar=egg'
+    const expected = 'https://user:password@example.com/path?bar=egg&str=foo'
+    expect(serialize(base, { str: 'foo' })).toBe(expected)
+    expect(serialize(new URL(base), { str: 'foo' })).toBe(expected)
+  })
+  it.each([
+    [
+      'empty search',
+      'https://example.com/path?',
+      'https://example.com/path?str=foo'
+    ],
+    [
+      'empty hash',
+      'https://example.com/path#',
+      'https://example.com/path?str=foo#'
+    ],
+    [
+      'empty search and hash',
+      'https://example.com/path?#',
+      'https://example.com/path?str=foo#'
+    ],
+    [
+      'empty search before a hash',
+      'https://example.com/path?#section',
+      'https://example.com/path?str=foo#section'
+    ]
+  ])('handles $0 in string and URL bases', (_, base, expected) => {
+    const serialize = createSerializer(parsers)
+    expect(serialize(base, { str: 'foo' })).toBe(expected)
+    expect(serialize(new URL(base), { str: 'foo' })).toBe(expected)
   })
   it('deletes a null value from base', () => {
     const serialize = createSerializer(parsers)

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -73,6 +73,14 @@ describe('serializer', () => {
     const result = serialize(url, { str: 'foo' })
     expect(result).toBe('https://example.com/path?bar=egg&str=foo')
   })
+  it('preserves credentials in a URL base', () => {
+    const serialize = createSerializer(parsers)
+    const url = new URL('https://user:password@example.com/path?bar=egg')
+    const result = serialize(url, { str: 'foo' })
+    expect(result).toBe(
+      'https://user:password@example.com/path?bar=egg&str=foo'
+    )
+  })
   it('deletes a null value from base', () => {
     const serialize = createSerializer(parsers)
     const result = serialize('?str=bar&int=-1', { str: 'foo', int: null })

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -128,8 +128,9 @@ function splitBase<BaseType extends Base>(base: BaseType) {
   } else if (base instanceof URLSearchParams) {
     return ['', new URLSearchParams(base), ''] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
   } else {
+    const baseLength = base.href.length - base.search.length - base.hash.length
     return [
-      base.origin + base.pathname,
+      base.href.slice(0, baseLength),
       new URLSearchParams(base.searchParams),
       base.hash
     ] as const

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -129,10 +129,8 @@ function splitBase<BaseType extends Base>(base: BaseType) {
     return ['', new URLSearchParams(base), ''] as const // Operate on a copy of URLSearchParams, as derived classes may restrict its allowed methods
   } else {
     const baseLength = base.href.length - base.search.length - base.hash.length
-    return [
-      base.href.slice(0, baseLength),
-      new URLSearchParams(base.searchParams),
-      base.hash
-    ] as const
+    const path = base.href.slice(0, baseLength).replace(/[?#]+$/, '')
+    const hash = base.hash || (base.href.endsWith('#') ? '#' : '')
+    return [path, new URLSearchParams(base.searchParams), hash] as const
   }
 }


### PR DESCRIPTION
## Summary

- Keep user credentials when `createSerializer` uses a `URL` as its base.
- Preserve the complete URL prefix while query parameters change.

## Test

- Add a regression test for a URL with a username and password.
