### PR TITLE
fix: render once on mount with a value in the URL

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -265,7 +265,16 @@ jobs:
         run: pnpm install --frozen-lockfile ${{ matrix.next-version != 'latest' && '--filter e2e-next...' || '' }}
       - name: Install Next.js version ${{ matrix.next-version }}
         if: ${{ matrix.next-version != 'local' }}
-        run: pnpm add --filter e2e-next next@${{ matrix.next-version }}
+        # Point the `next` catalog at the tested version so that every
+        # workspace package (nuqs devDependencies included) resolves a single
+        # Next.js copy. With two copies, Turbopack externalizes the one imported
+        # by nuqs under a hashed alias, which splits RouterContext between nuqs
+        # and the app during pages router SSR.
+        env:
+          NEXT_VERSION: ${{ matrix.next-version }}
+        run: |
+          sed -i -E "s/^([[:space:]]+next: ).*$/\1${NEXT_VERSION}/" pnpm-workspace.yaml
+          pnpm install --no-frozen-lockfile ${{ matrix.next-version != 'latest' && '--filter e2e-next...' || '' }}
       - name: Run cacheComponents codemod
         if: ${{ matrix.cache-components }}
         run: pnpm run cacheComponents:codemod

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -265,11 +265,6 @@ jobs:
         run: pnpm install --frozen-lockfile ${{ matrix.next-version != 'latest' && '--filter e2e-next...' || '' }}
       - name: Install Next.js version ${{ matrix.next-version }}
         if: ${{ matrix.next-version != 'local' }}
-        # Point the `next` catalog at the tested version so that every
-        # workspace package (nuqs devDependencies included) resolves a single
-        # Next.js copy. With two copies, Turbopack externalizes the one imported
-        # by nuqs under a hashed alias, which splits RouterContext between nuqs
-        # and the app during pages router SSR.
         env:
           NEXT_VERSION: ${{ matrix.next-version }}
         run: |

--- a/packages/e2e/shared/specs/render-count.spec.ts
+++ b/packages/e2e/shared/specs/render-count.spec.ts
@@ -37,6 +37,15 @@ export function testRenderCount({
         await assertLogCount(logSpy, 'render', expected.mount)
       })
 
+      it(`should render ${times(expected.mount)} on mount with an initial value`, async ({
+        page
+      }) => {
+        using logSpy = setupLogSpy(page)
+        await navigateTo(page, withInitialValue(path))
+        await expect(page.locator('#state')).toHaveText('init')
+        await assertLogCount(logSpy, 'render', expected.mount)
+      })
+
       it(`should then render ${times(expected.update)} on updates`, async ({
         page
       }) => {
@@ -60,4 +69,9 @@ function times(n: number) {
     return 'once'
   }
   return `${n} times`
+}
+
+function withInitialValue(path: string) {
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}test=init`
 }

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -515,6 +515,20 @@ describe('useQueryStates: referential equality', () => {
 })
 
 describe('useQueryStates: rendering & bail-out', () => {
+  it('should render once on mount with an initial value in the URL', async () => {
+    let renderBodyCount = 0
+    function TestComponent() {
+      renderBodyCount++
+      const [{ test }] = useQueryStates({ test: parseAsString })
+      return <div>value: {test}</div>
+    }
+    await render(<TestComponent />, {
+      wrapper: withNuqsTestingAdapter({ searchParams: '?test=init' })
+    })
+    await expect.element(page.getByText('value: init')).toBeInTheDocument()
+    expect(renderBodyCount).toBe(1)
+  })
+
   it('should bail out of rendering the same component when setting to the same value', async () => {
     let renderCount = 0
     function TestComponent() {

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -142,12 +142,11 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // the same pathname, so it still reconciles.
   const committedPathnameRef = useRef<string | null>(null)
   const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
-  // Parsing the initial state also fills the query cache, so the first
-  // render-time reconciliation below hits the cache instead of scheduling
-  // a render-phase state update for an unchanged value.
-  // The cache travels through state rather than being assigned to the ref
-  // in the initializer: that keeps the initializer pure, and under StrictMode
-  // both the ref and the state come from the same (retained) parse.
+  // Seed the query cache from the same parse as the state, so the first
+  // render-time reconcile below hits the cache instead of setting state
+  // during render (one extra render on mount when the URL holds a value).
+  // The initializer returns the cache rather than writing it to a ref:
+  // initializers must stay pure (for StrictMode compatibility).
   const [initial] = useState(() => {
     const cachedQuery: Record<string, Query | null> = {}
     const [, state] = parseMap(

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -125,7 +125,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   )
   const adapter = useAdapter(Object.values(resolvedUrlKeys))
   const initialSearchParams = adapter.searchParams
-  const queryRef = useRef<Record<string, Query | null>>({})
   // Tracks the URL source (search params + queued queries) the internal state
   // was last reconciled against during render. See the reconciliation block below.
   const lastSyncKeyRef = useRef<string | null>(null)
@@ -143,10 +142,25 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // the same pathname, so it still reconciles.
   const committedPathnameRef = useRef<string | null>(null)
   const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
-  const [internalState, setInternalState] = useState<V>(
-    () =>
-      parseMap(keyMap, resolvedUrlKeys, initialSearchParams, queuedQueries)[1]
-  )
+  // Parsing the initial state also fills the query cache, so the first
+  // render-time reconciliation below hits the cache instead of scheduling
+  // a render-phase state update for an unchanged value.
+  // The cache travels through state rather than being assigned to the ref
+  // in the initializer: that keeps the initializer pure, and under StrictMode
+  // both the ref and the state come from the same (retained) parse.
+  const [initial] = useState(() => {
+    const cachedQuery: Record<string, Query | null> = {}
+    const [, state] = parseMap(
+      keyMap,
+      resolvedUrlKeys,
+      initialSearchParams,
+      queuedQueries,
+      cachedQuery
+    )
+    return [state, cachedQuery] as const
+  })
+  const queryRef = useRef(initial[1])
+  const [internalState, setInternalState] = useState<V>(initial[0])
 
   const stateRef = useRef(internalState)
 
@@ -442,7 +456,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   resolvedUrlKeys: Record<string, string>,
   searchParams: URLSearchParams,
   queuedQueries: Record<string, Query | null | undefined>,
-  cachedQuery?: Record<string, Query | null>,
+  cachedQuery: Record<string, Query | null> = {},
   cachedState?: NullableValues<KeyMap>
 ): [hasChanged: boolean, state: NullableValues<KeyMap>] {
   let hasChanged = false
@@ -458,7 +472,6 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
         : queuedQuery
     const cachedStateValue = cachedState && getOwn(cachedState, stateKey)
     if (
-      cachedQuery &&
       cachedStateValue !== undefined &&
       compareQuery(getOwn(cachedQuery, urlKey) ?? fallbackValue, query)
     ) {
@@ -474,9 +487,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
         safeParse(parser.parse, query as string & Array<string>, urlKey)
 
     out[stateKey as keyof KeyMap] = value ?? null
-    if (cachedQuery) {
-      cachedQuery[urlKey] = query
-    }
+    cachedQuery[urlKey] = query
     return out
   }, {} as NullableValues<KeyMap>)
 


### PR DESCRIPTION
The initial parse left the query cache empty, so the first render-time reconciliation missed the cache and set state during render, which made React run the component twice on mount when there was a key in the URL (wasn't covered in render-count tests).

Seeding the cache from the same parse (through a pure useState initializer) removes that extra render.

Tasks:

- [x] De-sloppify the comments