### PR TITLE
fix: reactivity for startTransition callbacks

### DIFF
--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -604,6 +604,24 @@ describe('useQueryStates: clearOnDefault', () => {
     expect(onUrlUpdate.mock.calls[0]![0].options.history).toBe('push')
   })
 
+  it('follows parser startTransition changes', async () => {
+    const initialStartTransition = vi.fn((callback: () => void) => callback())
+    const nextStartTransition = vi.fn((callback: () => void) => callback())
+    const useTestHook = ({ startTransition = initialStartTransition } = {}) =>
+      useQueryStates({
+        test: parseAsString.withOptions({ startTransition })
+      })
+    const { result, rerender, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter()
+    })
+
+    await rerender({ startTransition: nextStartTransition })
+    await act(() => result.current[1]({ test: 'pass' }))
+
+    expect(initialStartTransition).not.toHaveBeenCalled()
+    expect(nextStartTransition).toHaveBeenCalledOnce()
+  })
+
   it('follows hook-level clearOnDefault changes', async () => {
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
     const useTestHook = (

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -98,6 +98,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     JSON.stringify(Object.entries(cachedKeyMap), omitDefaultValue) ===
       JSON.stringify(Object.entries(keyMap), omitDefaultValue) &&
     Object.entries(keyMap).every(([key, parser]) => {
+      if (cachedKeyMap[key]?.startTransition !== parser.startTransition) {
+        return false
+      }
       const previousDefault = cachedKeyMap[key]?.defaultValue
       const currentDefault = parser.defaultValue
       if (Object.is(previousDefault, currentDefault)) {


### PR DESCRIPTION
The transition callback can change when parser options are recreated during a rerender. Keeping the old callback sends later URL updates through stale React transition state.

Refresh the callback reference after each render so updates use the current parser options.
