### PR TITLE
doc: handle unavailable GitHub stats

### DIFF
--- a/packages/docs/src/app/(pages)/stats/_components/stars.tsx
+++ b/packages/docs/src/app/(pages)/stats/_components/stars.tsx
@@ -27,7 +27,7 @@ export async function StarHistoryGraph() {
         }
       >
         <p className="text-muted-foreground flex h-74.5 items-center justify-center text-sm">
-          Star history is unavailable: set GITHUB_TOKEN to enable it.
+          Star history is unavailable.
         </p>
       </Widget>
     )

--- a/packages/docs/src/app/(pages)/stats/lib/github.test.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.test.ts
@@ -195,6 +195,23 @@ describe('getStarHistory', () => {
     expect(history.bins.every(b => b.stargarzers.length === 0)).toBe(true)
   })
 
+  it('returns null when GitHub cannot return the repository', async () => {
+    server.use(
+      http.post(endpoint, () =>
+        HttpResponse.json({
+          data: { repository: null },
+          errors: [{ message: 'Repository data is unavailable' }]
+        })
+      )
+    )
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(await getStarHistory()).toBeNull()
+    expect(error).toHaveBeenCalledWith(
+      new Error('GitHub API error: Repository data is unavailable')
+    )
+  })
+
   it('throws on a malformed GraphQL response', async () => {
     server.use(http.post(endpoint, () => HttpResponse.json({ data: {} })))
     await expect(getStarHistory()).rejects.toThrow()

--- a/packages/docs/src/app/(pages)/stats/lib/github.ts
+++ b/packages/docs/src/app/(pages)/stats/lib/github.ts
@@ -23,33 +23,36 @@ export type GitHubStarHistory = {
 
 const starHistoryQuerySchema = z.object({
   data: z.object({
-    repository: z.object({
-      stargazers: z.object({
-        totalCount: z.number(),
-        pageInfo: z.object({
-          hasNextPage: z.boolean(),
-          endCursor: z.string().nullish()
-        }),
-        edges: z.array(
-          z.object({
-            starredAt: z
-              .string()
-              .datetime()
-              .transform(d => new Date(d)),
-            node: z.object({
-              login: z.string(),
-              name: z.string().nullish(),
-              avatarUrl: z.string(),
-              company: z.string().nullish(),
-              followers: z.object({
-                totalCount: z.number()
+    repository: z
+      .object({
+        stargazers: z.object({
+          totalCount: z.number(),
+          pageInfo: z.object({
+            hasNextPage: z.boolean(),
+            endCursor: z.string().nullish()
+          }),
+          edges: z.array(
+            z.object({
+              starredAt: z
+                .string()
+                .datetime()
+                .transform(d => new Date(d)),
+              node: z.object({
+                login: z.string(),
+                name: z.string().nullish(),
+                avatarUrl: z.string(),
+                company: z.string().nullish(),
+                followers: z.object({
+                  totalCount: z.number()
+                })
               })
             })
-          })
-        )
+          )
+        })
       })
-    })
-  })
+      .nullable()
+  }),
+  errors: z.array(z.object({ message: z.string() })).optional()
 })
 
 export async function getStarHistory(
@@ -127,13 +130,17 @@ ${await res.text()}`
       )
     }
 
+    const response = starHistoryQuerySchema.parse(await res.json())
+    if (response.data.repository === null) {
+      const message =
+        response.errors?.map(error => error.message).join('; ') ||
+        'Repository data is unavailable'
+      console.error(new Error(`GitHub API error: ${message}`))
+      return null
+    }
     const {
-      data: {
-        repository: {
-          stargazers: { totalCount: tc, pageInfo, edges }
-        }
-      }
-    } = starHistoryQuerySchema.parse(await res.json())
+      stargazers: { totalCount: tc, pageInfo, edges }
+    } = response.data.repository
 
     totalCount = tc
 


### PR DESCRIPTION
## Summary

GitHub now limits access to public stargazer lists to repository admins and collaborators. The token used by the docs site cannot access that list, so GraphQL returns a null repository with an access error and the stats page fails.

This change logs the GitHub error and shows the unavailable state instead of returning a 500 response. It also adds a test for the null repository response.

GitHub change: https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/