### PR TITLE
fix: pass the debounce callback at push time

### DIFF
--- a/packages/nuqs/src/lib/queues/debounce.test.ts
+++ b/packages/nuqs/src/lib/queues/debounce.test.ts
@@ -72,7 +72,7 @@ describe('debounce: DebouncedPromiseQueue', () => {
   it('clears the queued value when the callback returns its promise (not when it resolves)', () => {
     vi.useFakeTimers()
     const queue = new DebouncedPromiseQueue<string, string>()
-    queue.push('a', 100, async (input: string) => {
+    queue.push('a', 100, async input => {
       await setTimeout(100)
       return input
     })
@@ -178,6 +178,33 @@ describe('debounce: DebounceController', () => {
     await expect(promise1).resolves.toEqual(new URLSearchParams('?a=a'))
     await expect(promise2).resolves.toEqual(new URLSearchParams('?b=b'))
     expect(fakeAdapter.updateUrl).toHaveBeenCalledTimes(2)
+  })
+  it('flushes with the adapter of the most recent push', async () => {
+    vi.useFakeTimers()
+    const makeAdapter = (): UpdateQueueAdapterContext => ({
+      updateUrl: vi.fn<UpdateUrlFunction>(),
+      getSearchParamsSnapshot() {
+        return new URLSearchParams()
+      }
+    })
+    const stale = makeAdapter()
+    const latest = makeAdapter()
+    const controller = new DebounceController()
+    const update = { key: 'key', query: 'value', options: {} }
+    controller.push(update, 100, stale, search => {
+      search.set('config', 'stale')
+      return search
+    })
+    const promise = controller.push(update, 100, latest, search => {
+      search.set('config', 'latest')
+      return search
+    })
+    vi.runAllTimers()
+    await expect(promise).resolves.toEqual(
+      new URLSearchParams('?key=value&config=latest')
+    )
+    expect(stale.updateUrl).not.toHaveBeenCalled()
+    expect(latest.updateUrl).toHaveBeenCalledOnce()
   })
   it('keeps a record of pending updates', async () => {
     vi.useFakeTimers()

--- a/packages/nuqs/src/lib/queues/debounce.test.ts
+++ b/packages/nuqs/src/lib/queues/debounce.test.ts
@@ -12,26 +12,37 @@ describe('debounce: DebouncedPromiseQueue', () => {
   it('calls the callback after the timer expired', () => {
     vi.useFakeTimers()
     const spy = vi.fn().mockResolvedValue('output')
-    const queue = new DebouncedPromiseQueue(spy)
-    queue.push('value', 100)
+    const queue = new DebouncedPromiseQueue<string, string>()
+    queue.push('value', 100, spy)
     vi.advanceTimersToNextTimer()
     expect(spy).toHaveBeenCalledExactlyOnceWith('value')
   })
   it('debounces the queue', () => {
     vi.useFakeTimers()
     const spy = vi.fn().mockResolvedValue('output')
-    const queue = new DebouncedPromiseQueue(spy)
-    queue.push('a', 100)
-    queue.push('b', 100)
-    queue.push('c', 100)
+    const queue = new DebouncedPromiseQueue<string, string>()
+    queue.push('a', 100, spy)
+    queue.push('b', 100, spy)
+    queue.push('c', 100, spy)
     vi.advanceTimersToNextTimer()
     expect(spy).toHaveBeenCalledExactlyOnceWith('c')
   })
+  it('calls the callback of the most recent push', () => {
+    vi.useFakeTimers()
+    const stale = vi.fn().mockResolvedValue('stale')
+    const latest = vi.fn().mockResolvedValue('latest')
+    const queue = new DebouncedPromiseQueue<string, string>()
+    queue.push('a', 100, stale)
+    queue.push('b', 100, latest)
+    vi.advanceTimersToNextTimer()
+    expect(stale).not.toHaveBeenCalled()
+    expect(latest).toHaveBeenCalledExactlyOnceWith('b')
+  })
   it('returns a stable promise to the next time the callback is called', async () => {
     vi.useFakeTimers()
-    const queue = new DebouncedPromiseQueue(passThrough)
-    const p1 = queue.push('a', 100)
-    const p2 = queue.push('b', 100)
+    const queue = new DebouncedPromiseQueue<string, string>()
+    const p1 = queue.push('a', 100, passThrough)
+    const p2 = queue.push('b', 100, passThrough)
     expect(p1).toBe(p2)
     vi.advanceTimersToNextTimer()
     await expect(p1).resolves.toBe('b')
@@ -39,19 +50,20 @@ describe('debounce: DebouncedPromiseQueue', () => {
   it('returns a new Promise once the callback is called', async () => {
     vi.useFakeTimers()
     let count = 0
-    const queue = new DebouncedPromiseQueue(() => Promise.resolve(count++))
-    const p1 = queue.push('value', 100)
+    const callback = () => Promise.resolve(count++)
+    const queue = new DebouncedPromiseQueue<string, number>()
+    const p1 = queue.push('value', 100, callback)
     vi.advanceTimersToNextTimer()
     await expect(p1).resolves.toBe(0)
-    const p2 = queue.push('value', 100)
+    const p2 = queue.push('value', 100, callback)
     expect(p2).not.toBe(p1)
     vi.advanceTimersToNextTimer()
     await expect(p2).resolves.toBe(1)
   })
   it('keeps a record of the last queued value', async () => {
     vi.useFakeTimers()
-    const queue = new DebouncedPromiseQueue(passThrough)
-    const p = queue.push('a', 100)
+    const queue = new DebouncedPromiseQueue<string, string>()
+    const p = queue.push('a', 100, passThrough)
     expect(queue.queuedValue).toBe('a')
     vi.advanceTimersToNextTimer()
     await expect(p).resolves.toBe('a')
@@ -59,43 +71,42 @@ describe('debounce: DebouncedPromiseQueue', () => {
   })
   it('clears the queued value when the callback returns its promise (not when it resolves)', () => {
     vi.useFakeTimers()
-    const queue = new DebouncedPromiseQueue(async input => {
+    const queue = new DebouncedPromiseQueue<string, string>()
+    queue.push('a', 100, async (input: string) => {
       await setTimeout(100)
       return input
     })
-    queue.push('a', 100)
     vi.advanceTimersByTime(100)
     expect(queue.queuedValue).toBeUndefined()
   })
   it('clears the queued value when the callback throws an error synchronously', async () => {
     vi.useFakeTimers()
-    const queue = new DebouncedPromiseQueue(() => {
+    const queue = new DebouncedPromiseQueue<string, string>()
+    const p = queue.push('a', 100, () => {
       throw new Error('error')
     })
-    const p = queue.push('a', 100)
     vi.advanceTimersToNextTimer()
     expect(queue.queuedValue).toBeUndefined()
     await expect(p).rejects.toThrowError('error')
   })
   it('clears the queued value when the callback rejects', async () => {
     vi.useFakeTimers()
-    const queue = new DebouncedPromiseQueue(() =>
-      Promise.reject(new Error('error'))
-    )
-    const p = queue.push('a', 100)
+    const queue = new DebouncedPromiseQueue<string, string>()
+    const p = queue.push('a', 100, () => Promise.reject(new Error('error')))
     vi.advanceTimersToNextTimer()
     expect(queue.queuedValue).toBeUndefined()
     await expect(p).rejects.toThrowError('error')
   })
   it('returns a new Promise when an update is pushed while the callback is pending', async () => {
     vi.useFakeTimers()
-    const queue = new DebouncedPromiseQueue(async input => {
+    const callback = async (input: string) => {
       await setTimeout(100)
       return input
-    })
-    const p1 = queue.push('a', 100)
+    }
+    const queue = new DebouncedPromiseQueue<string, string>()
+    const p1 = queue.push('a', 100, callback)
     vi.advanceTimersByTime(150) // 100ms debounce + half the callback settle time
-    const p2 = queue.push('b', 100)
+    const p2 = queue.push('b', 100, callback)
     expect(p1).not.toBe(p2)
     vi.advanceTimersToNextTimer()
     await expect(p1).resolves.toBe('a')

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -87,28 +87,32 @@ export class DebounceController {
       return Promise.resolve(getSnapshot())
     }
     const key = update.key
-    if (!this.queues.has(key)) {
+    const callback = (update: Omit<UpdateQueuePushArgs, 'timeMs'>) => {
+      this.throttleQueue.push(update)
+      return this.throttleQueue
+        .flush(adapter, processUrlSearchParams)
+        .finally(() => {
+          const queuedValue = this.queues.get(update.key)?.queuedValue
+          if (queuedValue === undefined) {
+            debug(16, update.key)
+            this.queues.delete(update.key)
+          }
+          this.queuedQuerySync.emit(update.key)
+        })
+    }
+    let queue = this.queues.get(key)
+    if (!queue) {
       debug(15, key)
-      const queue = new DebouncedPromiseQueue<
+      queue = new DebouncedPromiseQueue<
         Omit<UpdateQueuePushArgs, 'timeMs'>,
         URLSearchParams
-      >(update => {
-        this.throttleQueue.push(update)
-        return this.throttleQueue
-          .flush(adapter, processUrlSearchParams)
-          .finally(() => {
-            const queuedValue = this.queues.get(update.key)?.queuedValue
-            if (queuedValue === undefined) {
-              debug(16, update.key)
-              this.queues.delete(update.key)
-            }
-            this.queuedQuerySync.emit(update.key)
-          })
-      })
+      >(callback)
       this.queues.set(key, queue)
+    } else {
+      queue.callback = callback
     }
     debug(17, update)
-    const promise = this.queues.get(key)!.push(update, timeMs)
+    const promise = queue.push(update, timeMs)
     this.queuedQuerySync.emit(key)
     return promise
   }

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -93,15 +93,14 @@ export class DebounceController {
       this.queues.set(key, queue)
     }
     debug(17, update)
-    // The queue runs the callback of its most recent push, so this closure
-    // always flushes with the adapter & processUrlSearchParams given here.
+    // A restarted debounce must flush with the adapter
+    // and processUrlSearchParams of its latest push.
     const flush = () => {
       this.throttleQueue.push(update)
       return this.throttleQueue
         .flush(adapter, processUrlSearchParams)
         .finally(() => {
-          const queuedValue = this.queues.get(key)?.queuedValue
-          if (queuedValue === undefined) {
+          if (this.queues.get(key)?.queuedValue === undefined) {
             debug(16, key)
             this.queues.delete(key)
           }

--- a/packages/nuqs/src/lib/queues/debounce.ts
+++ b/packages/nuqs/src/lib/queues/debounce.ts
@@ -14,21 +14,20 @@ import {
 import { useSyncExternalStores } from './useSyncExternalStores'
 
 export class DebouncedPromiseQueue<ValueType, OutputType> {
-  callback: (value: ValueType) => Promise<OutputType>
   resolvers: Resolvers<OutputType> = withResolvers<OutputType>()
   controller: AbortController = new AbortController()
   queuedValue: ValueType | undefined = undefined
-
-  constructor(callback: (value: ValueType) => Promise<OutputType>) {
-    this.callback = callback
-  }
 
   abort(): void {
     this.controller.abort()
     this.queuedValue = undefined
   }
 
-  push(value: ValueType, timeMs: number): Promise<OutputType> {
+  push(
+    value: ValueType,
+    timeMs: number,
+    callback: (value: ValueType) => Promise<OutputType>
+  ): Promise<OutputType> {
     this.queuedValue = value
     this.controller.abort()
     this.controller = new AbortController()
@@ -40,7 +39,7 @@ export class DebouncedPromiseQueue<ValueType, OutputType> {
         const outputResolvers = this.resolvers
         try {
           debug(13, value)
-          const callbackPromise = this.callback(value)
+          const callbackPromise = callback(value)
           debug(14, this.queuedValue)
           this.queuedValue = undefined
           this.resolvers = withResolvers<OutputType>()
@@ -87,32 +86,29 @@ export class DebounceController {
       return Promise.resolve(getSnapshot())
     }
     const key = update.key
-    const callback = (update: Omit<UpdateQueuePushArgs, 'timeMs'>) => {
+    let queue = this.queues.get(key)
+    if (!queue) {
+      debug(15, key)
+      queue = new DebouncedPromiseQueue()
+      this.queues.set(key, queue)
+    }
+    debug(17, update)
+    // The queue runs the callback of its most recent push, so this closure
+    // always flushes with the adapter & processUrlSearchParams given here.
+    const flush = () => {
       this.throttleQueue.push(update)
       return this.throttleQueue
         .flush(adapter, processUrlSearchParams)
         .finally(() => {
-          const queuedValue = this.queues.get(update.key)?.queuedValue
+          const queuedValue = this.queues.get(key)?.queuedValue
           if (queuedValue === undefined) {
-            debug(16, update.key)
-            this.queues.delete(update.key)
+            debug(16, key)
+            this.queues.delete(key)
           }
-          this.queuedQuerySync.emit(update.key)
+          this.queuedQuerySync.emit(key)
         })
     }
-    let queue = this.queues.get(key)
-    if (!queue) {
-      debug(15, key)
-      queue = new DebouncedPromiseQueue<
-        Omit<UpdateQueuePushArgs, 'timeMs'>,
-        URLSearchParams
-      >(callback)
-      this.queues.set(key, queue)
-    } else {
-      queue.callback = callback
-    }
-    debug(17, update)
-    const promise = queue.push(update, timeMs)
+    const promise = queue.push(update, timeMs, flush)
     this.queuedQuerySync.emit(key)
     return promise
   }

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -17,6 +17,7 @@ import {
   type OnUrlUpdateFunction
 } from './adapters/testing'
 import { debounce, throttle } from './lib/queues/rate-limiting'
+import { resetQueues } from './lib/queues/reset'
 import {
   createParser,
   parseAsArrayOf,
@@ -1584,7 +1585,7 @@ describe('useQueryStates: process url search params', () => {
           return search
         },
         rateLimitFactor: 1,
-        resetUrlUpdateQueueOnMount: config === 'a',
+        resetUrlUpdateQueueOnMount: false,
         children: [
           createElement('button', {
             key: 'btn',
@@ -1596,6 +1597,7 @@ describe('useQueryStates: process url search params', () => {
       })
     }
     try {
+      resetQueues()
       const { result, act } = await renderHook(
         () => useQueryStates({ test: parseAsString }),
         { wrapper: DynamicWrapper }

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1572,6 +1572,57 @@ describe('useQueryStates: process url search params', () => {
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe('?test=pass')
   })
+  it('should use the latest processUrlSearchParams when restarting a debounce', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    function DynamicWrapper({ children }: { children: ReactNode }) {
+      const [config, setConfig] = useState<'a' | 'b'>('a')
+      return createElement(NuqsTestingAdapter, {
+        onUrlUpdate,
+        processUrlSearchParams: search => {
+          search.set('config', config)
+          return search
+        },
+        rateLimitFactor: 1,
+        resetUrlUpdateQueueOnMount: config === 'a',
+        children: [
+          createElement('button', {
+            key: 'btn',
+            onClick: () => setConfig('b'),
+            'data-testid': 'btn'
+          }),
+          children
+        ]
+      })
+    }
+    try {
+      const { result, act } = await renderHook(
+        () => useQueryStates({ test: parseAsString }),
+        { wrapper: DynamicWrapper }
+      )
+      await act(() => {
+        void result.current[1](
+          { test: 'first' },
+          { limitUrlUpdates: debounce(100) }
+        )
+      })
+      await act(() => page.getByTestId('btn').click())
+      await act(() => {
+        void result.current[1](
+          { test: 'second' },
+          { limitUrlUpdates: debounce(100) }
+        )
+      })
+      await act(() => vi.advanceTimersByTimeAsync(200))
+
+      expect(onUrlUpdate).toHaveBeenCalledOnce()
+      expect(onUrlUpdate.mock.calls[0]![0].queryString).toBe(
+        '?test=second&config=b'
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe('useQueryStates: edge cases & repros', () => {


### PR DESCRIPTION
Initially, this was solving an issue where a debounced update would have used the processUrlSearchParams at the time it was pushed (and not a fresh version if it changed during the debounce time).

It only solves half the issue: now a subsequent debounced update will update the `processUrlSearchParams` closure, but without an update the eventual flush will only use the closed `processUrlSearchParams`. That one might be stale, although nobody should really have those change as they'd cause a whole-app re-render of NuqsAdapter.

This turns out to be a refactor of the debounce queue to make it simpler, smaller bundle size, by moving the exit callback into the push rather than at construction time (which works as each push overrides the previous one in a debounce behaviour).