### PR TITLE
fix: support server runtimes without process

### DIFF
--- a/packages/nuqs/src/hardened-global.test.ts
+++ b/packages/nuqs/src/hardened-global.test.ts
@@ -23,7 +23,7 @@ describe('hardened globalThis', () => {
       [
         '--input-type=module',
         '--eval',
-        `await import('react'); delete globalThis.process; await import(${JSON.stringify(entry)})`
+        `await import('react'); delete globalThis.process; const nuqs = await import(${JSON.stringify(entry)}); nuqs.createSerializer({ q: nuqs.parseAsString })({ q: 'hello' })`
       ],
       { encoding: 'utf8' }
     )

--- a/packages/nuqs/src/hardened-global.test.ts
+++ b/packages/nuqs/src/hardened-global.test.ts
@@ -15,4 +15,18 @@ describe('hardened globalThis', () => {
     )
     expect(result.status, result.stderr).toBe(0)
   })
+
+  it('loads the public server entry without a Node process global', () => {
+    const entry = new URL('../dist/server.js', import.meta.url).href
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `await import('react'); delete globalThis.process; await import(${JSON.stringify(entry)})`
+      ],
+      { encoding: 'utf8' }
+    )
+    expect(result.status, result.stderr).toBe(0)
+  })
 })

--- a/packages/nuqs/src/lib/debug.ts
+++ b/packages/nuqs/src/lib/debug.ts
@@ -37,7 +37,10 @@ export function isDebugFlagSet(): boolean {
   // Backend (Node/server): use DEBUG env var, never touch localStorage.
   // --localstorage-file triggers a warning.
   if (typeof window === 'undefined') {
-    return (process.env.DEBUG || '').includes('nuqs')
+    return (
+      typeof process !== 'undefined' &&
+      (process.env.DEBUG || '').includes('nuqs')
+    )
   }
 
   // Check if localStorage is available.

--- a/packages/nuqs/src/lib/url-encoding.ts
+++ b/packages/nuqs/src/lib/url-encoding.ts
@@ -54,7 +54,7 @@ function warnIfURLIsTooLong(queryString: string): void {
   if (typeof location === 'undefined') {
     return
   }
-  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production') {
     return
   }
   const url = new URL(location.href)

--- a/packages/nuqs/src/lib/url-encoding.ts
+++ b/packages/nuqs/src/lib/url-encoding.ts
@@ -51,10 +51,10 @@ export function encodeQueryValue(input: string): string {
 const URL_MAX_LENGTH = 2000
 
 function warnIfURLIsTooLong(queryString: string): void {
-  if (process.env.NODE_ENV === 'production') {
+  if (typeof location === 'undefined') {
     return
   }
-  if (typeof location === 'undefined') {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') {
     return
   }
   const url = new URL(location.href)


### PR DESCRIPTION
Cloudflare Workers do not expose Node's `process` global unless `nodejs_compat` is enabled. Importing `nuqs/server` could therefore fail when nuqs read debug settings.

This change guards server-only debug access and checks for a browser location before URL warnings. The regression test imports the built server entry without `process` and calls `createSerializer`.
