### PR TITLE
fix: ignore fragments in query-only URLs

### DIFF
--- a/packages/nuqs/src/lib/search-params.browser.test.ts
+++ b/packages/nuqs/src/lib/search-params.browser.test.ts
@@ -64,6 +64,12 @@ describe('search-params/getSearchParams', () => {
     const expected = new URLSearchParams('?foo=bar')
     expect(received).toEqual(expected)
   })
+  it.each([
+    ['?foo=bar#details?ignored=fragment', 'foo=bar'],
+    ['?#details?ignored=fragment', '']
+  ])('ignores the fragment in query-only URL %s', (url, expected) => {
+    expect(getSearchParams(url).toString()).toBe(expected)
+  })
   it('falls back to an empty search params object for invalid inputs', () => {
     const received = getSearchParams('invalid')
     const expected = new URLSearchParams()

--- a/packages/nuqs/src/lib/search-params.browser.test.ts
+++ b/packages/nuqs/src/lib/search-params.browser.test.ts
@@ -66,7 +66,9 @@ describe('search-params/getSearchParams', () => {
   })
   it.each([
     ['?foo=bar#details?ignored=fragment', 'foo=bar'],
-    ['?#details?ignored=fragment', '']
+    ['?#details?ignored=fragment', ''],
+    ['?foo=bar#a#b', 'foo=bar'],
+    ['?a=%23b#c', 'a=%23b']
   ])('ignores the fragment in query-only URL %s', (url, expected) => {
     expect(getSearchParams(url).toString()).toBe(expected)
   })

--- a/packages/nuqs/src/lib/search-params.ts
+++ b/packages/nuqs/src/lib/search-params.ts
@@ -31,7 +31,8 @@ export function getSearchParams(url: string | URL): URLSearchParams {
     return url.searchParams
   }
   if (url.startsWith('?')) {
-    return new URLSearchParams(url)
+    const hashIndex = url.indexOf('#')
+    return new URLSearchParams(hashIndex === -1 ? url : url.slice(0, hashIndex))
   }
   try {
     return new URL(url, location.origin).searchParams


### PR DESCRIPTION
Follow-up to #1543.

## Summary

- stop parsing URL fragments as query data for query-only URL references
- preserve encoded fragment delimiters inside legitimate query values
- cover populated and empty query strings followed by fragments

## Testing

- added browser regression coverage for query-only URLs containing fragments
- verified the focused package suite, types, bundle limits, formatting, and linting

## Review follow-up

- pin the first raw `#` as the fragment boundary when multiple hashes are present
- preserve encoded `%23` delimiters inside query values
