### PR TITLE
fix: support Object prototype query keys

### DIFF
--- a/packages/nuqs/src/cache.test.ts
+++ b/packages/nuqs/src/cache.test.ts
@@ -22,6 +22,14 @@ describe('cache', () => {
       string: "I'm a string"
     }
 
+    it.each(['constructor', 'hasOwnProperty'])(
+      'throws when reading %s before parsing',
+      key => {
+        const cache = createSearchParamsCache({ [key]: parseAsString })
+        expect(() => cache.get(key)).toThrow(/in get/)
+      }
+    )
+
     it('allows parsing the same object multiple times in a request', () => {
       const cache = createSearchParamsCache({
         string: parseAsString

--- a/packages/nuqs/src/cache.ts
+++ b/packages/nuqs/src/cache.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 import type { SearchParams, UrlKeys } from './defs'
 import { compareQuery } from './lib/compare'
 import { error } from './lib/errors'
+import { getOwn } from './lib/url-keys'
 import { createLoader, type LoaderFunctionOptions } from './loader'
 import type { inferParserType, ParserMap } from './parsers'
 
@@ -123,7 +124,7 @@ export function createSearchParamsCache<Parsers extends ParserMap>(
   }
   function get<Key extends Keys>(key: Key): ParsedSearchParams[Key] {
     const { searchParams } = getCache()
-    const entry = searchParams[key]
+    const entry = getOwn(searchParams, key)
     if (typeof entry === 'undefined') {
       throw new Error(
         error(500) +

--- a/packages/nuqs/src/lib/url-keys.ts
+++ b/packages/nuqs/src/lib/url-keys.ts
@@ -1,8 +1,13 @@
+export function getOwn<T>(
+  object: Partial<Record<string, T>>,
+  key: PropertyKey
+): T | undefined {
+  return Object.hasOwn(object, key) ? object[key as string] : undefined
+}
+
 export function getUrlKey(
   urlKeys: Partial<Record<string, string>>,
   key: string
 ): string {
-  return Object.prototype.hasOwnProperty.call(urlKeys, key)
-    ? (urlKeys[key] ?? key)
-    : key
+  return getOwn(urlKeys, key) ?? key
 }

--- a/packages/nuqs/src/lib/url-keys.ts
+++ b/packages/nuqs/src/lib/url-keys.ts
@@ -1,0 +1,8 @@
+export function getUrlKey(
+  urlKeys: Partial<Record<string, string>>,
+  key: string
+): string {
+  return Object.prototype.hasOwnProperty.call(urlKeys, key)
+    ? (urlKeys[key] ?? key)
+    : key
+}

--- a/packages/nuqs/src/loader.test.ts
+++ b/packages/nuqs/src/loader.test.ts
@@ -10,15 +10,31 @@ import { createSerializer } from './serializer'
 
 describe('loader', () => {
   describe('sync', () => {
-    it.each(['constructor', 'toString', 'hasOwnProperty'])(
+    it.each(['constructor', 'hasOwnProperty'])(
       'supports the object prototype key %s',
       key => {
         const parsers = { [key]: parseAsString }
         const serialize = createSerializer(parsers)
         const load = createLoader(parsers)
 
-        expect(serialize({ [key]: 'hello' })).toBe(`?${key}=hello`)
-        expect(load(`?${key}=hello`)).toEqual({ [key]: 'hello' })
+        expect(serialize({ [key]: 'acme' })).toBe(`?${key}=acme`)
+        expect(load(`?${key}=acme`)).toEqual({ [key]: 'acme' })
+
+        const urlKeys = { [key]: 'alias' }
+        const serializeAlias = createSerializer(parsers, { urlKeys })
+        const loadAlias = createLoader(parsers, { urlKeys })
+        expect(serializeAlias({ [key]: 'ajax' })).toBe('?alias=ajax')
+        expect(loadAlias('?alias=ajax')).toEqual({ [key]: 'ajax' })
+
+        const inheritedUrlKeys: Record<string, string> = Object.create({
+          [key]: 'alias'
+        })
+        const loadInheritedAlias = createLoader(parsers, {
+          urlKeys: inheritedUrlKeys
+        })
+        expect(loadInheritedAlias(`?${key}=acme&alias=ajax`)).toEqual({
+          [key]: 'acme'
+        })
       }
     )
     it('parses a URL object', () => {

--- a/packages/nuqs/src/loader.test.ts
+++ b/packages/nuqs/src/loader.test.ts
@@ -6,9 +6,21 @@ import {
   parseAsNativeArrayOf,
   parseAsString
 } from './parsers'
+import { createSerializer } from './serializer'
 
 describe('loader', () => {
   describe('sync', () => {
+    it.each(['constructor', 'toString', 'hasOwnProperty'])(
+      'supports the object prototype key %s',
+      key => {
+        const parsers = { [key]: parseAsString }
+        const serialize = createSerializer(parsers)
+        const load = createLoader(parsers)
+
+        expect(serialize({ [key]: 'hello' })).toBe(`?${key}=hello`)
+        expect(load(`?${key}=hello`)).toEqual({ [key]: 'hello' })
+      }
+    )
     it('parses a URL object', () => {
       const load = createLoader({
         a: parseAsInteger,

--- a/packages/nuqs/src/loader.ts
+++ b/packages/nuqs/src/loader.ts
@@ -1,5 +1,6 @@
 import type { UrlKeys } from './defs'
 import { isAbsentFromUrl } from './lib/search-params'
+import { getUrlKey } from './lib/url-keys'
 import type { inferParserType, ParserMap } from './parsers'
 
 export type LoaderInput =
@@ -96,7 +97,7 @@ export function createLoader<Parsers extends ParserMap>(
     const searchParams = extractSearchParams(input)
     const result = {} as any
     for (const [key, parser] of Object.entries(parsers)) {
-      const urlKey = urlKeys[key] ?? key
+      const urlKey = getUrlKey(urlKeys, key)
       const query =
         parser.type === 'multi'
           ? searchParams.getAll(urlKey)

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -253,14 +253,16 @@ describe('serializer', () => {
     const result = serialize({ multi: ['a', 'b', 'c'] })
     expect(result).toBe('?multi=a&multi=b&multi=c')
   })
-  it('ignores omitted parser keys from Object.prototype', () => {
-    const prototypeKey: string = 'toString'
-    const serialize = createSerializer({
-      a: parseAsString,
-      [prototypeKey]: parseAsString
-    })
-    expect(serialize({ a: 'hello' })).toBe('?a=hello')
-  })
+  it.each(['constructor', 'hasOwnProperty'])(
+    'ignores an omitted parser key named %s',
+    key => {
+      const serialize = createSerializer({
+        a: parseAsString,
+        [key]: parseAsString
+      })
+      expect(serialize({ a: 'acme' })).toBe('?a=acme')
+    }
+  )
   describe('supports processUrlSearchParams', () => {
     it('modifies search params in place', () => {
       const serialize = createSerializer(parsers, {

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -254,11 +254,12 @@ describe('serializer', () => {
     expect(result).toBe('?multi=a&multi=b&multi=c')
   })
   it('ignores omitted parser keys from Object.prototype', () => {
+    const prototypeKey: string = 'toString'
     const serialize = createSerializer({
       a: parseAsString,
-      toString: parseAsString
+      [prototypeKey]: parseAsString
     })
-    expect(serialize({ a: 'hello' } as any)).toBe('?a=hello')
+    expect(serialize({ a: 'hello' })).toBe('?a=hello')
   })
   describe('supports processUrlSearchParams', () => {
     it('modifies search params in place', () => {

--- a/packages/nuqs/src/serializer.test.ts
+++ b/packages/nuqs/src/serializer.test.ts
@@ -253,6 +253,13 @@ describe('serializer', () => {
     const result = serialize({ multi: ['a', 'b', 'c'] })
     expect(result).toBe('?multi=a&multi=b&multi=c')
   })
+  it('ignores omitted parser keys from Object.prototype', () => {
+    const serialize = createSerializer({
+      a: parseAsString,
+      toString: parseAsString
+    })
+    expect(serialize({ a: 'hello' } as any)).toBe('?a=hello')
+  })
   describe('supports processUrlSearchParams', () => {
     it('modifies search params in place', () => {
       const serialize = createSerializer(parsers, {

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -85,7 +85,11 @@ export function createSerializer<
     for (const key in parsers) {
       const parser = parsers[key]
       const value = values[key]
-      if (!parser || value === undefined) {
+      if (
+        !parser ||
+        !Object.prototype.hasOwnProperty.call(values, key) ||
+        value === undefined
+      ) {
         continue
       }
       const urlKey = getUrlKey(urlKeys, key)

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,7 +1,7 @@
 import type { Nullable, Options, UrlKeys } from './defs'
 import { write } from './lib/search-params'
 import { renderQueryString } from './lib/url-encoding'
-import { getUrlKey } from './lib/url-keys'
+import { getOwn, getUrlKey } from './lib/url-keys'
 import type { inferParserType, ParserMap } from './parsers'
 
 type Base = string | URLSearchParams | URL
@@ -73,7 +73,7 @@ export function createSerializer<
       : ['', new URLSearchParams(), '']
     const values = isBase(arg1BaseOrValues) ? arg2values : arg1BaseOrValues
     if (values === null) {
-      for (const key in parsers) {
+      for (const key of Object.keys(parsers)) {
         const urlKey = getUrlKey(urlKeys, key)
         search.delete(urlKey)
       }
@@ -82,14 +82,10 @@ export function createSerializer<
       }
       return (base + renderQueryString(search) + hash) as Return
     }
-    for (const key in parsers) {
-      const parser = parsers[key]
-      const value = values[key]
-      if (
-        !parser ||
-        !Object.prototype.hasOwnProperty.call(values, key) ||
-        value === undefined
-      ) {
+    for (const key of Object.keys(parsers)) {
+      const parser = parsers[key]!
+      const value = getOwn(values, key)
+      if (value === undefined) {
         continue
       }
       const urlKey = getUrlKey(urlKeys, key)

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,6 +1,7 @@
 import type { Nullable, Options, UrlKeys } from './defs'
 import { write } from './lib/search-params'
 import { renderQueryString } from './lib/url-encoding'
+import { getUrlKey } from './lib/url-keys'
 import type { inferParserType, ParserMap } from './parsers'
 
 type Base = string | URLSearchParams | URL
@@ -73,7 +74,7 @@ export function createSerializer<
     const values = isBase(arg1BaseOrValues) ? arg2values : arg1BaseOrValues
     if (values === null) {
       for (const key in parsers) {
-        const urlKey = urlKeys[key] ?? key
+        const urlKey = getUrlKey(urlKeys, key)
         search.delete(urlKey)
       }
       if (processUrlSearchParams) {
@@ -87,7 +88,7 @@ export function createSerializer<
       if (!parser || value === undefined) {
         continue
       }
-      const urlKey = urlKeys[key] ?? key
+      const urlKey = getUrlKey(urlKeys, key)
       const isMatchingDefault =
         parser.defaultValue !== undefined &&
         value !== null &&

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -34,22 +34,44 @@ const waitForNextTick = () =>
   })
 
 describe('useQueryStates', () => {
-  it('supports a query key named constructor', async () => {
-    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
-    const { result, act } = await renderHook(
-      () => useQueryState('constructor', parseAsString),
-      {
-        wrapper: withNuqsTestingAdapter({
-          searchParams: '?constructor=acme',
-          onUrlUpdate
-        })
-      }
-    )
+  it.each(['constructor', 'hasOwnProperty'])(
+    'supports a scalar query key named %s',
+    async key => {
+      const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+      const { result, act } = await renderHook(
+        () => useQueryState(key, parseAsString),
+        {
+          wrapper: withNuqsTestingAdapter({
+            searchParams: `?${key}=acme`,
+            onUrlUpdate
+          })
+        }
+      )
 
-    expect(result.current[0]).toBe('acme')
-    await act(() => result.current[1]('ajax'))
-    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?constructor=ajax')
-  })
+      expect(result.current[0]).toBe('acme')
+      await act(() => result.current[1]('ajax'))
+      expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe(`?${key}=ajax`)
+    }
+  )
+  it.each(['constructor', 'hasOwnProperty'])(
+    'supports a native array query key named %s',
+    async key => {
+      const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+      const { result, act } = await renderHook(
+        () => useQueryState(key, parseAsNativeArrayOf(parseAsString)),
+        {
+          wrapper: withNuqsTestingAdapter({
+            searchParams: `?${key}=acme`,
+            onUrlUpdate
+          })
+        }
+      )
+
+      expect(result.current[0]).toEqual(['acme'])
+      await act(() => result.current[1](['ajax']))
+      expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe(`?${key}=ajax`)
+    }
+  )
   it.each([
     {
       name: 'comma-containing values to repeated values',
@@ -814,6 +836,35 @@ describe('useQueryStates: clearOnDefault', () => {
 })
 
 describe('useQueryStates: dynamic keys', () => {
+  it.each(['constructor', 'hasOwnProperty'])(
+    'supports adding a dynamic native array key named %s',
+    async key => {
+      const parser = parseAsNativeArrayOf(parseAsString)
+      const useTestHook = (includePrototypeKey = false) => {
+        const parsers: Record<string, typeof parser> = { a: parser }
+        if (includePrototypeKey) {
+          parsers[key] = parser
+        }
+        return useQueryStates(parsers)
+      }
+      const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+      const { result, rerender, act } = await renderHook(useTestHook, {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: `?${key}=acme`,
+          onUrlUpdate
+        })
+      })
+
+      await act(() => result.current[1]({ [key]: ['ignored'] }))
+      expect(onUrlUpdate).not.toHaveBeenCalled()
+      await rerender(true)
+      expect(Object.hasOwn(result.current[0], key)).toBe(true)
+      expect(result.current[0][key]).toEqual(['acme'])
+      await act(() => result.current[1]({ [key]: ['ajax'] }))
+      expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe(`?${key}=ajax`)
+    }
+  )
+
   it('supports dynamic keys', async () => {
     const useTestHook = (keys: [string, string] = ['a', 'b']) =>
       useQueryStates({

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -40,15 +40,15 @@ describe('useQueryStates', () => {
       () => useQueryState('constructor', parseAsString),
       {
         wrapper: withNuqsTestingAdapter({
-          searchParams: '?constructor=hello',
+          searchParams: '?constructor=acme',
           onUrlUpdate
         })
       }
     )
 
-    expect(result.current[0]).toBe('hello')
-    await act(() => result.current[1]('world'))
-    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?constructor=world')
+    expect(result.current[0]).toBe('acme')
+    await act(() => result.current[1]('ajax'))
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?constructor=ajax')
   })
   it.each([
     {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -34,6 +34,22 @@ const waitForNextTick = () =>
   })
 
 describe('useQueryStates', () => {
+  it('supports a query key named constructor', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const { result, act } = await renderHook(
+      () => useQueryState('constructor', parseAsString),
+      {
+        wrapper: withNuqsTestingAdapter({
+          searchParams: '?constructor=hello',
+          onUrlUpdate
+        })
+      }
+    )
+
+    expect(result.current[0]).toBe('hello')
+    await act(() => result.current[1]('world'))
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?constructor=world')
+  })
   it.each([
     {
       name: 'comma-containing values to repeated values',

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -144,7 +144,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const committedPathnameRef = useRef<string | null>(null)
   const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
   const [internalState, setInternalState] = useState<V>(
-    () => parseMap(keyMap, urlKeys, initialSearchParams, queuedQueries).state
+    () =>
+      parseMap(keyMap, resolvedUrlKeys, initialSearchParams, queuedQueries)
+        .state
   )
 
   const stateRef = useRef(internalState)
@@ -165,7 +167,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const reconcile = () => {
     const { state, hasChanged } = parseMap(
       keyMap,
-      urlKeys,
+      resolvedUrlKeys,
       initialSearchParams,
       queuedQueries,
       queryRef.current,
@@ -429,7 +431,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
 function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   keyMap: KeyMap,
-  urlKeys: Partial<Record<keyof KeyMap, string>>,
+  resolvedUrlKeys: Record<string, string>,
   searchParams: URLSearchParams,
   queuedQueries: Record<string, Query | null | undefined>,
   cachedQuery?: Record<string, Query | null>,
@@ -440,7 +442,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
 } {
   let hasChanged = false
   const state = Object.entries(keyMap).reduce((out, [stateKey, parser]) => {
-    const urlKey = urlKeys?.[stateKey] ?? stateKey
+    const urlKey = resolvedUrlKeys[stateKey] ?? stateKey
     const queuedQuery = queuedQueries[urlKey]
     const fallbackValue = parser.type === 'multi' ? [] : null
     const query =

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -16,6 +16,7 @@ import {
 import { safeParse } from './lib/safe-parse'
 import { isAbsentFromUrl, type Query } from './lib/search-params'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
+import { getUrlKey } from './lib/url-keys'
 import { type GenericParser } from './parsers'
 
 type KeyMapValue<Type> = GenericParser<Type> &
@@ -118,7 +119,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const resolvedUrlKeys = useMemo(
     () =>
       Object.fromEntries(
-        Object.keys(keyMap).map(key => [key, urlKeys[key] ?? key])
+        Object.keys(keyMap).map(key => [key, getUrlKey(urlKeys, key)])
       ),
     [stateKeys, JSON.stringify(urlKeys)]
   )

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -16,7 +16,7 @@ import {
 import { safeParse } from './lib/safe-parse'
 import { isAbsentFromUrl, type Query } from './lib/search-params'
 import { emitter, type CrossHookSyncPayload } from './lib/sync'
-import { getUrlKey } from './lib/url-keys'
+import { getOwn, getUrlKey } from './lib/url-keys'
 import { type GenericParser } from './parsers'
 
 type KeyMapValue<Type> = GenericParser<Type> &
@@ -328,8 +328,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         (p: Promise<URLSearchParams>) => Promise<URLSearchParams>
       > = []
       for (let [stateKey, value] of Object.entries(newState)) {
-        const parser = stableKeyMap[stateKey]
-        const urlKey = resolvedUrlKeys[stateKey]
+        const parser = getOwn(stableKeyMap, stateKey)
+        const urlKey = resolvedUrlKeys[stateKey]!
         if (!parser || urlKey === undefined || value === undefined) {
           continue
         }
@@ -442,8 +442,8 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
 } {
   let hasChanged = false
   const state = Object.entries(keyMap).reduce((out, [stateKey, parser]) => {
-    const urlKey = resolvedUrlKeys[stateKey] ?? stateKey
-    const queuedQuery = queuedQueries[urlKey]
+    const urlKey = resolvedUrlKeys[stateKey]!
+    const queuedQuery = getOwn(queuedQueries, urlKey)
     const fallbackValue = parser.type === 'multi' ? [] : null
     const query =
       queuedQuery === undefined
@@ -451,13 +451,14 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
             ? searchParams.getAll(urlKey)
             : searchParams.get(urlKey)) ?? fallbackValue)
         : queuedQuery
+    const cachedStateValue = cachedState && getOwn(cachedState, stateKey)
     if (
       cachedQuery &&
-      cachedState &&
-      compareQuery(cachedQuery[urlKey] ?? fallbackValue, query)
+      cachedStateValue !== undefined &&
+      compareQuery(getOwn(cachedQuery, urlKey) ?? fallbackValue, query)
     ) {
       // Cache hit
-      out[stateKey as keyof KeyMap] = cachedState[stateKey] ?? null
+      out[stateKey as keyof KeyMap] = cachedStateValue
       return out
     }
     // Cache miss


### PR DESCRIPTION
## Summary

- Treat `constructor`, `toString`, and `hasOwnProperty` as normal query keys.
- Resolve URL key mappings from their own properties only.
- Ignore inherited serializer values and cover loaders, serializers, and hooks.
