### PR TITLE
fix: round-trip negative hexadecimal values

### DIFF
--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -47,6 +47,7 @@ describe('parsers', () => {
     expect(parseAsHex.parse('a')).toBe(0xa)
     expect(parseAsHex.parse('g')).toBeNull()
     expect(parseAsHex.serialize(0xa)).toBe('0a')
+    expect(isParserBijective(parseAsHex, '-10', -0x10)).toBe(true)
     for (let byte = 0; byte < 256; byte++) {
       const hexString = byte.toString(16).padStart(2, '0')
       expect(isParserBijective(parseAsHex, hexString, byte)).toBe(true)

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -253,9 +253,9 @@ export const parseAsHex: SingleParserBuilder<number> = createParser({
     return int == int ? int : null // NaN check at low bundle size cost
   },
   serialize: v => {
-    const rounded = Math.round(v)
-    const hex = Math.abs(rounded).toString(16)
-    return (rounded < 0 ? '-' : '') + (hex.length & 1 ? '0' : '') + hex
+    const hex = Math.round(v).toString(16)
+    // Negative hex starts with '-', which sorts before '0' and needs no padding
+    return hex < '0' || !(hex.length & 1) ? hex : '0' + hex
   }
 })
 

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -253,8 +253,9 @@ export const parseAsHex: SingleParserBuilder<number> = createParser({
     return int == int ? int : null // NaN check at low bundle size cost
   },
   serialize: v => {
-    const hex = Math.round(v).toString(16)
-    return (hex.length & 1 ? '0' : '') + hex
+    const rounded = Math.round(v)
+    const hex = Math.abs(rounded).toString(16)
+    return (rounded < 0 ? '-' : '') + (hex.length & 1 ? '0' : '') + hex
   }
 })
 


### PR DESCRIPTION
## Summary

- preserve the sign when serializing negative hexadecimal integers
- pad the hexadecimal magnitude independently from its sign
- add a negative-value bijectivity regression
