### PR TITLE
fix: cancel pending URL updates on history navigation

### DIFF
--- a/packages/e2e/next/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/next/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,4 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/app/queue-lifecycle', router: 'next-app' })
+testQueueLifecycle({ path: '/pages/queue-lifecycle', router: 'next-pages' })

--- a/packages/e2e/next/src/app/app/(shared)/queue-lifecycle/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/queue-lifecycle/page.tsx
@@ -1,0 +1,10 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <QueueLifecycle />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/pages/pages/queue-lifecycle.tsx
+++ b/packages/e2e/next/src/pages/pages/queue-lifecycle.tsx
@@ -1,0 +1,3 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export default QueueLifecycle

--- a/packages/e2e/react-router/v6/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/react-router/v6/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,3 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/queue-lifecycle', router: 'react-router-v6' })

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -37,6 +37,7 @@ const router = createBrowserRouter(
       <Route path="linking/useQueryStates/other"              lazy={load(import('./routes/linking.useQueryStates.other'))} />
       <Route path="native-array"                              lazy={load(import('./routes/native-array'))} />
       <Route path="pretty-urls"                               lazy={load(import('./routes/pretty-urls'))} />
+      <Route path="queue-lifecycle"                            lazy={load(import('./routes/queue-lifecycle'))} />
       <Route path="referential-stability/useQueryState"       lazy={load(import('./routes/referential-stability.useQueryState'))} />
       <Route path="referential-stability/useQueryStates"      lazy={load(import('./routes/referential-stability.useQueryStates'))} />
       <Route path="routing/useQueryState"                     lazy={load(import('./routes/routing.useQueryState'))} />

--- a/packages/e2e/react-router/v6/src/routes/queue-lifecycle.tsx
+++ b/packages/e2e/react-router/v6/src/routes/queue-lifecycle.tsx
@@ -1,0 +1,3 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export default QueueLifecycle

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -20,6 +20,7 @@ export default [
     route('/linking/useQueryStates/other',              './routes/linking.useQueryStates.other.tsx'),
     route('/native-array',                              './routes/native-array.tsx'),
     route('/pretty-urls',                               './routes/pretty-urls.tsx'),
+    route('/queue-lifecycle',                            './routes/queue-lifecycle.tsx'),
     route('/referential-stability/useQueryState',       './routes/referential-stability.useQueryState.tsx'),
     route('/referential-stability/useQueryStates',      './routes/referential-stability.useQueryStates.tsx'),
     route('/routing/useQueryState',                     './routes/routing.useQueryState.tsx'),

--- a/packages/e2e/react-router/v7/app/routes/queue-lifecycle.tsx
+++ b/packages/e2e/react-router/v7/app/routes/queue-lifecycle.tsx
@@ -1,0 +1,3 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export default QueueLifecycle

--- a/packages/e2e/react-router/v7/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/react-router/v7/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,3 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/queue-lifecycle', router: 'react-router-v7' })

--- a/packages/e2e/react-router/v8/app/routes.ts
+++ b/packages/e2e/react-router/v8/app/routes.ts
@@ -20,6 +20,7 @@ export default [
     route('/linking/useQueryStates/other',              './routes/linking.useQueryStates.other.tsx'),
     route('/native-array',                              './routes/native-array.tsx'),
     route('/pretty-urls',                               './routes/pretty-urls.tsx'),
+    route('/queue-lifecycle',                            './routes/queue-lifecycle.tsx'),
     route('/referential-stability/useQueryState',       './routes/referential-stability.useQueryState.tsx'),
     route('/referential-stability/useQueryStates',      './routes/referential-stability.useQueryStates.tsx'),
     route('/routing/useQueryState',                     './routes/routing.useQueryState.tsx'),

--- a/packages/e2e/react-router/v8/app/routes/queue-lifecycle.tsx
+++ b/packages/e2e/react-router/v8/app/routes/queue-lifecycle.tsx
@@ -1,0 +1,3 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export default QueueLifecycle

--- a/packages/e2e/react-router/v8/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/react-router/v8/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,3 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/queue-lifecycle', router: 'react-router-v8' })

--- a/packages/e2e/react/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/react/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,3 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/queue-lifecycle', router: 'react-spa' })

--- a/packages/e2e/react/src/routes.tsx
+++ b/packages/e2e/react/src/routes.tsx
@@ -19,6 +19,7 @@ const routes: Record<string, React.LazyExoticComponent<() => JSX.Element>> = {
   '/linking/useQueryStates/other':          lazy(() => import('./routes/linking.useQueryStates.other')),
   '/native-array':                          lazy(() => import('./routes/native-array')),
   '/pretty-urls':                           lazy(() => import('./routes/pretty-urls')),
+  '/queue-lifecycle':                       lazy(() => import('./routes/queue-lifecycle')),
   '/referential-stability/useQueryState':   lazy(() => import('./routes/referential-stability.useQueryState')),
   '/referential-stability/useQueryStates':  lazy(() => import('./routes/referential-stability.useQueryStates')),
   '/routing/useQueryState':                 lazy(() => import('./routes/routing.useQueryState')),

--- a/packages/e2e/react/src/routes/queue-lifecycle.tsx
+++ b/packages/e2e/react/src/routes/queue-lifecycle.tsx
@@ -1,0 +1,3 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export default QueueLifecycle

--- a/packages/e2e/remix/app/routes/queue-lifecycle.tsx
+++ b/packages/e2e/remix/app/routes/queue-lifecycle.tsx
@@ -1,0 +1,3 @@
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export default QueueLifecycle

--- a/packages/e2e/remix/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/remix/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,3 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/queue-lifecycle', router: 'remix' })

--- a/packages/e2e/shared/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/shared/specs/queue-lifecycle.spec.ts
@@ -5,7 +5,7 @@ import { navigateTo } from '../playwright/navigate'
 export const testQueueLifecycle = defineTest(
   'Queue lifecycle',
   ({ path }: TestConfig) => {
-    it('cancels a queued update on native Back after the last query subscriber unmounts', async ({
+    it('cancels a queued update when the Back button is used after the last query subscriber unmounts', async ({
       page
     }) => {
       await navigateTo(page, path)
@@ -17,9 +17,7 @@ export const testQueueLifecycle = defineTest(
       await expect(pushStatus).toHaveText('settled')
       await expect(page).toHaveURL(url => url.search === '?test=current')
 
-      await page
-        .getByRole('button', { name: 'Queue update and unmount' })
-        .click()
+      await page.getByRole('button', { name: 'Queue update' }).click()
       await expect(queueStatus).toHaveText('pending')
       await expect(page.locator('#no-query-subscribers').first()).toBeVisible()
       await expect(page.locator('#client-query-value')).toHaveCount(0)

--- a/packages/e2e/shared/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/shared/specs/queue-lifecycle.spec.ts
@@ -29,9 +29,8 @@ export const testQueueLifecycle = defineTest(
 
       await expect(queueStatus).toHaveText(/^(?:cancelled|applied|error)$/)
       await expect.soft(queueStatus).toHaveText('cancelled', { timeout: 250 })
-      await expect.soft(page).toHaveURL(url => url.search === '', {
-        timeout: 250
-      })
+      await page.waitForTimeout(700)
+      await expect(page).toHaveURL(url => url.search === '')
     })
   }
 )

--- a/packages/e2e/shared/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/shared/specs/queue-lifecycle.spec.ts
@@ -10,21 +10,23 @@ export const testQueueLifecycle = defineTest(
     }) => {
       await navigateTo(page, path)
 
+      const pushStatus = page.locator('#client-push-status').first()
+      const queueStatus = page.locator('#client-queue-status').first()
+
       await page.getByRole('button', { name: 'Create history entry' }).click()
-      await expect(page.locator('#client-push-status')).toHaveText('settled')
+      await expect(pushStatus).toHaveText('settled')
       await expect(page).toHaveURL(url => url.search === '?test=current')
 
       await page
         .getByRole('button', { name: 'Queue update and unmount' })
         .click()
-      await expect(page.locator('#client-queue-status')).toHaveText('pending')
-      await expect(page.locator('#no-query-subscribers')).toBeVisible()
+      await expect(queueStatus).toHaveText('pending')
+      await expect(page.locator('#no-query-subscribers').first()).toBeVisible()
       await expect(page.locator('#client-query-value')).toHaveCount(0)
 
       await page.goBack()
       await expect(page).toHaveURL(url => url.search === '')
 
-      const queueStatus = page.locator('#client-queue-status')
       await expect(queueStatus).toHaveText(/^(?:cancelled|applied|error)$/)
       await expect.soft(queueStatus).toHaveText('cancelled', { timeout: 250 })
       await expect.soft(page).toHaveURL(url => url.search === '', {

--- a/packages/e2e/shared/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/shared/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test as it } from '@playwright/test'
+import { defineTest, type TestConfig } from '../define-test'
+import { navigateTo } from '../playwright/navigate'
+
+export const testQueueLifecycle = defineTest(
+  'Queue lifecycle',
+  ({ path }: TestConfig) => {
+    it('cancels a queued update on native Back after the last query subscriber unmounts', async ({
+      page
+    }) => {
+      await navigateTo(page, path)
+
+      await page.getByRole('button', { name: 'Create history entry' }).click()
+      await expect(page.getByLabel('Push status')).toHaveText('settled')
+      await expect(page).toHaveURL(url => url.search === '?test=current')
+
+      await page
+        .getByRole('button', { name: 'Queue update and unmount' })
+        .click()
+      await expect(page.getByLabel('Queue status')).toHaveText('pending')
+      await expect(page.locator('#no-query-subscribers')).toBeVisible()
+      await expect(page.getByLabel('Query value')).toHaveCount(0)
+
+      await page.goBack()
+      await expect(page).toHaveURL(url => url.search === '')
+
+      const queueStatus = page.getByLabel('Queue status')
+      await expect(queueStatus).toHaveText(/^(?:cancelled|applied|error)$/)
+      await expect.soft(queueStatus).toHaveText('cancelled', { timeout: 250 })
+      await expect.soft(page).toHaveURL(url => url.search === '', {
+        timeout: 250
+      })
+    })
+  }
+)

--- a/packages/e2e/shared/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/shared/specs/queue-lifecycle.spec.ts
@@ -11,20 +11,20 @@ export const testQueueLifecycle = defineTest(
       await navigateTo(page, path)
 
       await page.getByRole('button', { name: 'Create history entry' }).click()
-      await expect(page.getByLabel('Push status')).toHaveText('settled')
+      await expect(page.locator('#client-push-status')).toHaveText('settled')
       await expect(page).toHaveURL(url => url.search === '?test=current')
 
       await page
         .getByRole('button', { name: 'Queue update and unmount' })
         .click()
-      await expect(page.getByLabel('Queue status')).toHaveText('pending')
+      await expect(page.locator('#client-queue-status')).toHaveText('pending')
       await expect(page.locator('#no-query-subscribers')).toBeVisible()
-      await expect(page.getByLabel('Query value')).toHaveCount(0)
+      await expect(page.locator('#client-query-value')).toHaveCount(0)
 
       await page.goBack()
       await expect(page).toHaveURL(url => url.search === '')
 
-      const queueStatus = page.getByLabel('Queue status')
+      const queueStatus = page.locator('#client-queue-status')
       await expect(queueStatus).toHaveText(/^(?:cancelled|applied|error)$/)
       await expect.soft(queueStatus).toHaveText('cancelled', { timeout: 250 })
       await expect.soft(page).toHaveURL(url => url.search === '', {

--- a/packages/e2e/shared/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/shared/specs/queue-lifecycle.spec.ts
@@ -20,6 +20,7 @@ export const testQueueLifecycle = defineTest(
       await page.getByRole('button', { name: 'Queue update' }).click()
       await expect(queueStatus).toHaveText('pending')
       await expect(page.locator('#no-query-subscribers').first()).toBeVisible()
+      // The query value is absent because its subscriber has unmounted.
       await expect(page.locator('#client-query-value')).toHaveCount(0)
 
       await page.goBack()

--- a/packages/e2e/shared/specs/queue-lifecycle.tsx
+++ b/packages/e2e/shared/specs/queue-lifecycle.tsx
@@ -5,28 +5,23 @@ import { useState } from 'react'
 import { Display } from '../components/display'
 
 type QueueStatus = 'idle' | 'pending' | 'cancelled' | 'applied' | 'error'
+type QueueResult = 'cancelled' | 'applied' | 'error'
 
 export function QueueLifecycle() {
   const [hasSubscriber, setHasSubscriber] = useState(true)
   const [queueStatus, setQueueStatus] = useState<QueueStatus>('idle')
 
-  const handleQueuedUpdate = (promise: Promise<URLSearchParams>) => {
-    setQueueStatus('pending')
-    setHasSubscriber(false)
-    promise.then(
-      search =>
-        setQueueStatus(
-          search.get('test') === 'stale' ? 'applied' : 'cancelled'
-        ),
-      () => setQueueStatus('error')
-    )
-  }
-
   return (
     <>
       <Display environment="client" target="queue-status" state={queueStatus} />
       {hasSubscriber ? (
-        <QueueLifecycleSubscriber onQueuedUpdate={handleQueuedUpdate} />
+        <QueueLifecycleSubscriber
+          onQueued={() => {
+            setQueueStatus('pending')
+            setHasSubscriber(false)
+          }}
+          onSettled={result => setQueueStatus(result)}
+        />
       ) : (
         <p id="no-query-subscribers">No query subscribers</p>
       )}
@@ -35,9 +30,11 @@ export function QueueLifecycle() {
 }
 
 function QueueLifecycleSubscriber({
-  onQueuedUpdate
+  onQueued,
+  onSettled
 }: {
-  onQueuedUpdate: (promise: Promise<URLSearchParams>) => void
+  onQueued: () => void
+  onSettled: (result: QueueResult) => void
 }) {
   const [value, setValue] = useQueryState('test', parseAsString)
   const [pushStatus, setPushStatus] = useState('idle')
@@ -48,11 +45,15 @@ function QueueLifecycleSubscriber({
     setPushStatus(search.get('test') === 'current' ? 'settled' : 'error')
   }
 
-  const queueUpdateAndUnmount = () => {
-    onQueuedUpdate(
-      setValue('stale', {
-        limitUrlUpdates: debounce(600)
-      })
+  const queueUpdate = () => {
+    const pendingUpdate = setValue('stale', {
+      limitUrlUpdates: debounce(600)
+    })
+    onQueued()
+    void pendingUpdate.then(
+      search =>
+        onSettled(search.get('test') === 'stale' ? 'applied' : 'cancelled'),
+      () => onSettled('error')
     )
   }
 
@@ -61,7 +62,7 @@ function QueueLifecycleSubscriber({
       <Display environment="client" target="query-value" state={value} />
       <Display environment="client" target="push-status" state={pushStatus} />
       <button onClick={createHistoryEntry}>Create history entry</button>
-      <button onClick={queueUpdateAndUnmount}>Queue update and unmount</button>
+      <button onClick={queueUpdate}>Queue update</button>
     </>
   )
 }

--- a/packages/e2e/shared/specs/queue-lifecycle.tsx
+++ b/packages/e2e/shared/specs/queue-lifecycle.tsx
@@ -2,6 +2,7 @@
 
 import { debounce, parseAsString, useQueryState } from 'nuqs'
 import { useState } from 'react'
+import { Display } from '../components/display'
 
 type QueueStatus = 'idle' | 'pending' | 'cancelled' | 'applied' | 'error'
 
@@ -23,7 +24,7 @@ export function QueueLifecycle() {
 
   return (
     <>
-      <output aria-label="Queue status">{queueStatus}</output>
+      <Display environment="client" target="queue-status" state={queueStatus} />
       {hasSubscriber ? (
         <QueueLifecycleSubscriber onQueuedUpdate={handleQueuedUpdate} />
       ) : (
@@ -57,8 +58,8 @@ function QueueLifecycleSubscriber({
 
   return (
     <>
-      <output aria-label="Query value">{value}</output>
-      <output aria-label="Push status">{pushStatus}</output>
+      <Display environment="client" target="query-value" state={value} />
+      <Display environment="client" target="push-status" state={pushStatus} />
       <button onClick={createHistoryEntry}>Create history entry</button>
       <button onClick={queueUpdateAndUnmount}>Queue update and unmount</button>
     </>

--- a/packages/e2e/shared/specs/queue-lifecycle.tsx
+++ b/packages/e2e/shared/specs/queue-lifecycle.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { debounce, parseAsString, useQueryState } from 'nuqs'
+import { useState } from 'react'
+
+type QueueStatus = 'idle' | 'pending' | 'cancelled' | 'applied' | 'error'
+
+export function QueueLifecycle() {
+  const [hasSubscriber, setHasSubscriber] = useState(true)
+  const [queueStatus, setQueueStatus] = useState<QueueStatus>('idle')
+
+  const handleQueuedUpdate = (promise: Promise<URLSearchParams>) => {
+    setQueueStatus('pending')
+    setHasSubscriber(false)
+    promise.then(
+      search =>
+        setQueueStatus(
+          search.get('test') === 'stale' ? 'applied' : 'cancelled'
+        ),
+      () => setQueueStatus('error')
+    )
+  }
+
+  return (
+    <>
+      <output aria-label="Queue status">{queueStatus}</output>
+      {hasSubscriber ? (
+        <QueueLifecycleSubscriber onQueuedUpdate={handleQueuedUpdate} />
+      ) : (
+        <p id="no-query-subscribers">No query subscribers</p>
+      )}
+    </>
+  )
+}
+
+function QueueLifecycleSubscriber({
+  onQueuedUpdate
+}: {
+  onQueuedUpdate: (promise: Promise<URLSearchParams>) => void
+}) {
+  const [value, setValue] = useQueryState('test', parseAsString)
+  const [pushStatus, setPushStatus] = useState('idle')
+
+  const createHistoryEntry = async () => {
+    setPushStatus('pending')
+    const search = await setValue('current', { history: 'push' })
+    setPushStatus(search.get('test') === 'current' ? 'settled' : 'error')
+  }
+
+  const queueUpdateAndUnmount = () => {
+    onQueuedUpdate(
+      setValue('stale', {
+        limitUrlUpdates: debounce(600)
+      })
+    )
+  }
+
+  return (
+    <>
+      <output aria-label="Query value">{value}</output>
+      <output aria-label="Push status">{pushStatus}</output>
+      <button onClick={createHistoryEntry}>Create history entry</button>
+      <button onClick={queueUpdateAndUnmount}>Queue update and unmount</button>
+    </>
+  )
+}

--- a/packages/e2e/tanstack-router/specs/queue-lifecycle.spec.ts
+++ b/packages/e2e/tanstack-router/specs/queue-lifecycle.spec.ts
@@ -1,0 +1,3 @@
+import { testQueueLifecycle } from 'e2e-shared/specs/queue-lifecycle.spec.ts'
+
+testQueueLifecycle({ path: '/queue-lifecycle', router: 'tanstack-router' })

--- a/packages/e2e/tanstack-router/src/routes/queue-lifecycle.tsx
+++ b/packages/e2e/tanstack-router/src/routes/queue-lifecycle.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { QueueLifecycle } from 'e2e-shared/specs/queue-lifecycle'
+
+export const Route = createFileRoute('/queue-lifecycle')({
+  component: QueueLifecycle
+})

--- a/packages/nuqs/src/adapters/next.ts
+++ b/packages/nuqs/src/adapters/next.ts
@@ -1,7 +1,12 @@
+import { createElement } from 'react'
 import { createAdapterProvider, type AdapterProvider } from './lib/context'
 import type { AdapterInterface } from './lib/defs'
 import { useNuqsNextAppRouterAdapter } from './next/impl.app'
-import { isPagesRouter, useNuqsNextPagesRouterAdapter } from './next/impl.pages'
+import {
+  isPagesRouter,
+  NavigationSpy,
+  useNuqsNextPagesRouterAdapter
+} from './next/impl.pages'
 
 function useNuqsNextAdapter(): AdapterInterface {
   const pagesRouterImpl = useNuqsNextPagesRouterAdapter()
@@ -19,5 +24,13 @@ function useNuqsNextAdapter(): AdapterInterface {
   }
 }
 
-export const NuqsAdapter: AdapterProvider =
-  createAdapterProvider(useNuqsNextAdapter)
+const Provider = createAdapterProvider(useNuqsNextAdapter)
+
+export const NuqsAdapter: AdapterProvider = ({ children, ...adapterProps }) =>
+  createElement(Provider, {
+    ...adapterProps,
+    children: [
+      createElement(NavigationSpy, { key: 'nuqs-adapter-navigation-spy' }),
+      children
+    ]
+  }) as ReturnType<AdapterProvider>

--- a/packages/nuqs/src/adapters/next/impl.pages.ts
+++ b/packages/nuqs/src/adapters/next/impl.pages.ts
@@ -23,15 +23,32 @@ export function isPagesRouter(): boolean {
   return typeof window.next?.router?.state?.asPath === 'string'
 }
 
-const updateState = globalSingleton('next-pages-router-update', () => ({
-  isNuqsUpdate: false
+const adapterState = globalSingleton('next-pages-router-update', () => ({
+  isNuqsUpdate: false,
+  navigationHandled: false,
+  fallbackScheduled: false
 }))
 
 function onNavigation() {
-  if (updateState.isNuqsUpdate) {
+  if (adapterState.isNuqsUpdate) {
     return
   }
+  adapterState.navigationHandled = true
   resetQueues()
+}
+
+function onNavigationWithoutSubscribers() {
+  if (adapterState.isNuqsUpdate || adapterState.fallbackScheduled) {
+    return
+  }
+  adapterState.fallbackScheduled = true
+  queueMicrotask(() => {
+    if (!adapterState.navigationHandled) {
+      resetQueues()
+    }
+    adapterState.navigationHandled = false
+    adapterState.fallbackScheduled = false
+  })
 }
 
 export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
@@ -80,7 +97,7 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
     debug(20, 'next/pages', asPath)
     const method =
       options.history === 'push' ? nextRouter.push : nextRouter.replace
-    updateState.isNuqsUpdate = true
+    adapterState.isNuqsUpdate = true
     try {
       method
         .call(
@@ -108,10 +125,10 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
           }
         )
         .finally(() => {
-          updateState.isNuqsUpdate = false
+          adapterState.isNuqsUpdate = false
         })
     } catch (error) {
-      updateState.isNuqsUpdate = false
+      adapterState.isNuqsUpdate = false
       throw error
     }
   }, [])
@@ -121,6 +138,21 @@ export function useNuqsNextPagesRouterAdapter(): AdapterInterface {
     updateUrl,
     autoResetQueueOnUpdate: false
   }
+}
+
+export function NavigationSpy() {
+  const router = useRouter()
+
+  useEffect(() => {
+    router?.events.on('routeChangeStart', onNavigationWithoutSubscribers)
+    router?.events.on('beforeHistoryChange', onNavigationWithoutSubscribers)
+    return () => {
+      router?.events.off('routeChangeStart', onNavigationWithoutSubscribers)
+      router?.events.off('beforeHistoryChange', onNavigationWithoutSubscribers)
+    }
+  }, [router?.events])
+
+  return null
 }
 
 export function getAsPathPathname(asPath: string): string {

--- a/packages/nuqs/src/adapters/next/pages.ts
+++ b/packages/nuqs/src/adapters/next/pages.ts
@@ -1,6 +1,14 @@
+import { createElement } from 'react'
 import { createAdapterProvider, type AdapterProvider } from '../lib/context'
-import { useNuqsNextPagesRouterAdapter } from './impl.pages'
+import { NavigationSpy, useNuqsNextPagesRouterAdapter } from './impl.pages'
 
-export const NuqsAdapter: AdapterProvider = createAdapterProvider(
-  useNuqsNextPagesRouterAdapter
-)
+const Provider = createAdapterProvider(useNuqsNextPagesRouterAdapter)
+
+export const NuqsAdapter: AdapterProvider = ({ children, ...adapterProps }) =>
+  createElement(Provider, {
+    ...adapterProps,
+    children: [
+      createElement(NavigationSpy, { key: 'nuqs-adapter-navigation-spy' }),
+      children
+    ]
+  }) as ReturnType<AdapterProvider>

--- a/packages/nuqs/src/adapters/tanstack-router.ts
+++ b/packages/nuqs/src/adapters/tanstack-router.ts
@@ -1,5 +1,12 @@
 import { useLocation, useRouter, useRouterState } from '@tanstack/react-router'
-import { startTransition, useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  createElement,
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef
+} from 'react'
 import { resetQueues } from '../lib/queues/reset'
 import { renderQueryString } from '../lib/url-encoding'
 import { createAdapterProvider, type AdapterProvider } from './lib/context'
@@ -41,21 +48,6 @@ function useNuqsTanstackRouterAdapter(watchKeys: string[]): AdapterInterface {
   })
   const router = useRouter()
   const { navigate } = router
-
-  useEffect(() => {
-    const unsubscribe = router.history.subscribe(
-      ({ action }: HistorySubscriberArgs) => {
-        if (
-          action.type === 'BACK' ||
-          action.type === 'FORWARD' ||
-          action.type === 'GO'
-        ) {
-          resetQueues()
-        }
-      }
-    )
-    return unsubscribe
-  }, [router.history])
 
   // Track which pathname this hook instance was mounted under to
   // keep its last stable search during cross-page transitions.
@@ -133,6 +125,31 @@ function useNuqsTanstackRouterAdapter(watchKeys: string[]): AdapterInterface {
   }
 }
 
-export const NuqsAdapter: AdapterProvider = createAdapterProvider(
-  useNuqsTanstackRouterAdapter
-)
+const Provider = createAdapterProvider(useNuqsTanstackRouterAdapter)
+
+function HistorySpy() {
+  const router = useRouter()
+
+  useEffect(() => {
+    return router.history.subscribe(({ action }: HistorySubscriberArgs) => {
+      if (
+        action.type === 'BACK' ||
+        action.type === 'FORWARD' ||
+        action.type === 'GO'
+      ) {
+        resetQueues()
+      }
+    })
+  }, [router.history])
+
+  return null
+}
+
+export const NuqsAdapter: AdapterProvider = ({ children, ...adapterProps }) =>
+  createElement(Provider, {
+    ...adapterProps,
+    children: [
+      createElement(HistorySpy, { key: 'nuqs-adapter-history-spy' }),
+      children
+    ]
+  }) as ReturnType<AdapterProvider>


### PR DESCRIPTION
## Summary

Cancel pending URL updates when history navigation occurs, whether query subscribers are mounted or not.

- keep the Next.js Pages Router queue-reset listener mounted with the adapter provider
- keep the TanStack Router history listener mounted with the adapter provider
- add a shared E2E scenario that verifies the Back button cancels a pending debounced update after the last query subscriber unmounts

## Why

Queue cleanup must follow navigation, not the lifetime of query-hook subscribers. Previously, the relevant listeners could unmount with the last subscriber. A later Back navigation could then leave a pending debounced update alive and allow stale state to modify the restored URL.

The listeners now remain active for the lifetime of the adapter, so history navigation resets pending queues in all cases.
