### PR TITLE
fix: reject invalid timestamps

### DIFF
--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -104,6 +104,7 @@ describe('parsers', () => {
 
   it('parseAsTimestamp', () => {
     expect(parseAsTimestamp.parse('')).toBeNull()
+    expect(parseAsTimestamp.parse('8640000000000001')).toBeNull()
     expect(parseAsTimestamp.parse('0')).toStrictEqual(new Date(0))
     expect(testParseThenSerialize(parseAsTimestamp, '0')).toBe(true)
     expect(testSerializeThenParse(parseAsTimestamp, new Date(1234567890))).toBe(

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -281,8 +281,8 @@ function compareDates(a: Date, b: Date) {
  */
 export const parseAsTimestamp: SingleParserBuilder<Date> = createParser({
   parse: v => {
-    const ms = parseInt(v)
-    return ms == ms ? new Date(ms) : null // NaN check at low bundle size cost
+    const date = new Date(parseInt(v))
+    return date.valueOf() == date.valueOf() ? date : null // NaN check at low bundle size cost
   },
   serialize: (v: Date) => '' + v.valueOf(),
   eq: compareDates


### PR DESCRIPTION
## Summary

- return `null` when timestamp input constructs an invalid `Date`
- preserve valid timestamp parsing behavior
- add regression coverage for milliseconds outside the supported date range
