### PR TITLE
fix: reject impossible calendar dates in parseAsIsoDate & IsoDateTime

### DIFF
--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -119,6 +119,7 @@ describe('parsers', () => {
   it('parseAsIsoDateTime', () => {
     expect(parseAsIsoDateTime.parse('')).toBeNull()
     expect(parseAsIsoDateTime.parse('not-a-date')).toBeNull()
+    expect(parseAsIsoDateTime.parse('2021-02-29T10:00:00Z')).toBeNull()
     const moment = '2020-01-01T00:00:00.000Z'
     const ref = new Date(moment)
     expect(parseAsIsoDateTime.parse(moment)).toStrictEqual(ref)

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -120,6 +120,15 @@ describe('parsers', () => {
     expect(parseAsIsoDateTime.parse('')).toBeNull()
     expect(parseAsIsoDateTime.parse('not-a-date')).toBeNull()
     expect(parseAsIsoDateTime.parse('2021-02-29T10:00:00Z')).toBeNull()
+    expect(parseAsIsoDateTime.parse('March 1, 2021')).toBeNull()
+    expect(parseAsIsoDateTime.parse('2020-02-29T10:00:00Z')).toStrictEqual(
+      new Date('2020-02-29T10:00:00Z')
+    )
+    // The calendar check applies to the written date part,
+    // not the UTC date of the parsed value
+    expect(parseAsIsoDateTime.parse('2021-03-01T00:30:00+01:00')).toStrictEqual(
+      new Date('2021-02-28T23:30:00.000Z')
+    )
     const moment = '2020-01-01T00:00:00.000Z'
     const ref = new Date(moment)
     expect(parseAsIsoDateTime.parse(moment)).toStrictEqual(ref)
@@ -135,6 +144,18 @@ describe('parsers', () => {
     expect(parseAsIsoDate.parse('')).toBeNull()
     expect(parseAsIsoDate.parse('not-a-date')).toBeNull()
     expect(parseAsIsoDate.parse('2021-02-29')).toBeNull()
+    expect(parseAsIsoDate.parse('2021-04-31')).toBeNull()
+    expect(parseAsIsoDate.parse('1900-02-29')).toBeNull()
+    expect(parseAsIsoDate.parse('2020-02-29')).toStrictEqual(
+      new Date('2020-02-29')
+    )
+    expect(parseAsIsoDate.parse('2000-02-29')).toStrictEqual(
+      new Date('2000-02-29')
+    )
+    // Reduced-precision and non-padded forms are rejected
+    expect(parseAsIsoDate.parse('2021')).toBeNull()
+    expect(parseAsIsoDate.parse('2021-02')).toBeNull()
+    expect(parseAsIsoDate.parse('2021-2-3')).toBeNull()
     const moment = '2020-01-01'
     const ref = new Date(moment)
     expect(parseAsIsoDate.parse(moment)).toStrictEqual(ref)

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -133,6 +133,7 @@ describe('parsers', () => {
   it('parseAsIsoDate', () => {
     expect(parseAsIsoDate.parse('')).toBeNull()
     expect(parseAsIsoDate.parse('not-a-date')).toBeNull()
+    expect(parseAsIsoDate.parse('2021-02-29')).toBeNull()
     const moment = '2020-01-01'
     const ref = new Date(moment)
     expect(parseAsIsoDate.parse(moment)).toStrictEqual(ref)

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -289,6 +289,15 @@ export const parseAsTimestamp: SingleParserBuilder<Date> = createParser({
   eq: compareDates
 })
 
+const parseIsoDatePart = (v: string): Date | null => {
+  const date = new Date(v.slice(0, 10))
+  // NaN and calendar date normalization checks
+  return date.valueOf() == date.valueOf() &&
+    date.toISOString().slice(0, 10) === v.slice(0, 10)
+    ? date
+    : null
+}
+
 /**
  * Querystring encoded as an ISO-8601 string (UTC),
  * and returned as a Date object.
@@ -297,7 +306,9 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
     // NaN check at low bundle size cost
-    return date.valueOf() == date.valueOf() ? date : null
+    return date.valueOf() == date.valueOf() && parseIsoDatePart(v)
+      ? date
+      : null
   },
   serialize: (v: Date) => v.toISOString(),
   eq: compareDates
@@ -312,15 +323,7 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
  * making it at 00:00:00 UTC.
  */
 export const parseAsIsoDate: SingleParserBuilder<Date> = createParser({
-  parse: v => {
-    const dateString = v.slice(0, 10)
-    const date = new Date(dateString)
-    // NaN and calendar date normalization checks
-    return date.valueOf() == date.valueOf() &&
-      date.toISOString().slice(0, 10) === dateString
-      ? date
-      : null
-  },
+  parse: parseIsoDatePart,
   serialize: (v: Date) => v.toISOString().slice(0, 10),
   eq: compareDates
 })

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -289,15 +289,6 @@ export const parseAsTimestamp: SingleParserBuilder<Date> = createParser({
   eq: compareDates
 })
 
-const parseIsoDatePart = (v: string): Date | null => {
-  const date = new Date(v.slice(0, 10))
-  // NaN and calendar date normalization checks
-  return date.valueOf() == date.valueOf() &&
-    date.toISOString().slice(0, 10) === v.slice(0, 10)
-    ? date
-    : null
-}
-
 /**
  * Querystring encoded as an ISO-8601 string (UTC),
  * and returned as a Date object.
@@ -306,7 +297,9 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
     // NaN check at low bundle size cost
-    return date.valueOf() == date.valueOf() && parseIsoDatePart(v) ? date : null
+    return parseAsIsoDate.parse(v) && date.valueOf() == date.valueOf()
+      ? date
+      : null
   },
   serialize: (v: Date) => v.toISOString(),
   eq: compareDates
@@ -321,7 +314,14 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
  * making it at 00:00:00 UTC.
  */
 export const parseAsIsoDate: SingleParserBuilder<Date> = createParser({
-  parse: parseIsoDatePart,
+  parse: v => {
+    const date = new Date(v.slice(0, 10))
+    // NaN and calendar date normalization checks
+    return date.valueOf() == date.valueOf() &&
+      parseAsIsoDate.serialize(date) === v.slice(0, 10)
+      ? date
+      : null
+  },
   serialize: (v: Date) => v.toISOString().slice(0, 10),
   eq: compareDates
 })

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -300,8 +300,9 @@ export const parseAsTimestamp: SingleParserBuilder<Date> = createParser({
 export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
-    // The NaN check rejects invalid time parts,
-    // reusing parseAsIsoDate.parse rejects invalid calendar dates
+    // The NaN check rejects invalid time parts.
+    // parseAsIsoDate.parse rejects invalid calendar dates
+    // (reused to keep the bundle small).
     return +date == +date && parseAsIsoDate.parse(v) ? date : null
   },
   serialize: (v: Date) => v.toISOString(),
@@ -324,7 +325,8 @@ export const parseAsIsoDate: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v.slice(0, 10))
     // NaN check first: serialize throws on Invalid Date.
-    // The roundtrip rejects dates the constructor normalizes.
+    // new Date() turns 2021-02-29 into 2021-03-01 silently,
+    // so serialize back and compare with the input.
     return +date == +date && parseAsIsoDate.serialize(date) === v.slice(0, 10)
       ? date
       : null

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -306,9 +306,7 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
     // NaN check at low bundle size cost
-    return date.valueOf() == date.valueOf() && parseIsoDatePart(v)
-      ? date
-      : null
+    return date.valueOf() == date.valueOf() && parseIsoDatePart(v) ? date : null
   },
   serialize: (v: Date) => v.toISOString(),
   eq: compareDates

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -292,11 +292,16 @@ export const parseAsTimestamp: SingleParserBuilder<Date> = createParser({
 /**
  * Querystring encoded as an ISO-8601 string (UTC),
  * and returned as a Date object.
+ *
+ * The date part must be a valid `YYYY-MM-DD` calendar date:
+ * impossible dates like 2021-02-29 and reduced-precision
+ * or non-ISO forms parse to null.
  */
 export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
-    // NaN check at low bundle size cost
+    // The NaN check rejects invalid time parts,
+    // reusing parseAsIsoDate.parse rejects invalid calendar dates
     return +date == +date && parseAsIsoDate.parse(v) ? date : null
   },
   serialize: (v: Date) => v.toISOString(),
@@ -310,11 +315,16 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
  *
  * The Date is parsed without the time zone offset,
  * making it at 00:00:00 UTC.
+ *
+ * Only valid `YYYY-MM-DD` calendar dates are accepted:
+ * impossible dates like 2021-02-29 and reduced-precision
+ * or non-ISO forms parse to null.
  */
 export const parseAsIsoDate: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v.slice(0, 10))
-    // NaN and calendar date normalization checks
+    // NaN check first: serialize throws on Invalid Date.
+    // The roundtrip rejects dates the constructor normalizes.
     return +date == +date && parseAsIsoDate.serialize(date) === v.slice(0, 10)
       ? date
       : null

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -283,7 +283,7 @@ function compareDates(a: Date, b: Date) {
 export const parseAsTimestamp: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(parseInt(v))
-    return date.valueOf() == date.valueOf() ? date : null // NaN check at low bundle size cost
+    return +date == +date ? date : null // NaN check at low bundle size cost
   },
   serialize: (v: Date) => '' + v.valueOf(),
   eq: compareDates
@@ -297,9 +297,7 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v)
     // NaN check at low bundle size cost
-    return parseAsIsoDate.parse(v) && date.valueOf() == date.valueOf()
-      ? date
-      : null
+    return +date == +date && parseAsIsoDate.parse(v) ? date : null
   },
   serialize: (v: Date) => v.toISOString(),
   eq: compareDates
@@ -317,8 +315,7 @@ export const parseAsIsoDate: SingleParserBuilder<Date> = createParser({
   parse: v => {
     const date = new Date(v.slice(0, 10))
     // NaN and calendar date normalization checks
-    return date.valueOf() == date.valueOf() &&
-      parseAsIsoDate.serialize(date) === v.slice(0, 10)
+    return +date == +date && parseAsIsoDate.serialize(date) === v.slice(0, 10)
       ? date
       : null
   },

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -313,9 +313,13 @@ export const parseAsIsoDateTime: SingleParserBuilder<Date> = createParser({
  */
 export const parseAsIsoDate: SingleParserBuilder<Date> = createParser({
   parse: v => {
-    const date = new Date(v.slice(0, 10))
-    // NaN check at low bundle size cost
-    return date.valueOf() == date.valueOf() ? date : null
+    const dateString = v.slice(0, 10)
+    const date = new Date(dateString)
+    // NaN and calendar date normalization checks
+    return date.valueOf() == date.valueOf() &&
+      date.toISOString().slice(0, 10) === dateString
+      ? date
+      : null
   },
   serialize: (v: Date) => v.toISOString().slice(0, 10),
   eq: compareDates


### PR DESCRIPTION
parseAsIsoDate('2021-02-29') returned a Date (2021-03-01T00:00:00.000Z) instead of null. The JavaScript Date constructor silently normalizes invalid calendar dates like Feb 29 in non-leap years into the next valid date, so the existing NaN check did not catch them.

The fix validates that the parsed date's ISO string matches the input string, so any normalization causes the parser to return null instead.