### PR TITLE
fix: preserve query on fragment-only history updates

### DIFF
--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -72,7 +72,7 @@ export function patchHistory(
   function sync(url: URL | string) {
     spinQueueResetMutex()
     try {
-      const newSearch = new URL(url, location.origin).search
+      const newSearch = new URL(url, location.href).search
       if (newSearch === lastSearchSeen) {
         return
       }

--- a/packages/nuqs/src/lib/search-params.browser.test.ts
+++ b/packages/nuqs/src/lib/search-params.browser.test.ts
@@ -64,6 +64,16 @@ describe('search-params/getSearchParams', () => {
     const expected = new URLSearchParams('?foo=bar')
     expect(received).toEqual(expected)
   })
+  it('preserves the current search params for a fragment-only URL', () => {
+    const originalUrl = location.href
+    history.replaceState(null, '', '?foo=bar')
+    try {
+      const received = getSearchParams('#details')
+      expect(received.toString()).toBe('foo=bar')
+    } finally {
+      history.replaceState(null, '', originalUrl)
+    }
+  })
   it('falls back to an empty search params object for invalid inputs', () => {
     const received = getSearchParams('invalid')
     const expected = new URLSearchParams()

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -34,7 +34,7 @@ export function getSearchParams(url: string | URL): URLSearchParams {
     return new URLSearchParams(url)
   }
   try {
-    return new URL(url, location.origin).searchParams
+    return new URL(url, location.href).searchParams
   } catch {
     return new URLSearchParams(url)
   }


### PR DESCRIPTION
## Summary

- resolve relative History API URLs against the current document URL
- preserve existing query parameters during fragment-only updates such as `history.pushState(null, "", "#details")`
- add browser regression coverage for fragment-only URL parsing