### PR TITLE
fix: recover queue after URL middleware errors

### DIFF
--- a/packages/nuqs/src/lib/errors.ts
+++ b/packages/nuqs/src/lib/errors.ts
@@ -5,7 +5,8 @@ export const errors = {
   414: 'Max safe URL length exceeded. Some browsers may not be able to accept this URL. Consider limiting the amount of state stored in the URL.',
   429: 'URL update rate-limited by the browser. Consider increasing `throttleMs` for key(s) `%s`. %O',
   500: "Empty search params cache. Search params can't be accessed in Layouts.",
-  501: 'Search params cache already populated. Have you called `parse` twice?'
+  501: 'Search params cache already populated. Have you called `parse` twice?',
+  502: '`processUrlSearchParams` threw while processing key(s) `%s`. %O'
 } as const
 
 export function error(code: keyof typeof errors) {

--- a/packages/nuqs/src/lib/queues/throttle.test.ts
+++ b/packages/nuqs/src/lib/queues/throttle.test.ts
@@ -322,6 +322,22 @@ describe('throttle: flush', () => {
       new Error('updateUrl error')
     )
   })
+  it('rejects and resets when processUrlSearchParams throws', async () => {
+    const adapter = createMockAdapter()
+    const queue = new ThrottledQueue()
+    queue.push({ key: 'a', query: 'a', options: {} })
+    const promise = queue.flush(adapter, () => {
+      throw new Error('middleware error')
+    })
+
+    expect(() => vi.runAllTimers()).not.toThrow()
+    await expect(promise).rejects.toEqual(new URLSearchParams('?a=a'))
+
+    queue.push({ key: 'b', query: 'b', options: {} })
+    const nextPromise = queue.flush(adapter)
+    vi.runAllTimers()
+    await expect(nextPromise).resolves.toEqual(new URLSearchParams('?b=b'))
+  })
   it('should process url search params', async () => {
     const mockAdapter = createMockAdapter()
     const queue = new ThrottledQueue()

--- a/packages/nuqs/src/lib/queues/throttle.test.ts
+++ b/packages/nuqs/src/lib/queues/throttle.test.ts
@@ -323,7 +323,13 @@ describe('throttle: flush', () => {
     )
   })
   it('rejects and resets when processUrlSearchParams throws', async () => {
-    const adapter = createMockAdapter()
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+    const adapter = {
+      ...createMockAdapter(),
+      autoResetQueueOnUpdate: false
+    }
     const queue = new ThrottledQueue()
     queue.push({ key: 'a', query: 'a', options: {} })
     const promise = queue.flush(adapter, () => {
@@ -332,6 +338,12 @@ describe('throttle: flush', () => {
 
     expect(() => vi.runAllTimers()).not.toThrow()
     await expect(promise).rejects.toEqual(new URLSearchParams('?a=a'))
+    expect(adapter.updateUrl).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledExactlyOnceWith(
+      '[nuqs] `processUrlSearchParams` threw while processing key(s) `%s`. %O\n  See https://nuqs.dev/NUQS-502',
+      'a',
+      new Error('middleware error')
+    )
 
     queue.push({ key: 'b', query: 'b', options: {} })
     const nextPromise = queue.flush(adapter)

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -194,6 +194,8 @@ export class ThrottledQueue {
       try {
         search = processUrlSearchParams(search)
       } catch (err) {
+        console.error(error(502), items.map(([key]) => key).join(), err)
+        this.resetQueueOnNextPush = true
         return [search, err]
       }
     }

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -191,7 +191,11 @@ export class ThrottledQueue {
       }
     }
     if (processUrlSearchParams) {
-      search = processUrlSearchParams(search)
+      try {
+        search = processUrlSearchParams(search)
+      } catch (err) {
+        return [search, err]
+      }
     }
     try {
       compose(transitions, () => updateUrl(search, options))

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -48,8 +48,6 @@ export class ThrottledQueue {
     timeMs: number = defaultRateLimit.timeMs
   ): void {
     if (this.resetQueueOnNextPush) {
-      // Some adapters keep queued values available during concurrent renders,
-      // so defer cleanup until the next update starts rather than after a flush.
       this.reset()
       this.resetQueueOnNextPush = false
     }
@@ -197,6 +195,8 @@ export class ThrottledQueue {
         search = processUrlSearchParams(search)
       } catch (err) {
         console.error(error(502), items.map(([key]) => key).join(), err)
+        // Some adapters keep the queue available during concurrent renders,
+        // so discard this failed batch only when the next update starts.
         this.resetQueueOnNextPush = true
         return [search, err]
       }

--- a/packages/nuqs/src/lib/queues/throttle.ts
+++ b/packages/nuqs/src/lib/queues/throttle.ts
@@ -48,6 +48,8 @@ export class ThrottledQueue {
     timeMs: number = defaultRateLimit.timeMs
   ): void {
     if (this.resetQueueOnNextPush) {
+      // Some adapters keep queued values available during concurrent renders,
+      // so defer cleanup until the next update starts rather than after a flush.
       this.reset()
       this.resetQueueOnNextPush = false
     }


### PR DESCRIPTION
## Summary

- Keep the update queue usable when `processUrlSearchParams` throws.
- Report the middleware error and reject the pending update without calling the adapter.
- Remove failed entries before the next update while preserving the queue during concurrent renders.
