### PR TITLE
doc: build and run without a GitHub token

### DIFF
--- a/packages/docs/.env.example
+++ b/packages/docs/.env.example
@@ -1,9 +1,10 @@
 # GitHub API token. Optional: a fine-grained token with only public
 # read access (no extra permissions) is enough.
 # Used at build time for: landing-page contributors & CI status, /stats star
-# history, changelog, last-modified dates. Without it, REST-backed sections
-# fall back to unauthenticated rate limits and GraphQL-backed ones
-# (CI status, star history) are hidden.
+# history, changelog, last-modified dates. Without it, the CI status section
+# is hidden, the star history widget shows an unavailable notice, and
+# REST-backed sections make anonymous requests — a cold build can exceed
+# the 60 req/h anonymous rate limit and still fail some pages.
 GITHUB_TOKEN=
 
 # Shared secret for the ISR cache-invalidation endpoint (src/app/api/isr).

--- a/packages/docs/.env.example
+++ b/packages/docs/.env.example
@@ -1,9 +1,9 @@
-# GitHub API token (classic, public_repo read scope is enough).
-# Explicit worktree setup populates this in .env.local from GITHUB_TOKEN or,
-# when the variable is absent, from `gh auth token`.
+# GitHub API token. Optional: a fine-grained token with only public
+# read access (no extra permissions) is enough.
 # Used at build time for: landing-page contributors & CI status, /stats star
-# history, changelog, last-modified dates. Without it, local builds hit
-# unauthenticated GitHub rate limits.
+# history, changelog, last-modified dates. Without it, REST-backed sections
+# fall back to unauthenticated rate limits and GraphQL-backed ones
+# (CI status, star history) are hidden.
 GITHUB_TOKEN=
 
 # Shared secret for the ISR cache-invalidation endpoint (src/app/api/isr).

--- a/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
@@ -4,6 +4,7 @@ import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   it,
@@ -35,11 +36,18 @@ function respondWith(nodes: unknown[]) {
 describe('getGitHubActionsStatus', () => {
   const server = setupServer()
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+  beforeEach(() => vi.stubEnv('GITHUB_TOKEN', 'test-token'))
   afterEach(() => {
     server.resetHandlers()
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
   })
   afterAll(() => server.close())
+
+  it('returns [] without a GitHub token', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    expect(await getGitHubActionsStatus()).toEqual([])
+  })
 
   it('keeps the last 5 completed runs, ordered oldest to newest', async () => {
     // API returns newest-first; n2 and n8 are not completed and must drop out.

--- a/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.test.ts
@@ -44,9 +44,13 @@ describe('getGitHubActionsStatus', () => {
   })
   afterAll(() => server.close())
 
-  it('returns [] without a GitHub token', async () => {
+  it('returns [] and warns without a GitHub token', async () => {
     vi.stubEnv('GITHUB_TOKEN', '')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(await getGitHubActionsStatus()).toEqual([])
+    expect(warn).toHaveBeenCalledWith(
+      'GITHUB_TOKEN is not set: GitHub Actions status is unavailable.'
+    )
   })
 
   it('keeps the last 5 completed runs, ordered oldest to newest', async () => {

--- a/packages/docs/src/app/(pages)/_landing/gha-status.tsx
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.tsx
@@ -64,6 +64,9 @@ const ghaStatusSchema = z.object({
 export async function getGitHubActionsStatus() {
   // The GraphQL API rejects unauthenticated requests
   if (!process.env.GITHUB_TOKEN) {
+    console.warn(
+      'GITHUB_TOKEN is not set: GitHub Actions status is unavailable.'
+    )
     return []
   }
   // Fetch a few more than needed to filter out non-completed runs

--- a/packages/docs/src/app/(pages)/_landing/gha-status.tsx
+++ b/packages/docs/src/app/(pages)/_landing/gha-status.tsx
@@ -62,6 +62,10 @@ const ghaStatusSchema = z.object({
 })
 
 export async function getGitHubActionsStatus() {
+  // The GraphQL API rejects unauthenticated requests
+  if (!process.env.GITHUB_TOKEN) {
+    return []
+  }
   // Fetch a few more than needed to filter out non-completed runs
   const query = `query {
     node(id: "W_kwDOD6wJuM4EeKz5") {

--- a/packages/docs/src/app/(pages)/stats/_components/stars.tsx
+++ b/packages/docs/src/app/(pages)/stats/_components/stars.tsx
@@ -5,6 +5,7 @@ import { getStarHistory } from '../lib/github'
 import { GraphSkeleton } from './graph.skeleton'
 import { StarsGraph } from './stars.client'
 import StargazersList from './stars.gazers-list'
+import { Widget } from './widget'
 import { WidgetSkeleton } from './widget.skeleton'
 
 const getCachedStarHistory = unstable_cache(
@@ -16,6 +17,21 @@ const getCachedStarHistory = unstable_cache(
 export async function StarHistoryGraph() {
   await connection()
   const stars = await getCachedStarHistory()
+  if (stars === null) {
+    return (
+      <Widget
+        title={
+          <>
+            <Star size={20} className="ml-2" /> Stars
+          </>
+        }
+      >
+        <p className="text-muted-foreground flex h-74.5 items-center justify-center text-sm">
+          Star history is unavailable: set GITHUB_TOKEN to enable it.
+        </p>
+      </Widget>
+    )
+  }
   return (
     <StarsGraph data={stars} stargazersTab={<StargazersList stars={stars} />} />
   )

--- a/packages/docs/src/app/(pages)/stats/lib/github.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.test.ts
@@ -60,10 +60,21 @@ afterAll(() => server.close())
 beforeEach(() => {
   vi.useFakeTimers({ toFake: ['Date'] })
   vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
+  vi.stubEnv('GITHUB_TOKEN', 'test-token')
 })
-afterEach(() => vi.useRealTimers())
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+})
 
 describe('getStarHistory', () => {
+  it('returns empty bins without a GitHub token', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    const history = await getStarHistory()
+    expect(history.count).toBe(0)
+    expect(history.bins).toHaveLength(12)
+    expect(history.bins.every(bin => bin.stars === 0)).toBe(true)
+  })
   it('fills the 12-day bins and computes end-of-day star totals', async () => {
     server.use(
       http.post(endpoint, () =>

--- a/packages/docs/src/app/(pages)/stats/lib/github.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.test.ts
@@ -17,6 +17,14 @@ import { getStarHistory } from './github.ts'
 
 const endpoint = 'https://api.github.com/graphql'
 
+async function getAvailableStarHistory() {
+  const history = await getStarHistory()
+  if (history === null) {
+    throw new Error('Expected star history to be available')
+  }
+  return history
+}
+
 function edge(login: string, starredAt: string) {
   return {
     starredAt,
@@ -65,15 +73,17 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers()
   vi.unstubAllEnvs()
+  vi.restoreAllMocks()
 })
 
 describe('getStarHistory', () => {
-  it('returns empty bins without a GitHub token', async () => {
+  it('returns null and warns without a GitHub token', async () => {
     vi.stubEnv('GITHUB_TOKEN', '')
-    const history = await getStarHistory()
-    expect(history.count).toBe(0)
-    expect(history.bins).toHaveLength(12)
-    expect(history.bins.every(bin => bin.stars === 0)).toBe(true)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(await getStarHistory()).toBeNull()
+    expect(warn).toHaveBeenCalledWith(
+      'GITHUB_TOKEN is not set: star history is unavailable.'
+    )
   })
   it('fills the 12-day bins and computes end-of-day star totals', async () => {
     server.use(
@@ -90,7 +100,7 @@ describe('getStarHistory', () => {
         )
       )
     )
-    const history = await getStarHistory()
+    const history = await getAvailableStarHistory()
     expect(history.count).toBe(100)
     expect(history.bins).toHaveLength(12)
     expect(history.bins[0]).toMatchObject({
@@ -119,7 +129,7 @@ describe('getStarHistory', () => {
         )
       )
     )
-    const history = await getStarHistory()
+    const history = await getAvailableStarHistory()
     expect(history.bins[11].date).toBe('2024-06-04')
     expect(history.bins[11].stargarzers.map(s => s.login)).toEqual(['boundary'])
     const allLogins = history.bins.flatMap(b => b.stargarzers.map(s => s.login))
@@ -149,7 +159,7 @@ describe('getStarHistory', () => {
         )
       })
     )
-    const history = await getStarHistory()
+    const history = await getAvailableStarHistory()
     // p2a only appears if the second page was fetched via the cursor.
     expect(history.bins[0].stargarzers.map(s => s.login)).toEqual(['p1a'])
     expect(history.bins[1].stargarzers.map(s => s.login)).toEqual(['p1b'])
@@ -164,7 +174,7 @@ describe('getStarHistory', () => {
         )
       )
     )
-    const history = await getStarHistory()
+    const history = await getAvailableStarHistory()
     expect(history.count).toBe(50)
     expect(history.bins).toHaveLength(12)
     expect(history.bins.every(b => b.diff === 0)).toBe(true)
@@ -179,7 +189,7 @@ describe('getStarHistory', () => {
         )
       )
     )
-    const history = await getStarHistory()
+    const history = await getAvailableStarHistory()
     expect(history.count).toBe(200)
     expect(history.bins[0]).toMatchObject({ stars: 200, diff: 0 })
     expect(history.bins.every(b => b.stargarzers.length === 0)).toBe(true)

--- a/packages/docs/src/app/(pages)/stats/lib/github.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.ts
@@ -54,7 +54,13 @@ const starHistoryQuerySchema = z.object({
 
 export async function getStarHistory(
   slug = '47ng/nuqs'
-): Promise<GitHubStarHistory> {
+): Promise<GitHubStarHistory | null> {
+  // The GraphQL API rejects unauthenticated requests
+  if (!process.env.GITHUB_TOKEN) {
+    console.warn('GITHUB_TOKEN is not set: star history is unavailable.')
+    return null
+  }
+
   const [owner, repo] = slug.split('/')
 
   // Compute the 12-day window [today .. today-11d] in UTC
@@ -71,12 +77,6 @@ export async function getStarHistory(
     date,
     stargarzers: []
   }))
-
-  // The GraphQL API rejects unauthenticated requests
-  if (!process.env.GITHUB_TOKEN) {
-    console.warn('GITHUB_TOKEN is not set: star history is unavailable.')
-    return { count: 0, bins }
-  }
 
   // Paginate through stargazers 100 at a time until we reach older than the window start
   let after: string | undefined

--- a/packages/docs/src/app/(pages)/stats/lib/github.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.ts
@@ -72,6 +72,12 @@ export async function getStarHistory(
     stargarzers: []
   }))
 
+  // The GraphQL API rejects unauthenticated requests
+  if (!process.env.GITHUB_TOKEN) {
+    console.warn('GITHUB_TOKEN is not set: star history is unavailable.')
+    return { count: 0, bins }
+  }
+
   // Paginate through stargazers 100 at a time until we reach older than the window start
   let after: string | undefined
   let hasNextPage = true

--- a/packages/docs/src/components/release-contribution-graph.lib.test.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.test.ts
@@ -86,6 +86,7 @@ describe('fetchGitHubReleases', () => {
   afterEach(() => {
     server.resetHandlers()
     vi.unstubAllEnvs()
+    vi.restoreAllMocks()
   })
   afterAll(() => server.close())
 
@@ -98,7 +99,7 @@ describe('fetchGitHubReleases', () => {
       http.get(endpoint, () => HttpResponse.json([release(1), release(2)]))
     )
     const releases = await fetchGitHubReleases()
-    expect(releases.map(r => r.tag_name)).toEqual(['v1', 'v2'])
+    expect(releases?.map(r => r.tag_name)).toEqual(['v1', 'v2'])
   })
 
   it('sends the token as an Authorization header when set', async () => {
@@ -136,7 +137,7 @@ describe('fetchGitHubReleases', () => {
     )
     const releases = await fetchGitHubReleases()
     expect(releases).toHaveLength(101)
-    expect(releases.at(-1)?.tag_name).toBe('v999')
+    expect(releases?.at(-1)?.tag_name).toBe('v999')
   })
 
   it('stops paginating on an empty page', async () => {
@@ -149,6 +150,17 @@ describe('fetchGitHubReleases', () => {
     )
     const releases = await fetchGitHubReleases()
     expect(releases).toHaveLength(100)
+  })
+
+  it('returns null and warns when rate limited', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    server.use(http.get(endpoint, () => HttpResponse.json({}, { status: 403 })))
+    expect(await fetchGitHubReleases()).toBeNull()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('GitHub rate limit reached (403)')
+    )
+    server.use(http.get(endpoint, () => HttpResponse.json({}, { status: 429 })))
+    expect(await fetchGitHubReleases()).toBeNull()
   })
 
   it('throws on a non-ok response', async () => {

--- a/packages/docs/src/components/release-contribution-graph.lib.test.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.test.ts
@@ -1,6 +1,15 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
 import {
   fetchGitHubReleases,
   isBetaVersion,
@@ -73,7 +82,11 @@ describe('processReleases', () => {
 describe('fetchGitHubReleases', () => {
   const server = setupServer()
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-  afterEach(() => server.resetHandlers())
+  beforeEach(() => vi.stubEnv('GITHUB_TOKEN', 'test-token'))
+  afterEach(() => {
+    server.resetHandlers()
+    vi.unstubAllEnvs()
+  })
   afterAll(() => server.close())
 
   function release(i: number) {
@@ -86,6 +99,31 @@ describe('fetchGitHubReleases', () => {
     )
     const releases = await fetchGitHubReleases()
     expect(releases.map(r => r.tag_name)).toEqual(['v1', 'v2'])
+  })
+
+  it('sends the token as an Authorization header when set', async () => {
+    let auth: string | null = null
+    server.use(
+      http.get(endpoint, ({ request }) => {
+        auth = request.headers.get('authorization')
+        return HttpResponse.json([release(1)])
+      })
+    )
+    await fetchGitHubReleases()
+    expect(auth).toBe('Bearer test-token')
+  })
+
+  it('makes anonymous requests without a GitHub token', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    let auth: string | null = 'unset'
+    server.use(
+      http.get(endpoint, ({ request }) => {
+        auth = request.headers.get('authorization')
+        return HttpResponse.json([release(1)])
+      })
+    )
+    await fetchGitHubReleases()
+    expect(auth).toBeNull()
   })
 
   it('concatenates across pages until a short page', async () => {

--- a/packages/docs/src/components/release-contribution-graph.lib.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.ts
@@ -24,15 +24,18 @@ export async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
   const releases: GitHubRelease[] = []
   let page = 1
   const perPage = 100
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json'
+  }
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
 
   while (true) {
     const response = await fetch(
       `https://api.github.com/repos/47ng/nuqs/releases?per_page=${perPage}&page=${page}`,
       {
-        headers: {
-          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-          Accept: 'application/vnd.github.v3+json'
-        },
+        headers,
         next: { revalidate: 3600 } // Cache for 1 hour
       }
     )

--- a/packages/docs/src/components/release-contribution-graph.lib.ts
+++ b/packages/docs/src/components/release-contribution-graph.lib.ts
@@ -20,7 +20,7 @@ const gitHubReleasesSchema = z.array(gitHubReleaseSchema)
 
 export type GitHubRelease = z.infer<typeof gitHubReleaseSchema>
 
-export async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
+export async function fetchGitHubReleases(): Promise<GitHubRelease[] | null> {
   const releases: GitHubRelease[] = []
   let page = 1
   const perPage = 100
@@ -40,6 +40,12 @@ export async function fetchGitHubReleases(): Promise<GitHubRelease[]> {
       }
     )
 
+    if (response.status === 403 || response.status === 429) {
+      console.warn(
+        `GitHub rate limit reached (${response.status}): release calendar is unavailable. Set GITHUB_TOKEN to raise the limit.`
+      )
+      return null
+    }
     if (!response.ok) {
       throw new Error(`GitHub API error: ${response.status}`)
     }

--- a/packages/docs/src/components/release-contribution-graph.tsx
+++ b/packages/docs/src/components/release-contribution-graph.tsx
@@ -51,6 +51,13 @@ async function ReleaseContributionGraphLoader({
   year
 }: ReleaseContributionGraphProps) {
   const releases = await fetchGitHubReleases()
+  if (releases === null) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        The release calendar is unavailable: GitHub rate limit reached.
+      </p>
+    )
+  }
   const { activities, releasesByDate } = processReleases(releases, year)
   const stableCount = activities.filter(a => a.level === 2).length
   const betaCount = activities.filter(a => a.level === 1).length

--- a/packages/docs/src/components/ui/pr-line.test.tsx
+++ b/packages/docs/src/components/ui/pr-line.test.tsx
@@ -144,6 +144,21 @@ describe('PullRequestLine', () => {
     expect(html).toContain('closed PR')
   })
 
+  it('degrades to a plain GitHub link when rate limited', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    server.use(
+      http.get(endpoint(42), () => HttpResponse.json({}, { status: 403 }))
+    )
+    const html = await render(42)
+    expect(html).toContain('https://github.com/47ng/nuqs/pull/42')
+    expect(html).toContain('View on GitHub')
+    expect(html).not.toContain('Failed to fetch details')
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('GitHub rate limit reached (403)')
+    )
+    warn.mockRestore()
+  })
+
   it('renders a fallback message on a non-ok response without throwing', async () => {
     server.use(
       http.get(endpoint(42), () =>

--- a/packages/docs/src/components/ui/pr-line.test.tsx
+++ b/packages/docs/src/components/ui/pr-line.test.tsx
@@ -1,7 +1,16 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi
+} from 'vitest'
 import { PullRequestLine } from './pr-line.tsx'
 
 function endpoint(number: number | string) {
@@ -35,8 +44,37 @@ async function render(number: number | string) {
 describe('PullRequestLine', () => {
   const server = setupServer()
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-  afterEach(() => server.resetHandlers())
+  beforeEach(() => vi.stubEnv('GITHUB_TOKEN', 'test-token'))
+  afterEach(() => {
+    server.resetHandlers()
+    vi.unstubAllEnvs()
+  })
   afterAll(() => server.close())
+
+  it('sends the token as an Authorization header when set', async () => {
+    let auth: string | null = null
+    server.use(
+      http.get(endpoint(1), ({ request }) => {
+        auth = request.headers.get('authorization')
+        return HttpResponse.json(pull())
+      })
+    )
+    await render(1)
+    expect(auth).toBe('bearer test-token')
+  })
+
+  it('makes anonymous requests without a GitHub token', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    let auth: string | null = 'unset'
+    server.use(
+      http.get(endpoint(1), ({ request }) => {
+        auth = request.headers.get('authorization')
+        return HttpResponse.json(pull())
+      })
+    )
+    await render(1)
+    expect(auth).toBeNull()
+  })
 
   it('strips the conventional-commit prefix (with scope) from the title', async () => {
     server.use(

--- a/packages/docs/src/components/ui/pr-line.tsx
+++ b/packages/docs/src/components/ui/pr-line.tsx
@@ -60,6 +60,31 @@ export async function PullRequestLine({
       cache: 'force-cache'
     }
   )
+  if (response.status === 403 || response.status === 429) {
+    // Rate limited: degrade to a plain link, the PR URL is predictable
+    console.warn(
+      `GitHub rate limit reached (${response.status}) fetching PR #${number}. Set GITHUB_TOKEN to raise the limit.`
+    )
+    return (
+      <li className={cn('not-prose space-x-2', className)} {...props}>
+        <a
+          href={`https://github.com/47ng/nuqs/pull/${number}`}
+          className="group space-x-1.5"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span className="text-sm text-gray-500 tabular-nums sm:text-base sm:font-medium">
+            <span aria-label="number">#</span>
+            {number}
+          </span>
+          <span className="font-medium group-hover:underline">
+            View on GitHub
+          </span>
+        </a>
+        {children}
+      </li>
+    )
+  }
   if (!response.ok) {
     return (
       <li className={cn('not-prose space-x-2', className)} {...props}>

--- a/packages/docs/src/components/ui/pr-line.tsx
+++ b/packages/docs/src/components/ui/pr-line.tsx
@@ -47,13 +47,16 @@ export async function PullRequestLine({
   children,
   ...props
 }: PullRequestLineProps) {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json'
+  }
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `bearer ${process.env.GITHUB_TOKEN}`
+  }
   const response = await fetch(
     `https://api.github.com/repos/47ng/nuqs/pulls/${number}`,
     {
-      headers: {
-        Accept: 'application/vnd.github.v3+json',
-        Authorization: `bearer ${process.env.GITHUB_TOKEN}`
-      },
+      headers,
       cache: 'force-cache'
     }
   )

--- a/packages/docs/src/lib/get-last-modified.ts
+++ b/packages/docs/src/lib/get-last-modified.ts
@@ -11,7 +11,9 @@ export async function getLastModified(
       repo: github.repo,
       path: `packages/docs${path}`,
       sha: branch,
-      token: `Bearer ${process.env.GITHUB_TOKEN}`
+      token: process.env.GITHUB_TOKEN
+        ? `Bearer ${process.env.GITHUB_TOKEN}`
+        : undefined
     })
     return lastEdit ?? new Date()
   } catch (error) {


### PR DESCRIPTION
Local docs builds fail when `GITHUB_TOKEN` is not set: fetch calls send `Authorization: Bearer undefined`, which GitHub rejects with a 401 instead of treating the request as anonymous.

The docs only need the token for higher rate limits on public data, so a missing token should degrade, not break. REST-backed sections now make anonymous requests. GraphQL-backed sections (CI status, star history) cannot work without auth, so they render empty instead of failing.
