### PR TITLE
fix: preserve explicit empty native arrays

### DIFF
--- a/packages/nuqs/src/loader.test.ts
+++ b/packages/nuqs/src/loader.test.ts
@@ -6,9 +6,19 @@ import {
   parseAsNativeArrayOf,
   parseAsString
 } from './parsers'
+import { createSerializer } from './serializer'
 
 describe('loader', () => {
   describe('sync', () => {
+    it('round-trips an explicit empty native array', () => {
+      const parser = parseAsNativeArrayOf(parseAsInteger).withDefault([42])
+      const serialize = createSerializer({ a: parser })
+      const load = createLoader({ a: parser })
+
+      const query = serialize({ a: [] })
+      expect(query).toBe('?a=')
+      expect(load(query)).toEqual({ a: [] })
+    })
     it('parses a URL object', () => {
       const load = createLoader({
         a: parseAsInteger,

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -518,7 +518,10 @@ export function parseAsNativeArrayOf<ItemType>(
       const parsed = query
         .map((item, index) => safeParse(itemParser.parse, item, `[${index}]`))
         .filter(value => value !== null && value !== undefined) as ItemType[]
-      return parsed.length === 0 ? null : parsed
+      if (parsed.length > 0) {
+        return parsed
+      }
+      return query.length === 1 && query[0] === '' ? [] : null
     },
     serialize: values => {
       // defensive check because we potentially get a single value passed from a standard schema

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -521,7 +521,7 @@ export function parseAsNativeArrayOf<ItemType>(
       if (parsed.length > 0) {
         return parsed
       }
-      // An explicit empty array serializes as one empty query value.
+      // Parse a single empty query value as an explicit empty array.
       return query.length === 1 && query[0] === '' ? [] : null
     },
     serialize: values => {

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -521,6 +521,7 @@ export function parseAsNativeArrayOf<ItemType>(
       if (parsed.length > 0) {
         return parsed
       }
+      // An explicit empty array serializes as one empty query value.
       return query.length === 1 && query[0] === '' ? [] : null
     },
     serialize: values => {


### PR DESCRIPTION
## Summary

- Preserve an explicit empty native array through serialization and loading.
- Keep the existing empty-string behavior for item parsers that accept an empty value.
- Add regression coverage for the empty array URL form.
