### PR TITLE
fix: distinguish comma-separated values from repeated keys

### DIFF
--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -34,20 +34,55 @@ const waitForNextTick = () =>
   })
 
 describe('useQueryStates', () => {
-  it('distinguishes comma-containing values from repeated values', async () => {
+  it.each([
+    {
+      name: 'comma-containing values to repeated values',
+      from: '?a=a%2Cb',
+      to: '?a=a&a=b',
+      initial: '{"a":["a,b"],"b":[]}',
+      expected: '{"a":["a","b"],"b":[]}'
+    },
+    {
+      name: 'repeated values to comma-containing values',
+      from: '?a=a&a=b',
+      to: '?a=a%2Cb',
+      initial: '{"a":["a","b"],"b":[]}',
+      expected: '{"a":["a,b"],"b":[]}'
+    },
+    {
+      name: 'an empty value to an absent key',
+      from: '?a=',
+      to: '',
+      initial: '{"a":[""],"b":[]}',
+      expected: '{"a":[],"b":[]}'
+    },
+    {
+      name: 'a trailing comma to a repeated empty value',
+      from: '?a=a%2C',
+      to: '?a=a&a=',
+      initial: '{"a":["a,"],"b":[]}',
+      expected: '{"a":["a",""],"b":[]}'
+    },
+    {
+      name: 'encoded separators to values split across keys',
+      from: '?a=1%26b%3D2',
+      to: '?a=1&b=2%26b%3D',
+      initial: '{"a":["1&b=2"],"b":[]}',
+      expected: '{"a":["1"],"b":["2&b="]}'
+    }
+  ])('distinguishes $name', async ({ from, to, initial, expected }) => {
     function Child() {
-      const [{ tag }] = useQueryStates({
-        tag: parseAsNativeArrayOf(parseAsString)
+      const [state] = useQueryStates({
+        a: parseAsNativeArrayOf(parseAsString),
+        b: parseAsNativeArrayOf(parseAsString)
       })
-      return <div data-testid="value">{JSON.stringify(tag)}</div>
+      return <div data-testid="value">{JSON.stringify(state)}</div>
     }
     function TestComponent() {
-      const [searchParams, setSearchParams] = useState('?tag=a%2Cb')
+      const [searchParams, setSearchParams] = useState(from)
       return (
         <>
-          <button onClick={() => setSearchParams('?tag=a&tag=b')}>
-            Navigate
-          </button>
+          <button onClick={() => setSearchParams(to)}>Navigate</button>
           <NuqsTestingAdapter searchParams={searchParams} hasMemory>
             <Child />
           </NuqsTestingAdapter>
@@ -57,13 +92,37 @@ describe('useQueryStates', () => {
 
     const user = userEvent.setup()
     render(<TestComponent />)
-    await expect.element(page.getByTestId('value')).toHaveTextContent('["a,b"]')
+    await expect.element(page.getByTestId('value')).toHaveTextContent(initial)
 
     await user.click(page.getByRole('button', { name: 'Navigate' }))
 
-    await expect
-      .element(page.getByTestId('value'))
-      .toHaveTextContent('["a","b"]')
+    await expect.element(page.getByTestId('value')).toHaveTextContent(expected)
+  })
+
+  it('distinguishes comma-containing and repeated values for a single parser', async () => {
+    function Child() {
+      const [value] = useQueryState('q')
+      return <div data-testid="value">{JSON.stringify(value)}</div>
+    }
+    function TestComponent() {
+      const [searchParams, setSearchParams] = useState('?q=a%2Cb')
+      return (
+        <>
+          <button onClick={() => setSearchParams('?q=a&q=b')}>Navigate</button>
+          <NuqsTestingAdapter searchParams={searchParams} hasMemory>
+            <Child />
+          </NuqsTestingAdapter>
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<TestComponent />)
+    await expect.element(page.getByTestId('value')).toHaveTextContent('"a,b"')
+
+    await user.click(page.getByRole('button', { name: 'Navigate' }))
+
+    await expect.element(page.getByTestId('value')).toHaveTextContent('"a"')
   })
 
   it('allows setting a single value', async () => {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -34,6 +34,38 @@ const waitForNextTick = () =>
   })
 
 describe('useQueryStates', () => {
+  it('distinguishes comma-containing values from repeated values', async () => {
+    function Child() {
+      const [{ tag }] = useQueryStates({
+        tag: parseAsNativeArrayOf(parseAsString)
+      })
+      return <div data-testid="value">{JSON.stringify(tag)}</div>
+    }
+    function TestComponent() {
+      const [searchParams, setSearchParams] = useState('?tag=a%2Cb')
+      return (
+        <>
+          <button onClick={() => setSearchParams('?tag=a&tag=b')}>
+            Navigate
+          </button>
+          <NuqsTestingAdapter searchParams={searchParams} hasMemory>
+            <Child />
+          </NuqsTestingAdapter>
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<TestComponent />)
+    await expect.element(page.getByTestId('value')).toHaveTextContent('["a,b"]')
+
+    await user.click(page.getByRole('button', { name: 'Navigate' }))
+
+    await expect
+      .element(page.getByTestId('value'))
+      .toHaveTextContent('["a","b"]')
+  })
+
   it('allows setting a single value', async () => {
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
     const useTestHook = () =>

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -152,10 +152,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // Mirrors the dependencies of the URL sync effect below so that render-time
   // reconciliation reacts to the same external changes, and never to internal
   // (optimistic) updates which don't immediately alter the URL source.
-  const searchParamsSyncKey =
-    Object.values(resolvedUrlKeys)
-      .map(key => `${key}=${initialSearchParams.getAll(key)}`)
-      .join('&') + JSON.stringify(queuedQueries)
+  const searchParamsSyncKey = JSON.stringify([
+    Object.values(resolvedUrlKeys).map(key => [
+      key,
+      initialSearchParams.getAll(key)
+    ]),
+    queuedQueries
+  ])
   // Adopts the current URL value into the internal state when it has changed.
   // Used both during render (below) and from the effect backstop further down.
   const reconcile = () => {


### PR DESCRIPTION
Comma-separated values and repeated query keys could produce the same synchronization key. This could leave `useQueryStates` with stale state.

This change uses structured serialization for query entries and adds a browser regression test for `?tag=a%2Cb` versus `?tag=a&tag=b`.
