### PR TITLE
fix: reject invalid empty queries in strict loaders

### DIFF
--- a/packages/nuqs/src/loader.test.ts
+++ b/packages/nuqs/src/loader.test.ts
@@ -116,6 +116,14 @@ describe('loader', () => {
         '[nuqs] Failed to parse query `will-be-null` for key `test` (got null)'
       )
     })
+    it('throws errors in strict mode when the parser rejects an empty query', () => {
+      const load = createLoader({
+        count: parseAsInteger
+      })
+      expect(() => load('?count=', { strict: true })).toThrow(
+        '[nuqs] Failed to parse query `` for key `count` (got null)'
+      )
+    })
     it('throws errors in strict mode when the parser throws an error', () => {
       const load = createLoader({
         test: createParser({

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -117,7 +117,7 @@ export function createLoader<Parsers extends ParserMap>(
         }
         parsedValue = null
       }
-      if (strict && query && parsedValue === null) {
+      if (strict && parsedValue === null) {
         throw new Error(
           `[nuqs] Failed to parse query \`${query}\` for key \`${key}\` (got null)`
         )


### PR DESCRIPTION
## Summary

- make strict loaders reject empty query values when the configured parser returns `null`
- preserve valid empty values for parsers that return a non-null result
- add focused regression coverage for an empty integer query

## Context

This isolates the strict-mode hardening that also appears incidentally in #1504, without introducing a separate `required` parser option.
