### PR TITLE
doc: update Inertia registry adapter

### DIFF
--- a/packages/docs/src/registry/items/adapter-inertia.json
+++ b/packages/docs/src/registry/items/adapter-inertia.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "type": "registry:file",
-      "path": "https://raw.githubusercontent.com/47ng/nuqs-inertia-pingcrm/70aeb29b9ce9e333ac5124d84191a6778fd62b3f/resources/js/lib/nuqs-inertia-adapter.ts",
+      "path": "https://raw.githubusercontent.com/47ng/nuqs-inertia-pingcrm/44e3fb2c03b7efc81b80acc2d964b24e3b19de2d/resources/js/lib/nuqs-inertia-adapter.ts",
       "target": "~/resources/js/lib/nuqs-inertia-adapter.ts"
     }
   ]


### PR DESCRIPTION
## Summary

- pin the Inertia registry item to the merged SSR-safe adapter
- ensure CLI installs no longer receive the `location`-dependent implementation

## Verification

- registry assembly and shadcn generation pass
- generated adapter contains the server-safe origin guard