### PR TITLE
Stable router on next pages adapter

### DIFF
--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -66,46 +66,46 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
   const updateUrl: UpdateUrlFunction = useCallback((search, options) => {
     const nextRouter = Router
     const urlParams = extractDynamicUrlParams(
-        nextRouter.pathname,
-        nextRouter.query
+      nextRouter.pathname,
+      nextRouter.query
     )
     const asPath =
-        getAsPathPathname(nextRouter.asPath) +
-        renderQueryString(search) +
-        location.hash
+      getAsPathPathname(nextRouter.asPath) +
+      renderQueryString(search) +
+      location.hash
     debug(20, 'next/pages', asPath)
     const method =
-        options.history === 'push' ? nextRouter.push : nextRouter.replace
+      options.history === 'push' ? nextRouter.push : nextRouter.replace
     updateState.isNuqsUpdate = true
     try {
       method
-          .call(
-              nextRouter,
-              // This is what makes the URL work (mapping dynamic segments placeholders
-              // in pathname to their values in query, plus search params in query too).
-              {
-                pathname: nextRouter.pathname,
-                query: {
-                  // Note: we put search params first so that one that conflicts
-                  // with dynamic params will be overwritten.
-                  ...urlSearchParamsToObject(search),
-                  ...urlParams
-                }
-                // For some reason we don't need to pass the hash here,
-                // it's preserved when passed as part of the asPath.
-              },
-              // This is what makes the URL pretty (resolved dynamic segments
-              // and nuqs-formatted search params).
-              asPath,
-              // And these are the options that are passed to the router.
-              {
-                scroll: options.scroll,
-                shallow: options.shallow
-              }
-          )
-          .finally(() => {
-            updateState.isNuqsUpdate = false
-          })
+        .call(
+          nextRouter,
+          // This is what makes the URL work (mapping dynamic segments placeholders
+          // in pathname to their values in query, plus search params in query too).
+          {
+            pathname: nextRouter.pathname,
+            query: {
+              // Note: we put search params first so that one that conflicts
+              // with dynamic params will be overwritten.
+              ...urlSearchParamsToObject(search),
+              ...urlParams
+            }
+            // For some reason we don't need to pass the hash here,
+            // it's preserved when passed as part of the asPath.
+          },
+          // This is what makes the URL pretty (resolved dynamic segments
+          // and nuqs-formatted search params).
+          asPath,
+          // And these are the options that are passed to the router.
+          {
+            scroll: options.scroll,
+            shallow: options.shallow
+          }
+        )
+        .finally(() => {
+          updateState.isNuqsUpdate = false
+        })
     } catch (error) {
       updateState.isNuqsUpdate = false
       throw error
@@ -121,12 +121,12 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
 
 export function getAsPathPathname(asPath: string): string {
   return asPath
-      .replace(/#.*$/, '') // Remove hash
-      .replace(/\?.*$/, '') // Remove search
+    .replace(/#.*$/, '') // Remove hash
+    .replace(/\?.*$/, '') // Remove search
 }
 
 export function urlSearchParamsToObject(
-    search: URLSearchParams
+  search: URLSearchParams
 ): Record<string, string | string[]> {
   const out: Record<string, string | string[]> = {}
   for (const key of search.keys()) {
@@ -150,8 +150,8 @@ export function urlSearchParamsToObject(
  * query state object, leaving out any other search params.
  */
 export function extractDynamicUrlParams(
-    pathname: string,
-    values: Record<string, string | string[] | undefined>
+  pathname: string,
+  values: Record<string, string | string[] | undefined>
 ): Record<string, string | string[] | undefined> {
   const paramNames = new Set<string>()
   const dynamicRegex = /\[([^\]]+)\]/g
@@ -166,7 +166,7 @@ export function extractDynamicUrlParams(
     }
   }
   const dynamicValues = Object.fromEntries(
-      Object.entries(values).filter(([key]) => paramNames.has(key))
+    Object.entries(values).filter(([key]) => paramNames.has(key))
   )
   const matchCatchAll = catchAllRegex.exec(pathname)
   if (matchCatchAll && matchCatchAll[1]) {

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/compat/router.js'
-import type { NextRouter } from 'next/router'
+import Router, { type NextRouter } from 'next/router'
 import { useCallback, useEffect, useMemo } from 'react'
 import { debug } from '../../lib/debug'
 import { globalSingleton } from '../../lib/global-singleton'
@@ -64,52 +64,48 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
   }, [JSON.stringify(router?.query)])
 
   const updateUrl: UpdateUrlFunction = useCallback((search, options) => {
-    // While the Next.js team doesn't recommend using internals like this,
-    // we need direct access to the pages router, as a bound/closured version from
-    // useRouter may be out of date by the time the updateUrl function is called,
-    // and would also cause updateUrl to not be referentially stable.
-    const nextRouter = window.next?.router!
+    const nextRouter = Router
     const urlParams = extractDynamicUrlParams(
-      nextRouter.pathname,
-      nextRouter.query
+        nextRouter.pathname,
+        nextRouter.query
     )
     const asPath =
-      getAsPathPathname(nextRouter.asPath) +
-      renderQueryString(search) +
-      location.hash
+        getAsPathPathname(nextRouter.asPath) +
+        renderQueryString(search) +
+        location.hash
     debug(20, 'next/pages', asPath)
     const method =
-      options.history === 'push' ? nextRouter.push : nextRouter.replace
+        options.history === 'push' ? nextRouter.push : nextRouter.replace
     updateState.isNuqsUpdate = true
     try {
       method
-        .call(
-          nextRouter,
-          // This is what makes the URL work (mapping dynamic segments placeholders
-          // in pathname to their values in query, plus search params in query too).
-          {
-            pathname: nextRouter.pathname,
-            query: {
-              // Note: we put search params first so that one that conflicts
-              // with dynamic params will be overwritten.
-              ...urlSearchParamsToObject(search),
-              ...urlParams
-            }
-            // For some reason we don't need to pass the hash here,
-            // it's preserved when passed as part of the asPath.
-          },
-          // This is what makes the URL pretty (resolved dynamic segments
-          // and nuqs-formatted search params).
-          asPath,
-          // And these are the options that are passed to the router.
-          {
-            scroll: options.scroll,
-            shallow: options.shallow
-          }
-        )
-        .finally(() => {
-          updateState.isNuqsUpdate = false
-        })
+          .call(
+              nextRouter,
+              // This is what makes the URL work (mapping dynamic segments placeholders
+              // in pathname to their values in query, plus search params in query too).
+              {
+                pathname: nextRouter.pathname,
+                query: {
+                  // Note: we put search params first so that one that conflicts
+                  // with dynamic params will be overwritten.
+                  ...urlSearchParamsToObject(search),
+                  ...urlParams
+                }
+                // For some reason we don't need to pass the hash here,
+                // it's preserved when passed as part of the asPath.
+              },
+              // This is what makes the URL pretty (resolved dynamic segments
+              // and nuqs-formatted search params).
+              asPath,
+              // And these are the options that are passed to the router.
+              {
+                scroll: options.scroll,
+                shallow: options.shallow
+              }
+          )
+          .finally(() => {
+            updateState.isNuqsUpdate = false
+          })
     } catch (error) {
       updateState.isNuqsUpdate = false
       throw error
@@ -125,12 +121,12 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
 
 export function getAsPathPathname(asPath: string): string {
   return asPath
-    .replace(/#.*$/, '') // Remove hash
-    .replace(/\?.*$/, '') // Remove search
+      .replace(/#.*$/, '') // Remove hash
+      .replace(/\?.*$/, '') // Remove search
 }
 
 export function urlSearchParamsToObject(
-  search: URLSearchParams
+    search: URLSearchParams
 ): Record<string, string | string[]> {
   const out: Record<string, string | string[]> = {}
   for (const key of search.keys()) {
@@ -154,8 +150,8 @@ export function urlSearchParamsToObject(
  * query state object, leaving out any other search params.
  */
 export function extractDynamicUrlParams(
-  pathname: string,
-  values: Record<string, string | string[] | undefined>
+    pathname: string,
+    values: Record<string, string | string[] | undefined>
 ): Record<string, string | string[] | undefined> {
   const paramNames = new Set<string>()
   const dynamicRegex = /\[([^\]]+)\]/g
@@ -170,7 +166,7 @@ export function extractDynamicUrlParams(
     }
   }
   const dynamicValues = Object.fromEntries(
-    Object.entries(values).filter(([key]) => paramNames.has(key))
+      Object.entries(values).filter(([key]) => paramNames.has(key))
   )
   const matchCatchAll = catchAllRegex.exec(pathname)
   if (matchCatchAll && matchCatchAll[1]) {


### PR DESCRIPTION
While using nuqs with a Next.js 16.3.0 project on the Pages Router, I noticed that window.next.router was occasionally undefined, causing navigation/query updates to fail.

I couldn’t reproduce the issue in a fresh Next.js project, so there may be something specific about my application’s setup or the interaction with other libraries.

As a workaround, I patched nuqs to use the stable router singleton exported by next/router instead of reading window.next.router. This resolved the issue consistently in my project.

I’m opening this PR with the same change so you can take a look and determine whether it’s an appropriate fix or if there’s a better approach.