### PR TITLE
chore: harden worktree checkout hook against untrusted branches

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -8,11 +8,13 @@
 #
 # Git appends the event's standard args to `command`:
 #   commit-msg passes the message-file path (consumed here by `--edit`);
-#   pre-commit takes none, pre-push passes <remote> <url> (ignored by node --run).
-# Runs the main checkout's script (trusted), not the checked-out branch's copy.
+#   pre-commit takes none, pre-push passes <remote> <url> (ignored by node --run);
+#   post-checkout passes <old> <new> <flag> (ignored by the setup script).
+# Runs the setup script pinned at origin/HEAD, never the checked-out branch's
+# copy, from a per-worktree cache in the git directory.
 [hook "worktree-setup"]
 	event = post-checkout
-	command = sh -c 'trusted=\"$(dirname \"$(git rev-parse --path-format=absolute --git-common-dir)\")/packages/scripts/worktree-setup.mjs\" && test ! -f \"$trusted\" || exec node \"$trusted\" --hook \"$@\"' -
+	command = "sh -c 'test -f .git || exit 0; dir=\"$(git rev-parse --path-format=absolute --git-dir)\" || exit; script=\"$dir/nuqs-worktree-setup.mjs\"; if git cat-file blob origin/HEAD:packages/scripts/worktree-setup.mjs > \"$script\" 2>/dev/null; then exec node \"$script\" --hook \"$@\"; else echo \"worktree-setup: cannot read the setup script from origin/HEAD, run node --run setup:worktree manually\" >&2; fi' -"
 [hook "prettier"]
 	event = pre-commit
 	command = node --run lint:prettier

--- a/.gitconfig
+++ b/.gitconfig
@@ -9,9 +9,10 @@
 # Git appends the event's standard args to `command`:
 #   commit-msg passes the message-file path (consumed here by `--edit`);
 #   pre-commit takes none, pre-push passes <remote> <url> (ignored by node --run).
+# Runs the main checkout's script (trusted), not the checked-out branch's copy.
 [hook "worktree-setup"]
 	event = post-checkout
-	command = sh -c 'test ! -f packages/scripts/worktree-setup.mjs || exec node packages/scripts/worktree-setup.mjs --hook "$@"' -
+	command = sh -c 'trusted=\"$(dirname \"$(git rev-parse --path-format=absolute --git-common-dir)\")/packages/scripts/worktree-setup.mjs\" && test ! -f \"$trusted\" || exec node \"$trusted\" --hook \"$@\"' -
 [hook "prettier"]
 	event = pre-commit
 	command = node --run lint:prettier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Refer to: [README.md](README.md) & [CONTRIBUTING.md](CONTRIBUTING.md) for author
 ### Configuration
 
 - **Package manager:** `pnpm`
-- **New worktrees:** With Git 2.54+, run `node --run setup:hooks` once per trusted clone. The hook installs dependencies for linked worktrees after `git worktree add`; otherwise run `node --run setup:worktree` in the new worktree. GitHub auth is optional and only copied to the docs environment by the explicit setup command.
+- **New worktrees:** With Git 2.54+, run `node --run setup:hooks` once per trusted clone. The hook installs dependencies for linked worktrees after `git worktree add`, using the main checkout's script and only when the branch's dependency manifests match `origin/HEAD`; otherwise review the manifests and run `node --run setup:worktree` in the new worktree.
 - **Build:** `pnpm build`
 - **Test suite:** `pnpm test` (5-10 minutes; includes build + unit + typing + e2e)
 - **Focused tests:** Use the root Turbo command, for example `pnpm run test --filter nuqs` or `pnpm run test --filter e2e-next`. Do not invoke package test scripts directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Refer to: [README.md](README.md) & [CONTRIBUTING.md](CONTRIBUTING.md) for author
 ### Configuration
 
 - **Package manager:** `pnpm`
-- **New worktrees:** With Git 2.54+, run `node --run setup:hooks` once per trusted clone. The hook installs dependencies for linked worktrees after `git worktree add`, using the main checkout's script and only when the branch's dependency manifests match `origin/HEAD`; otherwise review the manifests and run `node --run setup:worktree` in the new worktree.
+- **New worktrees:** With Git 2.54+, run `node --run setup:hooks` once per trusted clone. The hook installs dependencies for linked worktrees after `git worktree add`, using the setup script pinned at `origin/HEAD` and only when the branch's dependency manifests (root and workspace) match `origin/HEAD`; otherwise review the branch and run `node --run setup:worktree` in the new worktree.
 - **Build:** `pnpm build`
 - **Test suite:** `pnpm test` (5-10 minutes; includes build + unit + typing + e2e)
 - **Focused tests:** Use the root Turbo command, for example `pnpm run test --filter nuqs` or `pnpm run test --filter e2e-next`. Do not invoke package test scripts directly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Refer to: [README.md](README.md) & [CONTRIBUTING.md](CONTRIBUTING.md) for author
 ### Configuration
 
 - **Package manager:** `pnpm`
-- **New worktrees:** With Git 2.54+, run `node --run setup:hooks` once per trusted clone. The hook installs dependencies for linked worktrees after `git worktree add`, using the setup script pinned at `origin/HEAD` and only when the branch's dependency manifests (root and workspace) match `origin/HEAD`; otherwise review the branch and run `node --run setup:worktree` in the new worktree.
+- **New worktrees:** With Git 2.54+, run `node --run setup:hooks` once per trusted clone to auto-install dependencies after `git worktree add`. If the hook skips (branch manifests differ from `origin/HEAD`), review the branch and run `node --run setup:worktree` in the worktree.
 - **Build:** `pnpm build`
 - **Test suite:** `pnpm test` (5-10 minutes; includes build + unit + typing + e2e)
 - **Focused tests:** Use the root Turbo command, for example `pnpm run test --filter nuqs` or `pnpm run test --filter e2e-next`. Do not invoke package test scripts directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,20 +28,21 @@ worktrees. If the current Node version cannot run package scripts yet, invoke
 the setup directly with `node packages/scripts/worktree-setup.mjs` after
 activating `.node-version`.
 
-The checkout hook runs the setup script from the clone where you enabled it,
-never from the just-checked-out branch. It installs dependencies
-automatically only when the branch's dependency manifests (`package.json`,
-`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`) match `origin/HEAD`;
-otherwise it skips and asks for an explicit `node --run setup:worktree`.
-Review those manifests before running explicit setup on a branch you do not
-trust: `pnpm install` executes with whatever they declare.
+The checkout hook runs the setup script pinned at `origin/HEAD`, never the
+just-checked-out branch's copy. It installs dependencies automatically only
+when the branch's dependency manifests (root and workspace `package.json`,
+`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`, `.pnpmfile.cjs`) match
+`origin/HEAD`; otherwise it skips and asks for an explicit
+`node --run setup:worktree`. Review the whole branch (manifests and the
+setup script itself) before running explicit setup on a branch you do not
+trust: explicit setup executes the branch's code.
 
 ## Project structure
 
 This monorepo contains:
 
 - The source code for the `nuqs` NPM package, in [`packages/nuqs`](./packages/nuqs).
-- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. It builds and runs without secrets; optionally copy [`packages/docs/.env.example`](./packages/docs/.env.example) to `.env.local` for higher GitHub rate limits and the GitHub-powered sections.
+- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. It runs without secrets, though cold builds without a token can hit GitHub rate limits; copy [`packages/docs/.env.example`](./packages/docs/.env.example) to `.env.local` for higher limits and the GitHub-powered sections.
 - Test benches for [end-to-end tests](./packages/e2e) for each supported framework, driven by Playwright
 - Examples of integration with other tools.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,7 @@ First off, thanks for your help! 🙏
 
 1. Fork and clone the repository
 2. Set up the checkout with `node --run setup:worktree`. This validates the
-   pinned Node and pnpm versions and installs the frozen lockfile. When
-   available, `GITHUB_TOKEN` or `gh auth token` is copied to the docs
-   `.env.local`; missing GitHub authentication does not block setup.
+   pinned Node and pnpm versions and installs the frozen lockfile.
 3. Start the development environment with `pnpm dev --filter <package-name>...`
 
 ## Git hooks (optional)
@@ -30,17 +28,20 @@ worktrees. If the current Node version cannot run package scripts yet, invoke
 the setup directly with `node packages/scripts/worktree-setup.mjs` after
 activating `.node-version`.
 
-The checkout hook runs the checked-out branch's setup script and may run
-`pnpm install`. Enable it only for clones where you trust the branches you
-check out. The bundled script reads credentials only during explicit
-`setup:worktree` runs.
+The checkout hook runs the setup script from the clone where you enabled it,
+never from the just-checked-out branch. It installs dependencies
+automatically only when the branch's dependency manifests (`package.json`,
+`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`) match `origin/HEAD`;
+otherwise it skips and asks for an explicit `node --run setup:worktree`.
+Review those manifests before running explicit setup on a branch you do not
+trust: `pnpm install` executes with whatever they declare.
 
 ## Project structure
 
 This monorepo contains:
 
 - The source code for the `nuqs` NPM package, in [`packages/nuqs`](./packages/nuqs).
-- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. Explicit setup creates its `.env.local` when GitHub authentication is available; see [`.env.example`](./packages/docs/.env.example) for optional variables.
+- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. It builds and runs without secrets; optionally copy [`packages/docs/.env.example`](./packages/docs/.env.example) to `.env.local` for higher GitHub rate limits and the GitHub-powered sections.
 - Test benches for [end-to-end tests](./packages/e2e) for each supported framework, driven by Playwright
 - Examples of integration with other tools.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,12 @@ The checkout hook runs the setup script pinned at `origin/HEAD`, never the
 just-checked-out branch's copy. It installs dependencies automatically only
 when the branch's dependency manifests (root and workspace `package.json`,
 `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`, `.pnpmfile.cjs`) match
-`origin/HEAD`; otherwise it skips and asks for an explicit
+`origin/HEAD`, and it installs with `--ignore-scripts` so no lifecycle
+script runs from a checkout; otherwise it skips and asks for an explicit
 `node --run setup:worktree`. Review the whole branch (manifests and the
 setup script itself) before running explicit setup on a branch you do not
-trust: explicit setup executes the branch's code.
+trust: explicit setup executes the branch's code, including lifecycle
+scripts.
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,7 @@ First off, thanks for your help! 🙏
 ## Getting started
 
 1. Fork and clone the repository
-2. Set up the checkout with `node --run setup:worktree`. This validates the
-   pinned Node and pnpm versions and installs the frozen lockfile.
+2. Set up the checkout with `node --run setup:worktree`
 3. Start the development environment with `pnpm dev --filter <package-name>...`
 
 ## Git hooks (optional)
@@ -28,23 +27,17 @@ worktrees. If the current Node version cannot run package scripts yet, invoke
 the setup directly with `node packages/scripts/worktree-setup.mjs` after
 activating `.node-version`.
 
-The checkout hook runs the setup script pinned at `origin/HEAD`, never the
-just-checked-out branch's copy. It installs dependencies automatically only
-when the branch's dependency manifests (root and workspace `package.json`,
-`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`, `.pnpmfile.cjs`) match
-`origin/HEAD`, and it installs with `--ignore-scripts` so no lifecycle
-script runs from a checkout; otherwise it skips and asks for an explicit
-`node --run setup:worktree`. Review the whole branch (manifests and the
-setup script itself) before running explicit setup on a branch you do not
-trust: explicit setup executes the branch's code, including lifecycle
-scripts.
+The checkout hook only auto-installs dependencies for branches whose
+dependency manifests match `origin/HEAD`. When it skips, review the branch,
+then run `node --run setup:worktree` — explicit setup executes the branch's
+code.
 
 ## Project structure
 
 This monorepo contains:
 
 - The source code for the `nuqs` NPM package, in [`packages/nuqs`](./packages/nuqs).
-- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. It runs without secrets, though cold builds without a token can hit GitHub rate limits; copy [`packages/docs/.env.example`](./packages/docs/.env.example) to `.env.local` for higher limits and the GitHub-powered sections.
+- A Next.js app under [`packages/docs`](./packages/docs) that serves the documentation and as a playground deployed at <https://nuqs.dev>. Copy [`packages/docs/.env.example`](./packages/docs/.env.example) to `.env.local` for the optional env vars local docs dev can use.
 - Test benches for [end-to-end tests](./packages/e2e) for each supported framework, driven by Playwright
 - Examples of integration with other tools.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "turbo run build",
     "test": "turbo run test --log-order=stream",
     "verify": "packages/scripts/verify-release/verify.production.ts",
-    "// setup:worktree": "Prepare a linked worktree: validate tools, own dependencies, install the lockfile, and configure docs auth",
+    "// setup:worktree": "Prepare a linked worktree: validate tools, own dependencies, and install the lockfile",
     "setup:worktree": "node packages/scripts/worktree-setup.mjs",
     "test:worktree-setup": "pnpm --filter scripts exec vitest run worktree-setup.test.mjs",
     "// setup:hooks": "Opt-in per clone (not on install). Removes only the obsolete Husky path, adds the tracked config idempotently, and verifies the worktree hook",

--- a/packages/scripts/worktree-setup.mjs
+++ b/packages/scripts/worktree-setup.mjs
@@ -399,9 +399,16 @@ async function main() {
           `Removed ${removedLinks.length} worktree node_modules symlink(s); their targets were left untouched.`
         )
       }
+      const diffPaths = hookInstallSourcePaths
+        .map(path => (path.startsWith(':') ? `"${path}"` : path))
+        .join(' ')
       console.warn(
-        `worktree-setup: skipping automatic setup: ${sources.reason}. ` +
-          'Review the branch (including its setup script), then run `node --run setup:worktree` explicitly.'
+        [
+          `worktree-setup: skipping automatic dependency install: ${sources.reason}.`,
+          'Dependencies are required for builds and tests. To install them:',
+          `1. Review the changes: git diff origin/HEAD -- ${diffPaths} packages/scripts/worktree-setup.mjs`,
+          '2. If they are safe, run: node --run setup:worktree'
+        ].join('\n')
       )
       return
     }

--- a/packages/scripts/worktree-setup.mjs
+++ b/packages/scripts/worktree-setup.mjs
@@ -109,39 +109,73 @@ function spawnCommand(command, args, options = {}) {
   })
 }
 
-function commandSucceeds(command, args, root) {
+function runGit(args, root) {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, { cwd: root, stdio: 'ignore' })
+    const child = spawn('git', args, {
+      cwd: root,
+      stdio: ['ignore', 'pipe', 'inherit']
+    })
+    let stdout = ''
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', chunk => {
+      stdout += chunk
+    })
     child.on('error', reject)
-    child.on('exit', code => resolvePromise(code === 0))
+    child.on('exit', code => resolvePromise({ code, stdout }))
   })
 }
+
+export const hookInstallSourcePaths = [
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  '.npmrc',
+  '.pnpmfile.cjs',
+  ':(glob)packages/**/package.json',
+  ':(glob)packages/**/.npmrc',
+  ':(glob)packages/**/.pnpmfile.cjs'
+]
 
 export async function verifyHookInstallSources(
   root,
   {
     trustedRef = 'origin/HEAD',
-    paths = ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc'],
-    gitSucceeds = args => commandSucceeds('git', args, root)
+    paths = hookInstallSourcePaths,
+    git = args => runGit(args, root)
   } = {}
 ) {
-  const hasRef = await gitSucceeds([
+  const ref = await git([
     'rev-parse',
     '--verify',
     '--quiet',
     `${trustedRef}^{commit}`
   ])
-  if (!hasRef) {
+  if (ref.code !== 0) {
     return {
       trusted: false,
-      reason: `${trustedRef} is not available to compare dependency manifests against`
+      reason:
+        `${trustedRef} is not available to compare dependency manifests against ` +
+        '(fix with `git remote set-head origin --auto`)'
     }
   }
-  const unchanged = await gitSucceeds(['diff', '--quiet', trustedRef, '--', ...paths])
-  if (!unchanged) {
+  const diff = await git(['diff', '--quiet', trustedRef, '--', ...paths])
+  if (diff.code === 1) {
     return {
       trusted: false,
       reason: `dependency manifests differ from ${trustedRef}`
+    }
+  }
+  if (diff.code !== 0) {
+    throw new Error(`git diff exited with code ${diff.code}`)
+  }
+  const status = await git(['status', '--porcelain', '--', ...paths])
+  if (status.code !== 0) {
+    throw new Error(`git status exited with code ${status.code}`)
+  }
+  if (status.stdout.trim() !== '') {
+    return {
+      trusted: false,
+      reason: 'dependency manifests have uncommitted or untracked changes'
     }
   }
   return { trusted: true }
@@ -211,15 +245,13 @@ async function readState(path) {
 
 async function writeState(path, fingerprints) {
   const temporary = `${path}.${process.pid}.tmp`
-  const contents = JSON.stringify(fingerprints) + '\n'
-  const options = { flag: 'wx', mode: 0o600 }
-  try {
-    await writeFile(temporary, contents, options)
-  } catch (error) {
-    if (error.code !== 'EEXIST') throw error
-    await unlink(temporary)
-    await writeFile(temporary, contents, options)
-  }
+  await unlink(temporary).catch(error => {
+    if (error.code !== 'ENOENT') throw error
+  })
+  await writeFile(temporary, JSON.stringify(fingerprints) + '\n', {
+    flag: 'wx',
+    mode: 0o600
+  })
   await rename(temporary, path)
 }
 
@@ -255,14 +287,15 @@ export async function withSetupLock(gitDirectory, operation) {
     } catch (error) {
       if (error.code !== 'EEXIST') throw error
 
-      let owner
+      let ownerRaw
       try {
-        owner = Number.parseInt(await readFile(lockPath, 'utf8'), 10)
+        ownerRaw = await readFile(lockPath, 'utf8')
       } catch (readError) {
         if (readError.code === 'ENOENT') continue
         throw readError
       }
-      if (processIsAlive(owner)) {
+      const owner = Number.parseInt(ownerRaw, 10)
+      if (Number.isSafeInteger(owner) && processIsAlive(owner)) {
         throw new Error(
           `Another worktree setup is already running (${lockPath})`
         )
@@ -274,16 +307,37 @@ export async function withSetupLock(gitDirectory, operation) {
           mode: 0o600
         })
       } catch (reclaimError) {
-        if (reclaimError.code === 'EEXIST') {
+        if (reclaimError.code !== 'EEXIST') throw reclaimError
+        let reclaimOwner
+        try {
+          reclaimOwner = Number.parseInt(
+            await readFile(reclaimPath, 'utf8'),
+            10
+          )
+        } catch (readError) {
+          if (readError.code === 'ENOENT') continue
+          throw readError
+        }
+        if (
+          Number.isSafeInteger(reclaimOwner) &&
+          processIsAlive(reclaimOwner)
+        ) {
           throw new Error(
-            `Another worktree setup is already running (${lockPath})`
+            `Another worktree setup is already running (${reclaimPath}); ` +
+              'delete it if no setup is in progress'
           )
         }
-        throw reclaimError
+        await unlink(reclaimPath).catch(unlinkError => {
+          if (unlinkError.code !== 'ENOENT') throw unlinkError
+        })
+        continue
       }
       try {
-        const latest = Number.parseInt(await readFile(lockPath, 'utf8'), 10)
-        if (latest === owner && !processIsAlive(latest)) await unlink(lockPath)
+        const latestRaw = await readFile(lockPath, 'utf8')
+        const latest = Number.parseInt(latestRaw, 10)
+        const latestIsAlive =
+          Number.isSafeInteger(latest) && processIsAlive(latest)
+        if (latestRaw === ownerRaw && !latestIsAlive) await unlink(lockPath)
       } catch (reclaimError) {
         if (reclaimError.code !== 'ENOENT') throw reclaimError
       } finally {
@@ -329,13 +383,19 @@ async function main() {
     process.cwd()
   )
   const hookMode = process.argv.includes('--hook')
-  if (hookMode && !(await isLinkedWorktree(root))) return
   if (hookMode) {
+    if (!(await isLinkedWorktree(root))) return
     const sources = await verifyHookInstallSources(root)
     if (!sources.trusted) {
+      const removedLinks = await prepareNodeModules(root)
+      if (removedLinks.length > 0) {
+        console.log(
+          `Removed ${removedLinks.length} worktree node_modules symlink(s); their targets were left untouched.`
+        )
+      }
       console.warn(
-        `Skipping automatic worktree setup: ${sources.reason}. ` +
-          'Review the changes, then run `node --run setup:worktree` explicitly.'
+        `worktree-setup: skipping automatic setup: ${sources.reason}. ` +
+          'Review the branch (including its setup script), then run `node --run setup:worktree` explicitly.'
       )
       return
     }
@@ -387,7 +447,10 @@ async function main() {
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : ''
 if (invokedPath === fileURLToPath(import.meta.url)) {
   main().catch(error => {
-    console.error(`Worktree setup failed: ${error.message}`)
+    console.error(`Worktree setup failed: ${error.stack ?? error.message}`)
+    console.error(
+      'Fix the cause, then run `node --run setup:worktree` in the worktree.'
+    )
     process.exitCode = 1
   })
 }

--- a/packages/scripts/worktree-setup.mjs
+++ b/packages/scripts/worktree-setup.mjs
@@ -11,7 +11,7 @@ import {
   unlink,
   writeFile
 } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 function cleanVersion(value) {
@@ -36,41 +36,6 @@ export function assertToolVersions(actual, expected) {
 export async function isLinkedWorktree(root) {
   const stats = await lstat(join(root, '.git'))
   return stats.isFile()
-}
-
-export async function ensureDocsEnvironment(
-  root,
-  {
-    env = process.env,
-    readGhToken = () => capture('gh', ['auth', 'token'], root),
-    warn = console.warn
-  } = {}
-) {
-  const path = join(root, 'packages/docs/.env.local')
-  if (await exists(path)) return false
-
-  let token = env.GITHUB_TOKEN?.trim()
-  if (!token) {
-    try {
-      token = (await readGhToken()).trim()
-    } catch {}
-  }
-  if (!token) {
-    warn(
-      'Docs GitHub authentication was not configured; set GITHUB_TOKEN or run `gh auth login` before building the docs.'
-    )
-    return false
-  }
-  try {
-    await writeFile(path, `GITHUB_TOKEN=${JSON.stringify(token)}\n`, {
-      flag: 'wx',
-      mode: 0o600
-    })
-    return true
-  } catch (error) {
-    if (error.code === 'EEXIST') return false
-    throw error
-  }
 }
 
 async function unlinkNodeModulesSymlink(path) {
@@ -144,6 +109,44 @@ function spawnCommand(command, args, options = {}) {
   })
 }
 
+function commandSucceeds(command, args, root) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { cwd: root, stdio: 'ignore' })
+    child.on('error', reject)
+    child.on('exit', code => resolvePromise(code === 0))
+  })
+}
+
+export async function verifyHookInstallSources(
+  root,
+  {
+    trustedRef = 'origin/HEAD',
+    paths = ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc'],
+    gitSucceeds = args => commandSucceeds('git', args, root)
+  } = {}
+) {
+  const hasRef = await gitSucceeds([
+    'rev-parse',
+    '--verify',
+    '--quiet',
+    `${trustedRef}^{commit}`
+  ])
+  if (!hasRef) {
+    return {
+      trusted: false,
+      reason: `${trustedRef} is not available to compare dependency manifests against`
+    }
+  }
+  const unchanged = await gitSucceeds(['diff', '--quiet', trustedRef, '--', ...paths])
+  if (!unchanged) {
+    return {
+      trusted: false,
+      reason: `dependency manifests differ from ${trustedRef}`
+    }
+  }
+  return { trusted: true }
+}
+
 async function capture(command, args, root) {
   let output = ''
   await new Promise((resolvePromise, reject) => {
@@ -208,9 +211,15 @@ async function readState(path) {
 
 async function writeState(path, fingerprints) {
   const temporary = `${path}.${process.pid}.tmp`
-  await writeFile(temporary, JSON.stringify(fingerprints) + '\n', {
-    mode: 0o600
-  })
+  const contents = JSON.stringify(fingerprints) + '\n'
+  const options = { flag: 'wx', mode: 0o600 }
+  try {
+    await writeFile(temporary, contents, options)
+  } catch (error) {
+    if (error.code !== 'EEXIST') throw error
+    await unlink(temporary)
+    await writeFile(temporary, contents, options)
+  }
   await rename(temporary, path)
 }
 
@@ -294,9 +303,6 @@ export async function runWorktreeSetup({
   actualVersions,
   expectedVersions,
   install = true,
-  configureDocs = true,
-  env = process.env,
-  readGhToken,
   run = (command, args, options = {}) =>
     spawnCommand(command, args, {
       cwd: root,
@@ -313,16 +319,27 @@ export async function runWorktreeSetup({
   }
   if (!install) return { install }
   await run('pnpm', ['install', '--frozen-lockfile'], { env: { CI: '1' } })
-  if (configureDocs) {
-    await ensureDocsEnvironment(root, { env, readGhToken })
-  }
   return { install }
 }
 
 async function main() {
-  const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+  const root = await capture(
+    'git',
+    ['rev-parse', '--show-toplevel'],
+    process.cwd()
+  )
   const hookMode = process.argv.includes('--hook')
   if (hookMode && !(await isLinkedWorktree(root))) return
+  if (hookMode) {
+    const sources = await verifyHookInstallSources(root)
+    if (!sources.trusted) {
+      console.warn(
+        `Skipping automatic worktree setup: ${sources.reason}. ` +
+          'Review the changes, then run `node --run setup:worktree` explicitly.'
+      )
+      return
+    }
+  }
 
   const expectedVersions = await readExpectedVersions(root)
   const actualVersions = {
@@ -355,7 +372,6 @@ async function main() {
           root,
           actualVersions,
           expectedVersions,
-          configureDocs: !hookMode,
           ...plan
         })
     })

--- a/packages/scripts/worktree-setup.mjs
+++ b/packages/scripts/worktree-setup.mjs
@@ -120,8 +120,9 @@ function runGit(args, root) {
     child.stdout.on('data', chunk => {
       stdout += chunk
     })
+    child.stdout.on('error', reject)
     child.on('error', reject)
-    child.on('exit', code => resolvePromise({ code, stdout }))
+    child.on('close', code => resolvePromise({ code, stdout }))
   })
 }
 
@@ -168,14 +169,16 @@ export async function verifyHookInstallSources(
   if (diff.code !== 0) {
     throw new Error(`git diff exited with code ${diff.code}`)
   }
-  const status = await git(['status', '--porcelain', '--', ...paths])
-  if (status.code !== 0) {
-    throw new Error(`git status exited with code ${status.code}`)
+  // --others without --exclude-standard also surfaces ignored files,
+  // which neither git diff nor git status report
+  const untracked = await git(['ls-files', '--others', '--', ...paths])
+  if (untracked.code !== 0) {
+    throw new Error(`git ls-files exited with code ${untracked.code}`)
   }
-  if (status.stdout.trim() !== '') {
+  if (untracked.stdout.trim() !== '') {
     return {
       trusted: false,
-      reason: 'dependency manifests have uncommitted or untracked changes'
+      reason: 'dependency manifests have untracked or ignored files'
     }
   }
   return { trusted: true }

--- a/packages/scripts/worktree-setup.mjs
+++ b/packages/scripts/worktree-setup.mjs
@@ -360,6 +360,7 @@ export async function runWorktreeSetup({
   actualVersions,
   expectedVersions,
   install = true,
+  ignoreScripts = false,
   run = (command, args, options = {}) =>
     spawnCommand(command, args, {
       cwd: root,
@@ -375,7 +376,9 @@ export async function runWorktreeSetup({
     )
   }
   if (!install) return { install }
-  await run('pnpm', ['install', '--frozen-lockfile'], { env: { CI: '1' } })
+  const installArgs = ['install', '--frozen-lockfile']
+  if (ignoreScripts) installArgs.push('--ignore-scripts')
+  await run('pnpm', installArgs, { env: { CI: '1' } })
   return { install }
 }
 
@@ -435,6 +438,7 @@ async function main() {
           root,
           actualVersions,
           expectedVersions,
+          ignoreScripts: hookMode,
           ...plan
         })
     })
@@ -443,6 +447,11 @@ async function main() {
       return
     }
     console.log('Worktree ready: dependencies installed.')
+    if (hookMode) {
+      console.log(
+        'Lifecycle scripts were skipped; run `node --run setup:worktree` if a task needs them.'
+      )
+    }
     console.log('Turbo builds package dependencies for filtered checks.')
   })
 }

--- a/packages/scripts/worktree-setup.test.mjs
+++ b/packages/scripts/worktree-setup.test.mjs
@@ -1,9 +1,11 @@
+import { execFile } from 'node:child_process'
 import {
   mkdtemp,
   mkdir,
   readFile,
   readlink,
   symlink,
+  unlink,
   writeFile
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -12,6 +14,7 @@ import { expect, it } from 'vitest'
 
 import {
   assertToolVersions,
+  hookInstallSourcePaths,
   isLinkedWorktree,
   planHookSetup,
   prepareNodeModules,
@@ -34,47 +37,119 @@ it('recognizes linked worktrees without treating the canonical checkout as one',
   expect(await isLinkedWorktree(linked)).toBe(true)
 })
 
+function gitStub(overrides = {}) {
+  return async args => {
+    const result = overrides[args[0]]
+    if (result) return result
+    return { code: 0, stdout: '' }
+  }
+}
+
 it('trusts hook installs only when dependency manifests match the trusted ref', async () => {
-  const succeedAll = async () => true
   await expect(
-    verifyHookInstallSources('/repo', { gitSucceeds: succeedAll })
+    verifyHookInstallSources('/repo', { git: gitStub() })
   ).resolves.toEqual({ trusted: true })
 
-  const missingRef = async args => args[0] !== 'rev-parse'
   await expect(
-    verifyHookInstallSources('/repo', { gitSucceeds: missingRef })
-  ).resolves.toEqual({
+    verifyHookInstallSources('/repo', {
+      git: gitStub({ 'rev-parse': { code: 1, stdout: '' } })
+    })
+  ).resolves.toMatchObject({
     trusted: false,
-    reason: 'origin/HEAD is not available to compare dependency manifests against'
+    reason: expect.stringContaining('origin/HEAD is not available')
   })
 
-  const dirtyManifests = async args => args[0] !== 'diff'
   await expect(
-    verifyHookInstallSources('/repo', { gitSucceeds: dirtyManifests })
-  ).resolves.toEqual({
+    verifyHookInstallSources('/repo', {
+      git: gitStub({ diff: { code: 1, stdout: '' } })
+    })
+  ).resolves.toMatchObject({
     trusted: false,
-    reason: 'dependency manifests differ from origin/HEAD'
+    reason: expect.stringContaining('differ from origin/HEAD')
   })
+
+  await expect(
+    verifyHookInstallSources('/repo', {
+      git: gitStub({ status: { code: 0, stdout: '?? .npmrc\n' } })
+    })
+  ).resolves.toMatchObject({
+    trusted: false,
+    reason: expect.stringContaining('uncommitted or untracked')
+  })
+})
+
+it('throws when git itself fails instead of reporting untrusted manifests', async () => {
+  await expect(
+    verifyHookInstallSources('/repo', {
+      git: gitStub({ diff: { code: 128, stdout: '' } })
+    })
+  ).rejects.toThrow(/git diff exited with code 128/)
+  await expect(
+    verifyHookInstallSources('/repo', {
+      git: gitStub({ status: { code: 128, stdout: '' } })
+    })
+  ).rejects.toThrow(/git status exited with code 128/)
 })
 
 it('compares the dependency manifests that gate automatic installs', async () => {
   const calls = []
   await verifyHookInstallSources('/repo', {
-    gitSucceeds: async args => {
+    git: async args => {
       calls.push(args)
-      return true
+      return { code: 0, stdout: '' }
     }
   })
-  expect(calls[1]).toEqual([
-    'diff',
-    '--quiet',
-    'origin/HEAD',
-    '--',
-    'package.json',
-    'pnpm-lock.yaml',
-    'pnpm-workspace.yaml',
-    '.npmrc'
+  expect(calls).toEqual([
+    ['rev-parse', '--verify', '--quiet', 'origin/HEAD^{commit}'],
+    ['diff', '--quiet', 'origin/HEAD', '--', ...hookInstallSourcePaths],
+    ['status', '--porcelain', '--', ...hookInstallSourcePaths]
   ])
+  expect(hookInstallSourcePaths).toContain(':(glob)packages/**/package.json')
+  expect(hookInstallSourcePaths).toContain('.pnpmfile.cjs')
+})
+
+it('verifies dependency manifests against real git', async () => {
+  const repo = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-git-'))
+  const git = (...args) =>
+    new Promise((resolvePromise, reject) => {
+      execFile('git', args, { cwd: repo }, (error, stdout) => {
+        if (error) reject(error)
+        else resolvePromise(stdout)
+      })
+    })
+  await git('init', '--initial-branch=main')
+  await git('config', 'user.email', 'test@example.com')
+  await git('config', 'user.name', 'Test')
+  await mkdir(join(repo, 'packages/nuqs'), { recursive: true })
+  await writeFile(join(repo, 'package.json'), '{}\n')
+  await writeFile(join(repo, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n')
+  await writeFile(join(repo, 'packages/nuqs/package.json'), '{}\n')
+  await git('add', '--all')
+  await git('commit', '--message', 'baseline')
+  await git('branch', 'trusted')
+
+  const options = { trustedRef: 'trusted' }
+  await expect(verifyHookInstallSources(repo, options)).resolves.toEqual({
+    trusted: true
+  })
+
+  await writeFile(join(repo, '.npmrc'), 'registry=https://evil.example\n')
+  await expect(verifyHookInstallSources(repo, options)).resolves.toMatchObject({
+    trusted: false,
+    reason: expect.stringContaining('untracked')
+  })
+  await unlink(join(repo, '.npmrc'))
+
+  await writeFile(
+    join(repo, 'packages/nuqs/package.json'),
+    '{"scripts":{"postinstall":"true"}}\n'
+  )
+  await git('add', '--all')
+  await git('commit', '--message', 'workspace manifest change')
+  await expect(verifyHookInstallSources(repo, options)).resolves.toMatchObject({
+    trusted: false,
+    reason: expect.stringContaining('differ')
+  })
 })
 
 it('rejects a Node version that differs from .node-version', () => {
@@ -200,6 +275,38 @@ it('reclaims a setup lock owned by a dead process', async () => {
   await expect(readFile(lockPath, 'utf8')).rejects.toMatchObject({
     code: 'ENOENT'
   })
+})
+
+it('reclaims a corrupted (empty) setup lock instead of spinning forever', async () => {
+  const gitDirectory = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
+  const lockPath = join(gitDirectory, 'nuqs-worktree-setup.lock')
+  await writeFile(lockPath, '')
+
+  await expect(withSetupLock(gitDirectory, async () => 'ready')).resolves.toBe(
+    'ready'
+  )
+})
+
+it('self-heals a stale reclaim marker left by a dead process', async () => {
+  const gitDirectory = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
+  const lockPath = join(gitDirectory, 'nuqs-worktree-setup.lock')
+  await writeFile(lockPath, '999999999\n')
+  await writeFile(`${lockPath}.reclaim`, '999999999\n')
+
+  await expect(withSetupLock(gitDirectory, async () => 'ready')).resolves.toBe(
+    'ready'
+  )
+})
+
+it('does not steal a reclaim marker owned by a live process', async () => {
+  const gitDirectory = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
+  const lockPath = join(gitDirectory, 'nuqs-worktree-setup.lock')
+  await writeFile(lockPath, '999999999\n')
+  await writeFile(`${lockPath}.reclaim`, `${process.pid}\n`)
+
+  await expect(
+    withSetupLock(gitDirectory, async () => 'unreachable')
+  ).rejects.toThrow(/Another worktree setup is already running/)
 })
 
 it('does not reclaim a setup lock owned by a live process', async () => {

--- a/packages/scripts/worktree-setup.test.mjs
+++ b/packages/scripts/worktree-setup.test.mjs
@@ -70,11 +70,11 @@ it('trusts hook installs only when dependency manifests match the trusted ref', 
 
   await expect(
     verifyHookInstallSources('/repo', {
-      git: gitStub({ status: { code: 0, stdout: '?? .npmrc\n' } })
+      git: gitStub({ 'ls-files': { code: 0, stdout: '.npmrc\n' } })
     })
   ).resolves.toMatchObject({
     trusted: false,
-    reason: expect.stringContaining('uncommitted or untracked')
+    reason: expect.stringContaining('untracked or ignored')
   })
 })
 
@@ -86,9 +86,9 @@ it('throws when git itself fails instead of reporting untrusted manifests', asyn
   ).rejects.toThrow(/git diff exited with code 128/)
   await expect(
     verifyHookInstallSources('/repo', {
-      git: gitStub({ status: { code: 128, stdout: '' } })
+      git: gitStub({ 'ls-files': { code: 128, stdout: '' } })
     })
-  ).rejects.toThrow(/git status exited with code 128/)
+  ).rejects.toThrow(/git ls-files exited with code 128/)
 })
 
 it('compares the dependency manifests that gate automatic installs', async () => {
@@ -102,7 +102,7 @@ it('compares the dependency manifests that gate automatic installs', async () =>
   expect(calls).toEqual([
     ['rev-parse', '--verify', '--quiet', 'origin/HEAD^{commit}'],
     ['diff', '--quiet', 'origin/HEAD', '--', ...hookInstallSourcePaths],
-    ['status', '--porcelain', '--', ...hookInstallSourcePaths]
+    ['ls-files', '--others', '--', ...hookInstallSourcePaths]
   ])
   expect(hookInstallSourcePaths).toContain(':(glob)packages/**/package.json')
   expect(hookInstallSourcePaths).toContain('.pnpmfile.cjs')
@@ -112,10 +112,22 @@ it('verifies dependency manifests against real git', async () => {
   const repo = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-git-'))
   const git = (...args) =>
     new Promise((resolvePromise, reject) => {
-      execFile('git', args, { cwd: repo }, (error, stdout) => {
-        if (error) reject(error)
-        else resolvePromise(stdout)
-      })
+      execFile(
+        'git',
+        args,
+        {
+          cwd: repo,
+          env: {
+            ...process.env,
+            GIT_CONFIG_GLOBAL: '/dev/null',
+            GIT_CONFIG_SYSTEM: '/dev/null'
+          }
+        },
+        (error, stdout) => {
+          if (error) reject(error)
+          else resolvePromise(stdout)
+        }
+      )
     })
   await git('init', '--initial-branch=main')
   await git('config', 'user.email', 'test@example.com')
@@ -137,6 +149,12 @@ it('verifies dependency manifests against real git', async () => {
   await expect(verifyHookInstallSources(repo, options)).resolves.toMatchObject({
     trusted: false,
     reason: expect.stringContaining('untracked')
+  })
+
+  await writeFile(join(repo, '.git/info/exclude'), '.npmrc\n')
+  await expect(verifyHookInstallSources(repo, options)).resolves.toMatchObject({
+    trusted: false,
+    reason: expect.stringContaining('ignored')
   })
   await unlink(join(repo, '.npmrc'))
 

--- a/packages/scripts/worktree-setup.test.mjs
+++ b/packages/scripts/worktree-setup.test.mjs
@@ -3,7 +3,6 @@ import {
   mkdir,
   readFile,
   readlink,
-  stat,
   symlink,
   writeFile
 } from 'node:fs/promises'
@@ -13,12 +12,12 @@ import { expect, it } from 'vitest'
 
 import {
   assertToolVersions,
-  ensureDocsEnvironment,
   isLinkedWorktree,
   planHookSetup,
   prepareNodeModules,
   recordSetup,
   runWorktreeSetup,
+  verifyHookInstallSources,
   withSetupLock
 } from './worktree-setup.mjs'
 
@@ -35,64 +34,46 @@ it('recognizes linked worktrees without treating the canonical checkout as one',
   expect(await isLinkedWorktree(linked)).toBe(true)
 })
 
-it('creates the docs environment once from the GitHub CLI credential', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
-  await mkdir(join(root, 'packages/docs'), { recursive: true })
-  let calls = 0
-
-  await ensureDocsEnvironment(root, {
-    env: {},
-    readGhToken: async () => {
-      calls++
-      return 'from-gh\n'
-    }
-  })
-  await ensureDocsEnvironment(root, {
-    env: {},
-    readGhToken: async () => {
-      calls++
-      return 'replacement'
-    }
-  })
-
-  const path = join(root, 'packages/docs/.env.local')
-  expect(await readFile(path, 'utf8')).toBe('GITHUB_TOKEN="from-gh"\n')
-  expect((await stat(path)).mode & 0o777).toBe(0o600)
-  expect(calls).toBe(1)
-})
-
-it('prefers an explicit GitHub token when creating the docs environment', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
-  await mkdir(join(root, 'packages/docs'), { recursive: true })
-
-  await ensureDocsEnvironment(root, {
-    env: { GITHUB_TOKEN: 'from-env' },
-    readGhToken: async () => {
-      throw new Error('should not read gh auth')
-    }
-  })
-
-  expect(await readFile(join(root, 'packages/docs/.env.local'), 'utf8')).toBe(
-    'GITHUB_TOKEN="from-env"\n'
-  )
-})
-
-it('keeps setup usable when GitHub authentication is unavailable', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
-  await mkdir(join(root, 'packages/docs'), { recursive: true })
-  const warnings = []
-
+it('trusts hook installs only when dependency manifests match the trusted ref', async () => {
+  const succeedAll = async () => true
   await expect(
-    ensureDocsEnvironment(root, {
-      env: {},
-      readGhToken: async () => {
-        throw new Error('gh is unavailable')
-      },
-      warn: message => warnings.push(message)
-    })
-  ).resolves.toBe(false)
-  expect(warnings).toEqual([
-    'Docs GitHub authentication was not configured; set GITHUB_TOKEN or run `gh auth login` before building the docs.'
+    verifyHookInstallSources('/repo', { gitSucceeds: succeedAll })
+  ).resolves.toEqual({ trusted: true })
+
+  const missingRef = async args => args[0] !== 'rev-parse'
+  await expect(
+    verifyHookInstallSources('/repo', { gitSucceeds: missingRef })
+  ).resolves.toEqual({
+    trusted: false,
+    reason: 'origin/HEAD is not available to compare dependency manifests against'
+  })
+
+  const dirtyManifests = async args => args[0] !== 'diff'
+  await expect(
+    verifyHookInstallSources('/repo', { gitSucceeds: dirtyManifests })
+  ).resolves.toEqual({
+    trusted: false,
+    reason: 'dependency manifests differ from origin/HEAD'
+  })
+})
+
+it('compares the dependency manifests that gate automatic installs', async () => {
+  const calls = []
+  await verifyHookInstallSources('/repo', {
+    gitSucceeds: async args => {
+      calls.push(args)
+      return true
+    }
+  })
+  expect(calls[1]).toEqual([
+    'diff',
+    '--quiet',
+    'origin/HEAD',
+    '--',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    '.npmrc'
   ])
 })
 
@@ -160,42 +141,16 @@ it('hook setup reinstalls when install inputs change', () => {
 it('installs from the lockfile without building packages directly', async () => {
   const commands = []
   const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
-  await mkdir(join(root, 'packages/docs'), { recursive: true })
 
   await runWorktreeSetup({
     root,
     actualVersions: { node: '24.11.0', pnpm: '11.0.9' },
     expectedVersions: { node: '24.11.0', pnpm: '11.0.9' },
-    env: { GITHUB_TOKEN: 'test-token' },
     run: async (command, args, options) =>
       commands.push([command, ...args, options?.env?.CI ?? null])
   })
 
   expect(commands).toEqual([['pnpm', 'install', '--frozen-lockfile', '1']])
-})
-
-it('checkout hooks do not persist GitHub credentials', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
-  await mkdir(join(root, 'packages/docs'), { recursive: true })
-  let credentialReads = 0
-
-  await runWorktreeSetup({
-    root,
-    actualVersions: { node: '24.11.0', pnpm: '11.0.9' },
-    expectedVersions: { node: '24.11.0', pnpm: '11.0.9' },
-    configureDocs: false,
-    env: {},
-    readGhToken: async () => {
-      credentialReads++
-      return 'secret'
-    },
-    run: async () => {}
-  })
-
-  expect(credentialReads).toBe(0)
-  await expect(
-    readFile(join(root, 'packages/docs/.env.local'), 'utf8')
-  ).rejects.toMatchObject({ code: 'ENOENT' })
 })
 
 it('does not keep a current fingerprint after setup fails', async () => {
@@ -215,6 +170,23 @@ it('does not keep a current fingerprint after setup fails', async () => {
   await expect(readFile(statePath, 'utf8')).rejects.toMatchObject({
     code: 'ENOENT'
   })
+})
+
+it('does not write state through a planted symlink at the temporary path', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
+  const statePath = join(root, 'state.json')
+  const victim = join(root, 'victim')
+  await writeFile(victim, 'untouched')
+  await symlink(victim, `${statePath}.${process.pid}.tmp`)
+
+  await recordSetup({
+    statePath,
+    current: { install: 'fingerprint' },
+    operation: async () => {}
+  })
+
+  expect(await readFile(victim, 'utf8')).toBe('untouched')
+  expect(await readFile(statePath, 'utf8')).toBe('{"install":"fingerprint"}\n')
 })
 
 it('reclaims a setup lock owned by a dead process', async () => {

--- a/packages/scripts/worktree-setup.test.mjs
+++ b/packages/scripts/worktree-setup.test.mjs
@@ -246,6 +246,23 @@ it('installs from the lockfile without building packages directly', async () => 
   expect(commands).toEqual([['pnpm', 'install', '--frozen-lockfile', '1']])
 })
 
+it('skips lifecycle scripts for hook-triggered installs', async () => {
+  const commands = []
+  const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
+
+  await runWorktreeSetup({
+    root,
+    actualVersions: { node: '24.11.0', pnpm: '11.0.9' },
+    expectedVersions: { node: '24.11.0', pnpm: '11.0.9' },
+    ignoreScripts: true,
+    run: async (command, args) => commands.push([command, ...args])
+  })
+
+  expect(commands).toEqual([
+    ['pnpm', 'install', '--frozen-lockfile', '--ignore-scripts']
+  ])
+})
+
 it('does not keep a current fingerprint after setup fails', async () => {
   const root = await mkdtemp(join(tmpdir(), 'nuqs-worktree-setup-'))
   const statePath = join(root, 'state.json')


### PR DESCRIPTION
The post-checkout hook from #1539 ran the setup script of the checked-out branch. A malicious branch could run code on your machine at checkout, and `pnpm install` used manifests that the branch controls.

Now the hook runs the setup script pinned at `origin/HEAD`. It installs dependencies only when the branch's dependency manifests (root and workspace) match `origin/HEAD`, and always with `--ignore-scripts`. Untracked and ignored files also block the install. When the check fails, the hook prints the commands to review the diff and install manually.

Also:

- The setup script no longer reads or writes GitHub credentials. #1540 removed the need for them.
- An empty or corrupt lock file no longer hangs the hook.
- Git errors show their own diagnostics instead of "manifests differ".
- The state temp file cannot follow a planted symlink.
- The hook command in `.gitconfig` is now double-quoted. Git config truncates unquoted values at the first semicolon.
