### PR TITLE
doc: unify recent npm stats snapshot

### DIFF
--- a/packages/docs/src/app/(pages)/stats/_components/downloads.tsx
+++ b/packages/docs/src/app/(pages)/stats/_components/downloads.tsx
@@ -4,7 +4,8 @@ import { Download, Minus, TrendingDown, TrendingUp } from 'lucide-react'
 import { formatStatNumber } from '../lib/format'
 import {
   combineStats,
-  fetchNpmPackage,
+  fetchNpmPackages,
+  getDownloadsNDaysBeforeLatest,
   getIsoWeekday,
   getPartialPreviousWeekDownloads
 } from '../lib/npm'
@@ -13,10 +14,7 @@ import { GraphSkeleton } from './graph.skeleton'
 import { WidgetSkeleton } from './widget.skeleton'
 
 export async function NPMStats() {
-  const [nuqs, nextUseQueryState] = await Promise.all([
-    fetchNpmPackage('nuqs'),
-    fetchNpmPackage('next-usequerystate')
-  ])
+  const [nuqs, nextUseQueryState] = await fetchNpmPackages()
   const both = combineStats(nuqs, nextUseQueryState)
   return (
     <>
@@ -50,10 +48,7 @@ export const NPMStatsSkeleton = () => (
 )
 
 export async function NPMDownloads() {
-  const [nuqs, nextUseQueryState] = await Promise.all([
-    fetchNpmPackage('nuqs'),
-    fetchNpmPackage('next-usequerystate')
-  ])
+  const [nuqs, nextUseQueryState] = await fetchNpmPackages()
   const both = combineStats(nuqs, nextUseQueryState)
   const lastDate = both.last30Days.at(-1)?.date
   const lastDateWeekday = getIsoWeekday(lastDate ?? '')
@@ -119,7 +114,9 @@ export async function NPMDownloads() {
         trend={
           <TrendBadge
             label="nuqs downloads compared to 7 days ago"
-            oldValue={nuqs.last30Days.at(-8)?.downloads ?? 0}
+            oldValue={
+              getDownloadsNDaysBeforeLatest(nuqs.last30Days, 7)?.downloads ?? 0
+            }
             newValue={nuqs.last30Days.at(-1)?.downloads ?? 0}
           />
         }
@@ -238,7 +235,9 @@ function TrendBadge({ oldValue, newValue, label, estimated }: TrendBadgeProps) {
       {diff > 0 ? '+' : '-'}
       {formatStatNumber(Math.abs(diff)) || 'No change'}
       {oldValue !== 0 && (
-        <span className="font-normal">({pct.toFixed(1)}%){estimated && '*'}</span>
+        <span className="font-normal">
+          ({pct.toFixed(1)}%){estimated && '*'}
+        </span>
       )}
     </Badge>
   )

--- a/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
@@ -36,7 +36,7 @@ afterAll(() => server.close())
 // deterministic, while leaving real timers for the fetch/MSW plumbing.
 beforeEach(() => {
   vi.useFakeTimers({ toFake: ['Date'] })
-  vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
+  vi.setSystemTime(new Date(2024, 5, 15, 12))
 })
 afterEach(() => {
   vi.useRealTimers()
@@ -101,6 +101,7 @@ describe('getDownloadsNDaysBeforeLatest', () => {
       date: '2024-06-06',
       downloads: 60
     })
+    expect(getDownloadsNDaysBeforeLatest(data, 6)).toBeUndefined()
   })
 })
 
@@ -177,6 +178,7 @@ describe('fetchNpmPackages', () => {
       new Date(Date.UTC(2024, 4, 15 + i)).toISOString().slice(0, 10)
     )
     let combinedRangeRequests = 0
+    let combinedRange: string | undefined
     server.use(
       http.get(registryEndpoint, () =>
         HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
@@ -184,6 +186,7 @@ describe('fetchNpmPackages', () => {
       http.get(rangeEndpoint, ({ params }) => {
         if (params.pkg === 'nuqs,next-usequerystate') {
           combinedRangeRequests++
+          combinedRange = String(params.range)
           return HttpResponse.json({
             nuqs: {
               downloads: dates.map((day, i) => ({ downloads: i + 1, day }))
@@ -200,6 +203,7 @@ describe('fetchNpmPackages', () => {
     const [nuqs, nextUseQueryState] = await fetchNpmPackages()
 
     expect(combinedRangeRequests).toBe(1)
+    expect(combinedRange).toBe('2024-03-11:2024-06-14')
     expect(nuqs.last30Days).toEqual(
       dates.slice(-30).map((date, i) => ({ date, downloads: i + 2 }))
     )
@@ -208,9 +212,10 @@ describe('fetchNpmPackages', () => {
     )
     expect(nuqs.last90Days.at(-1)?.downloads).toBe(145)
     expect(nextUseQueryState.last90Days.at(-1)?.downloads).toBe(640)
+    expect(nuqs.last90Days.every(d => /^'\d{2}W\d{2}$/.test(d.date))).toBe(true)
   })
 
-  it('drops a trailing date from both packages when either is not published yet', async () => {
+  it('keeps a trailing date when only one package reports zero downloads', async () => {
     const dates = Array.from(
       { length: 9 },
       (_, i) => `2024-05-${String(i + 23).padStart(2, '0')}`
@@ -224,6 +229,49 @@ describe('fetchNpmPackages', () => {
           return HttpResponse.json({
             nuqs: {
               downloads: dates.map(day => ({ downloads: 10, day }))
+            },
+            'next-usequerystate': {
+              downloads: dates.map((day, i) => ({
+                downloads: i === dates.length - 1 ? 0 : 5,
+                day
+              }))
+            }
+          })
+        }
+        return HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      })
+    )
+
+    const [nuqs, nextUseQueryState] = await fetchNpmPackages()
+
+    expect(nuqs.last30Days.at(-1)).toEqual({
+      date: '2024-05-31',
+      downloads: 10
+    })
+    expect(nextUseQueryState.last30Days.at(-1)).toEqual({
+      date: '2024-05-31',
+      downloads: 5,
+      estimated: true
+    })
+  })
+
+  it('drops a trailing date when both packages report zero downloads', async () => {
+    const dates = Array.from(
+      { length: 9 },
+      (_, i) => `2024-05-${String(i + 23).padStart(2, '0')}`
+    )
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, ({ params }) => {
+        if (params.pkg === 'nuqs,next-usequerystate') {
+          return HttpResponse.json({
+            nuqs: {
+              downloads: dates.map((day, i) => ({
+                downloads: i === dates.length - 1 ? 0 : 10,
+                day
+              }))
             },
             'next-usequerystate': {
               downloads: dates.map((day, i) => ({
@@ -314,6 +362,40 @@ describe('fetchNpmPackages', () => {
     })
   })
 
+  it('rejects an unsuccessful combined response before parsing its body', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, ({ params }) => {
+        if (params.pkg === 'nuqs,next-usequerystate') {
+          return HttpResponse.json(
+            {
+              nuqs: { downloads: [{ downloads: 10, day: '2024-06-14' }] },
+              'next-usequerystate': {
+                downloads: [{ downloads: 5, day: '2024-06-14' }]
+              }
+            },
+            { status: 503 }
+          )
+        }
+        return HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      })
+    )
+
+    const [nuqs, nextUseQueryState] = await fetchNpmPackages()
+
+    expect(nuqs.last30Days).toEqual([])
+    expect(nextUseQueryState.last30Days).toEqual([])
+    expect(errorSpy).toHaveBeenCalledOnce()
+    expect(errorSpy.mock.calls[0][0]).toMatchObject({
+      cause: expect.objectContaining({
+        message: expect.stringContaining('503')
+      })
+    })
+  })
+
   it('returns empty recent series and logs when the combined response is malformed', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     server.use(
@@ -329,6 +411,8 @@ describe('fetchNpmPackages', () => {
 
     const [nuqs, nextUseQueryState] = await fetchNpmPackages()
 
+    expect(nuqs.allTime).toBe(12)
+    expect(nextUseQueryState.allTime).toBe(12)
     expect(nuqs.last30Days).toEqual([])
     expect(nuqs.last90Days).toEqual([])
     expect(nextUseQueryState.last30Days).toEqual([])

--- a/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.test.ts
@@ -15,9 +15,9 @@ vi.mock('server-only', () => ({}))
 
 import {
   combineStats,
-  fetchNpmPackage,
+  fetchNpmPackages,
   getAllTime,
-  getLastNDays,
+  getDownloadsNDaysBeforeLatest,
   getPackageCreationDate,
   interpolateZeroDays,
   type Datum,
@@ -89,44 +89,18 @@ describe('interpolateZeroDays', () => {
   })
 })
 
-describe('getLastNDays', () => {
-  it('maps the range response to dated download counts', async () => {
-    server.use(
-      http.get(rangeEndpoint, () =>
-        HttpResponse.json({
-          downloads: [
-            { downloads: 10, day: '2024-06-01' },
-            { downloads: 20, day: '2024-06-02' }
-          ]
-        })
-      )
-    )
-    await expect(getLastNDays('nuqs', 30)).resolves.toEqual([
-      { date: '2024-06-01', downloads: 10 },
-      { date: '2024-06-02', downloads: 20 }
-    ])
-  })
+describe('getDownloadsNDaysBeforeLatest', () => {
+  it('looks up by calendar date rather than array position', () => {
+    const data = [
+      { date: '2024-06-06', downloads: 60 },
+      { date: '2024-06-08', downloads: 80 },
+      { date: '2024-06-13', downloads: 130 }
+    ]
 
-  it('drops a trailing zero-download day (stats not in yet)', async () => {
-    server.use(
-      http.get(rangeEndpoint, () =>
-        HttpResponse.json({
-          downloads: [
-            { downloads: 20, day: '2024-06-01' },
-            { downloads: 0, day: '2024-06-02' }
-          ]
-        })
-      )
-    )
-    const data = await getLastNDays('nuqs', 30)
-    expect(data).toEqual([{ date: '2024-06-01', downloads: 20 }])
-  })
-
-  it('returns an empty array and logs on a malformed response', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    server.use(http.get(rangeEndpoint, () => HttpResponse.json({ nope: true })))
-    await expect(getLastNDays('nuqs', 30)).resolves.toEqual([])
-    expect(errorSpy).toHaveBeenCalled()
+    expect(getDownloadsNDaysBeforeLatest(data, 7)).toEqual({
+      date: '2024-06-06',
+      downloads: 60
+    })
   })
 })
 
@@ -197,27 +171,169 @@ describe('getAllTime', () => {
   })
 })
 
-describe('fetchNpmPackage', () => {
-  it('combines all-time, last-30-day and weekly-grouped last-90-day stats', async () => {
-    const days = Array.from({ length: 14 }, (_, i) => ({
-      downloads: 100,
-      day: `2024-06-${String(i + 1).padStart(2, '0')}`
-    }))
+describe('fetchNpmPackages', () => {
+  it('derives both time windows from one combined recent-download snapshot', async () => {
+    const dates = Array.from({ length: 31 }, (_, i) =>
+      new Date(Date.UTC(2024, 4, 15 + i)).toISOString().slice(0, 10)
+    )
+    let combinedRangeRequests = 0
     server.use(
       http.get(registryEndpoint, () =>
         HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
       ),
-      http.get(rangeEndpoint, () => HttpResponse.json({ downloads: days }))
+      http.get(rangeEndpoint, ({ params }) => {
+        if (params.pkg === 'nuqs,next-usequerystate') {
+          combinedRangeRequests++
+          return HttpResponse.json({
+            nuqs: {
+              downloads: dates.map((day, i) => ({ downloads: i + 1, day }))
+            },
+            'next-usequerystate': {
+              downloads: dates.map((day, i) => ({ downloads: 100 + i, day }))
+            }
+          })
+        }
+        return HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      })
     )
-    const stats = await fetchNpmPackage('nuqs')
-    // One 18-month window from a June-2024 creation date: 14 × 100.
-    expect(stats.allTime).toBe(1400)
-    expect(stats.last30Days).toHaveLength(14)
-    // last90Days is grouped by ISO week, so fewer entries keyed as 'YYWww.
-    expect(stats.last90Days.length).toBeLessThan(14)
-    expect(stats.last90Days.every(d => /^'\d{2}W\d{2}$/.test(d.date))).toBe(
-      true
+
+    const [nuqs, nextUseQueryState] = await fetchNpmPackages()
+
+    expect(combinedRangeRequests).toBe(1)
+    expect(nuqs.last30Days).toEqual(
+      dates.slice(-30).map((date, i) => ({ date, downloads: i + 2 }))
     )
+    expect(nextUseQueryState.last30Days).toEqual(
+      dates.slice(-30).map((date, i) => ({ date, downloads: 101 + i }))
+    )
+    expect(nuqs.last90Days.at(-1)?.downloads).toBe(145)
+    expect(nextUseQueryState.last90Days.at(-1)?.downloads).toBe(640)
+  })
+
+  it('drops a trailing date from both packages when either is not published yet', async () => {
+    const dates = Array.from(
+      { length: 9 },
+      (_, i) => `2024-05-${String(i + 23).padStart(2, '0')}`
+    )
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, ({ params }) => {
+        if (params.pkg === 'nuqs,next-usequerystate') {
+          return HttpResponse.json({
+            nuqs: {
+              downloads: dates.map(day => ({ downloads: 10, day }))
+            },
+            'next-usequerystate': {
+              downloads: dates.map((day, i) => ({
+                downloads: i === dates.length - 1 ? 0 : 5,
+                day
+              }))
+            }
+          })
+        }
+        return HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      })
+    )
+
+    const [nuqs, nextUseQueryState] = await fetchNpmPackages()
+
+    expect(nuqs.last30Days.at(-1)?.date).toBe('2024-05-30')
+    expect(nextUseQueryState.last30Days.at(-1)?.date).toBe('2024-05-30')
+  })
+
+  it('uses only dates present for both packages without extending the 30-day window', async () => {
+    const dates = Array.from({ length: 31 }, (_, i) =>
+      new Date(Date.UTC(2024, 4, 15 + i)).toISOString().slice(0, 10)
+    )
+    const missingDate = '2024-06-01'
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, ({ params }) => {
+        if (params.pkg === 'nuqs,next-usequerystate') {
+          return HttpResponse.json({
+            nuqs: {
+              downloads: dates.map(day => ({ downloads: 10, day }))
+            },
+            'next-usequerystate': {
+              downloads: dates
+                .filter(day => day !== missingDate)
+                .map(day => ({ downloads: 5, day }))
+            }
+          })
+        }
+        return HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      })
+    )
+
+    const [nuqs, nextUseQueryState] = await fetchNpmPackages()
+
+    const expectedDates = dates.slice(-30).filter(date => date !== missingDate)
+    expect(nuqs.last30Days.map(d => d.date)).toEqual(expectedDates)
+    expect(nextUseQueryState.last30Days.map(d => d.date)).toEqual(expectedDates)
+  })
+
+  it('preserves calendar offsets when a package omits an internal date', async () => {
+    const dates = Array.from({ length: 15 }, (_, i) =>
+      new Date(Date.UTC(2024, 4, 31 + i)).toISOString().slice(0, 10)
+    )
+    const missingDate = '2024-06-06'
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, ({ params }) => {
+        if (params.pkg === 'nuqs,next-usequerystate') {
+          return HttpResponse.json({
+            nuqs: {
+              downloads: dates.map((day, i) => ({
+                downloads: i === 5 ? 10 : i === 13 ? 0 : 100,
+                day
+              }))
+            },
+            'next-usequerystate': {
+              downloads: dates
+                .filter(day => day !== missingDate)
+                .map(day => ({ downloads: 5, day }))
+            }
+          })
+        }
+        return HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      })
+    )
+
+    const [nuqs] = await fetchNpmPackages()
+
+    expect(nuqs.last30Days.find(d => d.date === '2024-06-13')).toEqual({
+      date: '2024-06-13',
+      downloads: 550,
+      estimated: true
+    })
+  })
+
+  it('returns empty recent series and logs when the combined response is malformed', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    server.use(
+      http.get(registryEndpoint, () =>
+        HttpResponse.json({ time: { created: '2024-06-01T00:00:00Z' } })
+      ),
+      http.get(rangeEndpoint, ({ params }) =>
+        params.pkg === 'nuqs,next-usequerystate'
+          ? HttpResponse.json({ broken: true })
+          : HttpResponse.json({ downloads: [{ downloads: 12, day: 'x' }] })
+      )
+    )
+
+    const [nuqs, nextUseQueryState] = await fetchNpmPackages()
+
+    expect(nuqs.last30Days).toEqual([])
+    expect(nuqs.last90Days).toEqual([])
+    expect(nextUseQueryState.last30Days).toEqual([])
+    expect(nextUseQueryState.last90Days).toEqual([])
+    expect(errorSpy).toHaveBeenCalledOnce()
   })
 })
 
@@ -253,7 +369,7 @@ describe('combineStats', () => {
     })
   })
 
-  it('aligns package stats by date and fills missing values with zero', () => {
+  it('combines only dates shared by both packages', () => {
     const combined = combineStats(
       stats(
         100,
@@ -274,18 +390,13 @@ describe('combineStats', () => {
     )
 
     expect(combined.last30Days).toEqual([
-      { date: 'd1', nuqs: 10, 'next-usequerystate': 0 },
       {
         date: 'd2',
         nuqs: 20,
         'next-usequerystate': 5,
         estimated: { 'next-usequerystate': true }
-      },
-      { date: 'd3', nuqs: 0, 'next-usequerystate': 6 }
+      }
     ])
-    expect(combined.last90Days).toEqual([
-      { date: 'w1', nuqs: 70, 'next-usequerystate': 0 },
-      { date: 'w2', nuqs: 0, 'next-usequerystate': 35 }
-    ])
+    expect(combined.last90Days).toEqual([])
   })
 })

--- a/packages/docs/src/app/(pages)/stats/lib/npm.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.ts
@@ -30,13 +30,6 @@ export type NpmPackageStatsData = {
 
 // const regexp = /https:\/\/npmjs\.com\/package\/([\w.-]+|@[\w.-]+\/[\w.-]+)/gm
 
-type RangeResponse = {
-  downloads: Array<{
-    downloads: number
-    day: string
-  }>
-}
-
 const rangeResponseSchema = z.object({
   downloads: z.array(
     z.object({
@@ -46,28 +39,10 @@ const rangeResponseSchema = z.object({
   )
 })
 
-export async function getLastNDays(pkg: string, n: number): Promise<Datum[]> {
-  const start = dayjs().subtract(n, 'day').format('YYYY-MM-DD')
-  const end = dayjs().subtract(1, 'day').endOf('day').format('YYYY-MM-DD')
-  const url = `https://api.npmjs.org/downloads/range/${start}:${end}/${pkg}`
-  try {
-    const { downloads } = rangeResponseSchema.parse(await get(url))
-    const data = downloads.map(d => ({
-      date: d.day,
-      downloads: d.downloads
-    }))
-    if (data.at(-1)?.downloads === 0) {
-      data.pop() // Remove last day if it's zero (stats not available yet)
-    }
-    return data
-  } catch (cause) {
-    const error = new Error(`error: getLastNDays(${pkg}, ${n}) - url: ${url}`, {
-      cause
-    })
-    console.error(error)
-    return []
-  }
-}
+const combinedRangeResponseSchema = z.object({
+  nuqs: rangeResponseSchema,
+  'next-usequerystate': rangeResponseSchema
+})
 
 /**
  * Interpolate zero-download days using weekly rhythm-aware estimation.
@@ -127,6 +102,18 @@ export function interpolateZeroDays(data: Datum[]): Datum[] {
   return data
 }
 
+export function getDownloadsNDaysBeforeLatest(
+  data: Datum[],
+  days: number
+): Datum | undefined {
+  const latestDate = data.at(-1)?.date
+  if (!latestDate) return undefined
+  const targetDate = dayjs(latestDate)
+    .subtract(days, 'day')
+    .format('YYYY-MM-DD')
+  return data.find(d => d.date === targetDate)
+}
+
 const packageResponseSchema = z.object({
   time: z.object({
     created: z.string()
@@ -176,24 +163,88 @@ export async function getAllTime(pkg: string): Promise<number> {
   return downloads
 }
 
-export async function fetchNpmPackage(
-  pkg: string
-): Promise<NpmPackageStatsData> {
-  // Ensure we cover 90 days + a full first week
-  const startOfFirstWeek = dayjs().subtract(90, 'day').startOf('isoWeek')
-  const ninetyOrSoDays = dayjs().diff(startOfFirstWeek, 'day')
-  const [allTime, last30DaysRaw, last90DaysRaw] = await Promise.all([
-    getAllTime(pkg),
-    getLastNDays(pkg, 30),
-    getLastNDays(pkg, ninetyOrSoDays)
-  ])
-  const last30Days = interpolateZeroDays(last30DaysRaw)
-  const last90Days = interpolateZeroDays(last90DaysRaw)
-  return {
-    allTime,
-    last30Days,
-    last90Days: groupByWeek(last90Days)
+async function getRecentPackages(url: string) {
+  try {
+    return combinedRangeResponseSchema.parse(await get(url))
+  } catch (cause) {
+    console.error(
+      new Error(`error: getRecentPackages() - url: ${url}`, { cause })
+    )
+    return {
+      nuqs: { downloads: [] },
+      'next-usequerystate': { downloads: [] }
+    }
   }
+}
+
+export async function fetchNpmPackages(): Promise<
+  readonly [NpmPackageStatsData, NpmPackageStatsData]
+> {
+  // Ensure we cover 90 days + a full first week. The same response is also
+  // derived for the 30-day chart so both views share one cache watermark.
+  const startOfFirstWeek = dayjs().subtract(90, 'day').startOf('isoWeek')
+  const endDate = dayjs().subtract(1, 'day')
+  const end = endDate.format('YYYY-MM-DD')
+  const last30DaysStart = endDate.subtract(29, 'day').format('YYYY-MM-DD')
+  const rangeDates: string[] = []
+  for (
+    let date = startOfFirstWeek;
+    !date.isAfter(endDate, 'day');
+    date = date.add(1, 'day')
+  ) {
+    rangeDates.push(date.format('YYYY-MM-DD'))
+  }
+  const url = `https://api.npmjs.org/downloads/range/${startOfFirstWeek.format(
+    'YYYY-MM-DD'
+  )}:${end}/nuqs,next-usequerystate`
+  const [nuqsAllTime, nextUseQueryStateAllTime, recent] = await Promise.all([
+    getAllTime('nuqs'),
+    getAllTime('next-usequerystate'),
+    getRecentPackages(url)
+  ])
+  const nuqsByDate = new Map(
+    recent.nuqs.downloads.map(d => [d.day, d.downloads])
+  )
+  const nextUseQueryStateByDate = new Map(
+    recent['next-usequerystate'].downloads.map(d => [d.day, d.downloads])
+  )
+  const sharedDates = new Set(
+    rangeDates.filter(
+      date => nuqsByDate.has(date) && nextUseQueryStateByDate.has(date)
+    )
+  )
+  const lastSharedDate = rangeDates.findLast(date => sharedDates.has(date))
+  if (
+    lastSharedDate &&
+    (nuqsByDate.get(lastSharedDate) === 0 ||
+      nextUseQueryStateByDate.get(lastSharedDate) === 0)
+  ) {
+    sharedDates.delete(lastSharedDate)
+  }
+  const nuqs = interpolateZeroDays(
+    rangeDates.map(date => ({
+      date,
+      downloads: nuqsByDate.get(date) ?? 0
+    }))
+  ).filter(d => sharedDates.has(d.date))
+  const nextUseQueryState = interpolateZeroDays(
+    rangeDates.map(date => ({
+      date,
+      downloads: nextUseQueryStateByDate.get(date) ?? 0
+    }))
+  ).filter(d => sharedDates.has(d.date))
+  return [
+    {
+      allTime: nuqsAllTime,
+      last30Days: nuqs.filter(d => d.date >= last30DaysStart),
+      last90Days: groupByWeek(nuqs)
+    },
+    {
+      allTime: nextUseQueryStateAllTime,
+      last30Days: nextUseQueryState.filter(d => d.date >= last30DaysStart),
+      last90Days: groupByWeek(nextUseQueryState)
+    }
+  ]
 }
 
 async function get(url: string): Promise<unknown> {
@@ -243,23 +294,23 @@ export function combineStats(
 function combineDownloads(nuqs: Datum[], n_uqs: Datum[]): MultiDatum[] {
   const nuqsByDate = new Map(nuqs.map(datum => [datum.date, datum]))
   const n_uqsByDate = new Map(n_uqs.map(datum => [datum.date, datum]))
-  const dates = new Set([...nuqsByDate.keys(), ...n_uqsByDate.keys()])
+  const dates = Array.from(nuqsByDate.keys()).filter(date =>
+    n_uqsByDate.has(date)
+  )
 
-  return Array.from(dates)
-    .sort()
-    .map(date => {
-      const nuqsDatum = nuqsByDate.get(date)
-      const n_uqsDatum = n_uqsByDate.get(date)
-      const estimated: NonNullable<MultiDatum['estimated']> = {}
-      if (nuqsDatum?.estimated) estimated.nuqs = true
-      if (n_uqsDatum?.estimated) estimated['next-usequerystate'] = true
-      return {
-        date,
-        nuqs: nuqsDatum?.downloads ?? 0,
-        'next-usequerystate': n_uqsDatum?.downloads ?? 0,
-        ...(Object.keys(estimated).length > 0 ? { estimated } : {})
-      }
-    })
+  return dates.sort().map(date => {
+    const nuqsDatum = nuqsByDate.get(date)!
+    const n_uqsDatum = n_uqsByDate.get(date)!
+    const estimated: NonNullable<MultiDatum['estimated']> = {}
+    if (nuqsDatum.estimated) estimated.nuqs = true
+    if (n_uqsDatum.estimated) estimated['next-usequerystate'] = true
+    return {
+      date,
+      nuqs: nuqsDatum.downloads,
+      'next-usequerystate': n_uqsDatum.downloads,
+      ...(Object.keys(estimated).length > 0 ? { estimated } : {})
+    }
+  })
 }
 
 // Re-export to avoid importing dayjs everywhere

--- a/packages/docs/src/app/(pages)/stats/lib/npm.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/npm.ts
@@ -28,8 +28,6 @@ export type NpmPackageStatsData = {
   last90Days: Datum[]
 }
 
-// const regexp = /https:\/\/npmjs\.com\/package\/([\w.-]+|@[\w.-]+\/[\w.-]+)/gm
-
 const rangeResponseSchema = z.object({
   downloads: z.array(
     z.object({
@@ -45,8 +43,8 @@ const combinedRangeResponseSchema = z.object({
 })
 
 /**
- * Interpolate zero-download days using weekly rhythm-aware estimation.
- * Processes left-to-right so earlier interpolated values can feed later ones.
+ * Interpolate zero-download days in a dense, chronological daily series.
+ * Mutates the array from left to right so earlier estimates can feed later ones.
  */
 export function interpolateZeroDays(data: Datum[]): Datum[] {
   for (let i = 0; i < data.length; i++) {
@@ -178,10 +176,10 @@ async function getRecentPackages(url: string) {
 }
 
 export async function fetchNpmPackages(): Promise<
-  readonly [NpmPackageStatsData, NpmPackageStatsData]
+  readonly [nuqs: NpmPackageStatsData, nextUseQueryState: NpmPackageStatsData]
 > {
-  // Ensure we cover 90 days + a full first week. The same response is also
-  // derived for the 30-day chart so both views share one cache watermark.
+  // Fetch one range for both packages, then derive both chart windows locally.
+  // This keeps all recent views on the same npm response and cache entry.
   const startOfFirstWeek = dayjs().subtract(90, 'day').startOf('isoWeek')
   const endDate = dayjs().subtract(1, 'day')
   const end = endDate.format('YYYY-MM-DD')
@@ -213,11 +211,13 @@ export async function fetchNpmPackages(): Promise<
       date => nuqsByDate.has(date) && nextUseQueryStateByDate.has(date)
     )
   )
+  // npm can include tomorrow's placeholder before either package has stats.
+  // Drop that date only when both package totals are still zero.
   const lastSharedDate = rangeDates.findLast(date => sharedDates.has(date))
   if (
     lastSharedDate &&
-    (nuqsByDate.get(lastSharedDate) === 0 ||
-      nextUseQueryStateByDate.get(lastSharedDate) === 0)
+    nuqsByDate.get(lastSharedDate) === 0 &&
+    nextUseQueryStateByDate.get(lastSharedDate) === 0
   ) {
     sharedDates.delete(lastSharedDate)
   }
@@ -254,6 +254,11 @@ async function get(url: string): Promise<unknown> {
       tags: ['npm-stats']
     }
   })
+  if (!res.ok) {
+    throw new Error(
+      `npm downloads request failed: ${res.status} ${res.statusText}`
+    )
+  }
   return res.json()
 }
 


### PR DESCRIPTION
The npm charts cached each package and date range separately. A Sunday or Monday refresh could mix publication watermarks, show a false zero for one package, and compare an incomplete week with a full prior week.

This uses one widest multi-package request for recent data and derives both chart ranges from that response. Missing dates and trend comparisons keep calendar-date semantics.

Regression tests cover trailing cache skew, interior gaps, calendar windows, weekly grouping, and date-based comparisons.

## Review follow-up

The final review found that a zero for either package could drop the other package's valid trailing day. The follow-up only drops a trailing date when both packages report zero, rejects unsuccessful npm responses before parsing, and adds timezone-independent range and week-key coverage.