### PR TITLE
chore: de-nullify docs & tests

### DIFF
--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -106,7 +106,7 @@ export function StringParserDemo() {
       <input
         className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         value={value}
-        onChange={e => setValue(e.target.value || null)}
+        onChange={e => setValue(e.target.value)}
         placeholder="Type something here..."
         autoComplete="off"
       />

--- a/packages/docs/content/docs/parsers/demos.tsx
+++ b/packages/docs/content/docs/parsers/demos.tsx
@@ -77,13 +77,13 @@ function DemoContainer({
 }
 
 export function BasicUsageDemo() {
-  const [name, setName] = useQueryState('name', { defaultValue: '' })
+  const [name, setName] = useQueryState('name')
   return (
     <DemoContainer className="flex-col items-stretch" demoKey="name">
       <input
         className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-10 flex-1 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        value={name}
-        onChange={e => setName(e.target.value || null)}
+        value={name || ''}
+        onChange={e => setName(e.target.value)}
         placeholder="Enter your name..."
         autoComplete="off"
       />

--- a/packages/docs/src/app/(pages)/_landing/demo.client.tsx
+++ b/packages/docs/src/app/(pages)/_landing/demo.client.tsx
@@ -19,14 +19,14 @@ export function Demo() {
         Count: {count}
       </button>
       <input
-        value={hello}
         placeholder="Enter your name"
+        value={hello}
         autoComplete="off"
         className="peer border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         onChange={e => setHello(e.target.value)}
         data-interacted={Boolean(hello)}
       />
-      <p className="max-w-full break-words line-clamp-2 sm:truncate">
+      <p className="wrap-break-words line-clamp-2 max-w-full sm:truncate">
         Hello, {hello || 'anonymous visitor'}!
       </p>
     </>

--- a/packages/docs/src/app/(pages)/_landing/demo.client.tsx
+++ b/packages/docs/src/app/(pages)/_landing/demo.client.tsx
@@ -23,7 +23,7 @@ export function Demo() {
         placeholder="Enter your name"
         autoComplete="off"
         className="peer border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-        onChange={e => setHello(e.target.value || null)}
+        onChange={e => setHello(e.target.value)}
         data-interacted={Boolean(hello)}
       />
       <p className="max-w-full break-words line-clamp-2 sm:truncate">

--- a/packages/docs/src/app/(pages)/_landing/demo.tsx
+++ b/packages/docs/src/app/(pages)/_landing/demo.tsx
@@ -13,7 +13,7 @@ export async function LandingDemo() {
     .replace(/className=".+"/g, '') // Strip styling
     .replace('autoComplete="off"', '') // Strip irrelevant attributes
     .split('\n')
-    .filter(line => !line.includes('data-interacted='))
+    .filter(line => line.trim() && !line.includes('data-interacted='))
     .join('\n')
   const formattedCode = await format(demoCode, {
     parser: 'typescript'

--- a/packages/e2e/shared/specs/popstate-queue-reset.tsx
+++ b/packages/e2e/shared/specs/popstate-queue-reset.tsx
@@ -16,7 +16,7 @@ export function PopstateQueueResetClient({
   // Debounced value update - used to test queue cancellation on popstate
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setControls(
-      { value: e.target.value || null },
+      { value: e.target.value },
       { limitUrlUpdates: debounce(debounceTime) }
     )
   }

--- a/packages/e2e/shared/specs/repro-1444.tsx
+++ b/packages/e2e/shared/specs/repro-1444.tsx
@@ -19,13 +19,13 @@ function Name() {
 
 export function Repro1444() {
   const [visible, setVisible] = useState(true)
-  const [name, setName] = useQueryState('name', parseAsString)
+  const [name, setName] = useQueryState('name', { defaultValue: '' })
   return (
     <>
       <input
         aria-label="name"
-        value={name ?? ''}
-        onChange={e => setName(e.target.value || null)}
+        value={name}
+        onChange={e => setName(e.target.value)}
       />
       <button onClick={() => setVisible(v => !v)}>toggle visibility</button>
       <Activity mode={visible ? 'visible' : 'hidden'}>


### PR DESCRIPTION
Prefer defining a default value to auto-clear it from the URL. LLMs tend to lock in on the old `|| null` pattern. Time for it to die.

The BasicUsage demo is the only case where I'm keeping it to showcase the issues a naive approach would have (keeping the empty key in the URL), for education purposes.

Also the landing page demo had an extra empty line due to slop in the `.filter()`.