### PR TITLE
chore: enable Rust React Compiler for docs

### DIFF
--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -15,6 +15,9 @@ const config = {
     ]
   },
   reactCompiler: true,
+  experimental: {
+    turbopackRustReactCompiler: true
+  },
   reactStrictMode: true,
   // The changelog page imports the IO-free changelog codec straight from the
   // `scripts` workspace as raw TypeScript; transpile it as part of the build.


### PR DESCRIPTION
## Summary

Enable Next.js 16.3's experimental Rust React Compiler backend for the documentation app. The app already uses React Compiler, so this replaces its Turbopack compilation path without changing application behavior.

## Local performance

Isolated baseline and candidate measurements on the same machine:

- cold `/docs/installation`: 146.01s to 107.43s (26.4% faster)
- warm `/docs/installation`: 1.245s to 0.404s (67.6% faster)
- clean Next.js compiler stage: 7.0min to 6.1min (12.9% faster)
- clean build wall time: 444.63s to 431.39s (3.0% faster)
- development server readiness: 1.00s to 1.17s

## Caveat

The Rust backend is experimental in Next.js 16.3. This PR is a small, reversible configuration change so CI and preview behavior can provide more evidence before it is marked ready.
