### PR TITLE
perf: trim useQueryStates bundle size

### DIFF
--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -5,6 +5,17 @@ export function isEqual(a: unknown, b: unknown): boolean {
   return a === b
 }
 
+export function compareArrays<T>(
+  a: T[],
+  b: T[],
+  eq: (a: T, b: T) => boolean
+): boolean {
+  return (
+    a === b ||
+    (a.length === b.length && a.every((value, index) => eq(value, b[index]!)))
+  )
+}
+
 export function compareQuery<T extends Query>(
   a: T | null,
   b: T | null

--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -1,5 +1,6 @@
 import type { Query } from './search-params'
 
+// Replaces inline `(a, b) => a === b` calls for bundle size reduction.
 export function isEqual(a: unknown, b: unknown): boolean {
   return a === b
 }

--- a/packages/nuqs/src/lib/compare.ts
+++ b/packages/nuqs/src/lib/compare.ts
@@ -1,5 +1,9 @@
 import type { Query } from './search-params'
 
+export function isEqual(a: unknown, b: unknown): boolean {
+  return a === b
+}
+
 export function compareQuery<T extends Query>(
   a: T | null,
   b: T | null

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -1,5 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { Options } from './defs'
+import { isEqual } from './lib/compare'
 import { safeParse } from './lib/safe-parse'
 
 type Require<T, Keys extends keyof T> = Pick<Required<T>, Keys> & Omit<T, Keys>
@@ -470,11 +471,18 @@ export function parseAsJson<T>(
  * @param itemParser Parser for each individual item in the array
  * @param separator The character to use to separate items (default ',')
  */
+function compareArrays<T>(a: T[], b: T[], eq: (a: T, b: T) => boolean) {
+  return (
+    a === b ||
+    (a.length === b.length && a.every((value, index) => eq(value, b[index]!)))
+  )
+}
+
 export function parseAsArrayOf<ItemType>(
   itemParser: SingleParser<ItemType>,
   separator = ','
 ): SingleParserBuilder<ItemType[]> {
-  const itemEq = itemParser.eq ?? ((a: ItemType, b: ItemType) => a === b)
+  const itemEq = itemParser.eq ?? isEqual
   const encodedSeparator = encodeURIComponent(separator)
   // todo: Handle default item values and make return type non-nullable
   return createParser({
@@ -504,22 +512,14 @@ export function parseAsArrayOf<ItemType>(
           return str.replaceAll(separator, encodedSeparator)
         })
         .join(separator),
-    eq(a, b) {
-      if (a === b) {
-        return true // Referentially stable
-      }
-      if (a.length !== b.length) {
-        return false
-      }
-      return a.every((value, index) => itemEq(value, b[index]!))
-    }
+    eq: (a, b) => compareArrays(a, b, itemEq)
   })
 }
 
 export function parseAsNativeArrayOf<ItemType>(
   itemParser: SingleParser<ItemType>
 ): ReturnType<MultiParserBuilder<ItemType[]>['withDefault']> {
-  const itemEq = itemParser.eq ?? ((a: ItemType, b: ItemType) => a === b)
+  const itemEq = itemParser.eq ?? isEqual
   return createMultiParser({
     parse: query => {
       const parsed = query
@@ -539,15 +539,7 @@ export function parseAsNativeArrayOf<ItemType>(
         return typeof serialized === 'string' ? [serialized] : [...serialized]
       })
     },
-    eq(a, b) {
-      if (a === b) {
-        return true // Referentially stable
-      }
-      if (a.length !== b.length) {
-        return false
-      }
-      return a.every((value, index) => itemEq(value, b[index]!))
-    }
+    eq: (a, b) => compareArrays(a, b, itemEq)
   }).withDefault([])
 }
 

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -153,19 +153,12 @@ export function createParser<T>(
     if (typeof value === 'undefined') {
       return null
     }
-    let str = ''
-    if (Array.isArray(value)) {
-      // Follow the spec:
-      // https://url.spec.whatwg.org/#dom-urlsearchparams-get
-      if (value[0] === undefined) {
-        return null
-      }
-      str = value[0]
+    const isArray = Array.isArray(value)
+    if (isArray && value[0] === undefined) {
+      return null
     }
-    if (typeof value === 'string') {
-      str = value
-    }
-    return safeParse(parser.parse, str)
+    value = isArray ? value[0]! : typeof value === 'string' ? value : ''
+    return safeParse(parser.parse, value)
   }
 
   return {

--- a/packages/nuqs/src/parsers.ts
+++ b/packages/nuqs/src/parsers.ts
@@ -1,6 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { Options } from './defs'
-import { isEqual } from './lib/compare'
+import { compareArrays, isEqual } from './lib/compare'
 import { safeParse } from './lib/safe-parse'
 
 type Require<T, Keys extends keyof T> = Pick<Required<T>, Keys> & Omit<T, Keys>
@@ -471,13 +471,6 @@ export function parseAsJson<T>(
  * @param itemParser Parser for each individual item in the array
  * @param separator The character to use to separate items (default ',')
  */
-function compareArrays<T>(a: T[], b: T[], eq: (a: T, b: T) => boolean) {
-  return (
-    a === b ||
-    (a.length === b.length && a.every((value, index) => eq(value, b[index]!)))
-  )
-}
-
 export function parseAsArrayOf<ItemType>(
   itemParser: SingleParser<ItemType>,
   separator = ','

--- a/packages/nuqs/src/serializer.ts
+++ b/packages/nuqs/src/serializer.ts
@@ -1,4 +1,5 @@
 import type { Nullable, Options, UrlKeys } from './defs'
+import { isEqual } from './lib/compare'
 import { write } from './lib/search-params'
 import { renderQueryString } from './lib/url-encoding'
 import { getOwn, getUrlKey } from './lib/url-keys'
@@ -92,7 +93,7 @@ export function createSerializer<
       const isMatchingDefault =
         parser.defaultValue !== undefined &&
         value !== null &&
-        (parser.eq ?? ((a, b) => a === b))(value, parser.defaultValue)
+        (parser.eq ?? isEqual)(value, parser.defaultValue)
 
       if (
         value === null ||

--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -135,6 +135,24 @@ describe('useQueryState: referential equality', () => {
     const [, setState3] = result.current
     expect(setState1).toBe(setState3)
   })
+
+  it('keeps an equal default value reference when hook options change', async () => {
+    const useTestHook = (history: 'replace' | 'push' = 'replace') =>
+      useQueryState(
+        'test',
+        parseAsNativeArrayOf(parseAsString)
+          .withDefault([])
+          .withOptions({ history })
+      )
+    const { result, rerender } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter()
+    })
+    const defaultValue = result.current[0]
+
+    await rerender('push')
+
+    expect(result.current[0]).toBe(defaultValue)
+  })
 })
 
 describe('useQueryState: clearOnDefault', () => {

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -197,21 +197,24 @@ export function useQueryState<T = string>(
     defaultValue?: T
   } = {}
 ) {
-  // The single parser carries the options too: parser-level and hook-level
-  // options resolve to the same values here, so precedence is unaffected.
-  // `startTransition` stays hook-level: `useQueryStates` compares it by
-  // identity per parser (the other options compare structurally), so an
-  // unstable callback in the parser would invalidate the stable key map and the
-  // returned state object on every render.
-  const { startTransition, ...parser } = options
+  const {
+    parse = (x: any) => x as unknown as T,
+    type,
+    serialize,
+    eq,
+    defaultValue,
+    ...hookOptions
+  } = options
+  const parser = {
+    parse,
+    type,
+    serialize,
+    eq,
+    defaultValue
+  } as GenericParser<T>
   const [{ [key]: state }, setState] = useQueryStates(
-    {
-      [key]: {
-        ...parser,
-        parse: parser.parse ?? ((x: any) => x as unknown as T)
-      } as GenericParser<T>
-    },
-    options
+    { [key]: parser },
+    hookOptions
   )
   const update = useCallback(
     (stateUpdater: React.SetStateAction<T | null>, callOptions: Options = {}) =>

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -197,18 +197,20 @@ export function useQueryState<T = string>(
     defaultValue?: T
   } = {}
 ) {
-  const { parse, type, serialize, eq, defaultValue, ...hookOptions } = options
+  // The single parser carries the options too: parser-level and hook-level
+  // options resolve to the same values here, so precedence is unaffected.
+  // Only JSON-serialisable options may go through the spread: `useQueryStates`
+  // compares key map entries with `JSON.stringify`, which drops functions, so
+  // function-valued options like `startTransition` must stay out of the parser.
+  const { startTransition, ...parser } = options
   const [{ [key]: state }, setState] = useQueryStates(
     {
       [key]: {
-        parse: parse ?? ((x: any) => x as unknown as T),
-        type,
-        serialize,
-        eq,
-        defaultValue
+        ...parser,
+        parse: parser.parse ?? ((x: any) => x as unknown as T)
       } as GenericParser<T>
     },
-    hookOptions
+    options
   )
   const update = useCallback(
     (stateUpdater: React.SetStateAction<T | null>, callOptions: Options = {}) =>

--- a/packages/nuqs/src/useQueryState.ts
+++ b/packages/nuqs/src/useQueryState.ts
@@ -199,9 +199,10 @@ export function useQueryState<T = string>(
 ) {
   // The single parser carries the options too: parser-level and hook-level
   // options resolve to the same values here, so precedence is unaffected.
-  // Only JSON-serialisable options may go through the spread: `useQueryStates`
-  // compares key map entries with `JSON.stringify`, which drops functions, so
-  // function-valued options like `startTransition` must stay out of the parser.
+  // `startTransition` stays hook-level: `useQueryStates` compares it by
+  // identity per parser (the other options compare structurally), so an
+  // unstable callback in the parser would invalidate the stable key map and the
+  // returned state object on every render.
   const { startTransition, ...parser } = options
   const [{ [key]: state }, setState] = useQueryStates(
     {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -923,6 +923,24 @@ describe('useQueryStates: dynamic keys', () => {
     expect(result.current[0]).toStrictEqual({ a: null, b: null, d: null })
   })
 
+  it('moves the cross-hook subscriptions when the key set changes', async () => {
+    const useTestHook = (keys: string[] = ['a']) => ({
+      dynamic: useQueryStates(
+        Object.fromEntries(keys.map(key => [key, parseAsString]))
+      ),
+      a: useQueryStates({ a: parseAsString }),
+      b: useQueryStates({ b: parseAsString })
+    })
+    const { result, rerender, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({ searchParams: '' })
+    })
+    await rerender(['b'])
+    await act(() => result.current.a[1]({ a: 'stale' }))
+    expect(result.current.dynamic[0]).toStrictEqual({ b: null })
+    await act(() => result.current.b[1]({ b: 'live' }))
+    expect(result.current.dynamic[0]).toStrictEqual({ b: 'live' })
+  })
+
   it('supports dynamic keys with remapping', async () => {
     const useTestHook = (keys: [string, string] = ['a', 'b']) =>
       useQueryStates(
@@ -1238,6 +1256,37 @@ describe('useQueryStates: update sequencing', () => {
     expect(onUrlUpdate).toHaveBeenCalledTimes(2)
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?b=pass')
     expect(onUrlUpdate.mock.calls[1]![0].queryString).toEqual('?a=debounced')
+  })
+
+  it('flushes the throttled key and debounces the other in a single update', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    // The adapter re-renders on each URL update when it has memory,
+    // so the queue reset must not run on render.
+    resetQueues()
+    const { result, act } = await renderHook(
+      () =>
+        useQueryStates({
+          a: parseAsString.withOptions({ limitUrlUpdates: debounce(100) }),
+          b: parseAsString
+        }),
+      {
+        wrapper: withNuqsTestingAdapter({
+          onUrlUpdate,
+          rateLimitFactor: 1,
+          hasMemory: true,
+          resetUrlUpdateQueueOnMount: false
+        })
+      }
+    )
+    let p: Promise<URLSearchParams> | undefined = undefined
+    await act(async () => {
+      p = result.current[1]({ a: 'slow', b: 'fast' })
+      await vi.waitFor(() => expect(onUrlUpdate).toHaveBeenCalledOnce())
+    })
+    expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?b=fast')
+    await expect(p).resolves.toEqual(new URLSearchParams('?b=fast&a=slow'))
+    expect(onUrlUpdate).toHaveBeenCalledTimes(2)
+    expect(onUrlUpdate.mock.calls[1]![0].queryString).toEqual('?b=fast&a=slow')
   })
 
   it('does flush when pushing throttled updates', async () => {

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -123,7 +123,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       ),
     [stateKeys, JSON.stringify(urlKeys)]
   )
-  const adapter = useAdapter(Object.values(resolvedUrlKeys))
+  const urlKeyList = Object.values(resolvedUrlKeys)
+  const adapter = useAdapter(urlKeyList)
   const initialSearchParams = adapter.searchParams
   // Tracks the URL source (search params + queued queries) the internal state
   // was last reconciled against during render. See the reconciliation block below.
@@ -141,7 +142,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // render and skip the reconcile (#1273). A genuine `<Activity>` reveal keeps
   // the same pathname, so it still reconciles.
   const committedPathnameRef = useRef<string | null>(null)
-  const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
+  const queuedQueries = useQueuedQueries(urlKeyList)
   // Seed the query cache from the same parse as the state, so the first
   // render-time reconcile below hits the cache instead of setting state
   // during render (one extra render on mount when the URL holds a value).
@@ -169,10 +170,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // (optimistic) updates which don't immediately alter the URL source.
   const getSearchParamsSyncKey = (searchParams: URLSearchParams) =>
     JSON.stringify([
-      Object.values(resolvedUrlKeys).map(key => [
-        key,
-        searchParams.getAll(key)
-      ]),
+      urlKeyList.map(key => [key, searchParams.getAll(key)]),
       queuedQueries
     ])
   const searchParamsSyncKey = getSearchParamsSyncKey(initialSearchParams)
@@ -207,51 +205,42 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // render an outgoing/incoming page against the other route's in-flight URL,
   // and adopting it there produces cross-page renders React discards (#1293).
   const keysChanged =
-    Object.keys(queryRef.current).join('&') !==
-    Object.values(resolvedUrlKeys).join('&')
+    Object.keys(queryRef.current).join('&') !== urlKeyList.join('&')
   // `committedPathnameRef` is only ever assigned from the client,
   // so a null value covers both SSR and the first client render.
   const onCommittedPathname =
     committedPathnameRef.current === null ||
     committedPathnameRef.current === (adapter.pathname ?? location.pathname)
-  let didReconcileState = false
-  if (
-    keysChanged ||
-    (onCommittedPathname && lastSyncKeyRef.current !== searchParamsSyncKey)
-  ) {
+  if (keysChanged) {
     lastSyncKeyRef.current = searchParamsSyncKey
-    didReconcileState = reconcile()
-    if (keysChanged) {
-      queryRef.current = Object.fromEntries(
-        Object.entries(resolvedUrlKeys).map(([key, urlKey]) => {
-          const parser = keyMap[key]
-          return [
-            urlKey,
-            parser?.type === 'multi'
-              ? initialSearchParams.getAll(urlKey)
-              : (initialSearchParams.get(urlKey) ?? null)
-          ]
-        })
-      )
+    reconcile()
+    queryRef.current = Object.fromEntries(
+      Object.entries(resolvedUrlKeys).map(([key, urlKey]) => [
+        urlKey,
+        keyMap[key]?.type === 'multi'
+          ? initialSearchParams.getAll(urlKey)
+          : initialSearchParams.get(urlKey)
+      ])
+    )
+  } else {
+    // Skipped on key-set changes: `stateRef` may still describe the previous
+    // key map, so restoring from it would resurrect removed keys.
+    let didReconcileState = false
+    if (onCommittedPathname && lastSyncKeyRef.current !== searchParamsSyncKey) {
+      lastSyncKeyRef.current = searchParamsSyncKey
+      didReconcileState = reconcile()
     }
-  }
-  // A key-set change initializes from the current URL source; `stateRef` may
-  // still describe the previous key map and must not be restored.
-  if (
-    !keysChanged &&
-    !didReconcileState &&
-    internalState !== stateRef.current
-  ) {
-    // Recover a render-phase state update lost with an abandoned render or a
-    // concurrent rebase whose URL source is already reflected in the cache.
-    if (onCommittedPathname) {
-      setInternalState(stateRef.current)
-    } else if (
-      adapter.pathname === undefined &&
-      lastSyncKeyRef.current ===
-        getSearchParamsSyncKey(new URLSearchParams(location.search))
-    ) {
-      setInternalState(stateRef.current)
+    if (!didReconcileState && internalState !== stateRef.current) {
+      // Recover a render-phase state update lost with an abandoned render or a
+      // concurrent rebase whose URL source is already reflected in the cache.
+      if (
+        onCommittedPathname ||
+        (adapter.pathname === undefined &&
+          lastSyncKeyRef.current ===
+            getSearchParamsSyncKey(new URLSearchParams(location.search)))
+      ) {
+        setInternalState(stateRef.current)
+      }
     }
   }
 
@@ -272,14 +261,10 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
   // Sync all hooks together & with external URL changes
   useEffect(() => {
-    const handlers = Object.keys(keyMap).reduce(
-      (handlers, stateKey) => {
-        handlers[stateKey as keyof KeyMap] = ({
-          state,
-          query
-        }: CrossHookSyncPayload) => {
+    const subscriptions = Object.entries(resolvedUrlKeys).map(
+      ([stateKey, urlKey]) => {
+        const handler = ({ state, query }: CrossHookSyncPayload) => {
           setInternalState(currentState => {
-            const urlKey = resolvedUrlKeys[stateKey]!
             if (Object.is(currentState[stateKey] ?? null, state)) {
               debug(
                 2,
@@ -312,39 +297,36 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             return stateRef.current
           })
         }
-        return handlers
-      },
-      {} as Record<keyof KeyMap, (payload: CrossHookSyncPayload) => void>
+        debug(4, hookId, urlKey, stateKeys)
+        emitter.on(urlKey, handler)
+        return [urlKey, handler] as const
+      }
     )
-
-    for (const stateKey of Object.keys(keyMap)) {
-      const urlKey = resolvedUrlKeys[stateKey]!
-      debug(4, hookId, urlKey, stateKeys)
-      emitter.on(urlKey, handlers[stateKey]!)
-    }
     return () => {
-      for (const stateKey of Object.keys(keyMap)) {
-        const urlKey = resolvedUrlKeys[stateKey]!
+      for (const [urlKey, handler] of subscriptions) {
         debug(5, hookId, urlKey, stateKeys)
-        emitter.off(urlKey, handlers[stateKey])
+        emitter.off(urlKey, handler)
       }
     }
   }, [stateKeys, resolvedUrlKeys])
 
   const update = useCallback<SetValues<KeyMap>>(
     (stateUpdater, callOptions = {}) => {
-      const nullMap = Object.fromEntries(
-        Object.keys(stableKeyMap).map(key => [key, null])
-      ) as Nullable<KeyMap>
-      const newState: Partial<Nullable<KeyMap>> =
+      const requestedState =
         typeof stateUpdater === 'function'
-          ? (stateUpdater(applyDefaultValues(stateRef.current, stableKeyMap)) ??
-            nullMap)
-          : (stateUpdater ?? nullMap)
+          ? stateUpdater(applyDefaultValues(stateRef.current, stableKeyMap))
+          : stateUpdater
+      // A null update clears every key of the map.
+      const newState: Partial<Nullable<KeyMap>> =
+        requestedState ??
+        (Object.fromEntries(
+          Object.keys(stableKeyMap).map(key => [key, null])
+        ) as Nullable<KeyMap>)
       debug(6, hookId, stateKeys, newState)
       let returnedPromise: Promise<URLSearchParams> | undefined = undefined
       let maxDebounceTime = 0
-      let doFlush = false
+      // One abort per key sent to the throttle queue, so a non-empty list
+      // also means the queue has something to flush.
       const debounceAborts: Array<
         (p: Promise<URLSearchParams>) => Promise<URLSearchParams>
       > = []
@@ -409,14 +391,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             throttleMs
           debounceAborts.push(debounceController.abort(urlKey))
           globalThrottleQueue.push(update, timeMs)
-          doFlush = true
         }
       }
       // We need to flush the throttle queue, but we may have a pending
       // debounced update that will resolve afterwards.
       const globalPromise = debounceAborts.reduce(
         (previous, fn) => fn(previous),
-        doFlush
+        debounceAborts.length
           ? globalThrottleQueue.flush(adapter, processUrlSearchParams)
           : globalThrottleQueue.getPendingPromise(adapter)
       )
@@ -456,20 +437,22 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   searchParams: URLSearchParams,
   queuedQueries: Record<string, Query | null | undefined>,
   cachedQuery: Record<string, Query | null> = {},
-  cachedState?: NullableValues<KeyMap>
+  cachedState: Partial<NullableValues<KeyMap>> = {}
 ): [hasChanged: boolean, state: NullableValues<KeyMap>] {
   let hasChanged = false
   const state = Object.entries(keyMap).reduce((out, [stateKey, parser]) => {
     const urlKey = resolvedUrlKeys[stateKey]!
     const queuedQuery = getOwn(queuedQueries, urlKey)
+    // `getAll` returns an empty array and `get` returns null when the key is
+    // absent, so URL reads need no fallback; the cached query does (below).
     const fallbackValue = parser.type === 'multi' ? [] : null
     const query =
       queuedQuery === undefined
-        ? ((parser.type === 'multi'
-            ? searchParams.getAll(urlKey)
-            : searchParams.get(urlKey)) ?? fallbackValue)
+        ? parser.type === 'multi'
+          ? searchParams.getAll(urlKey)
+          : searchParams.get(urlKey)
         : queuedQuery
-    const cachedStateValue = cachedState && getOwn(cachedState, stateKey)
+    const cachedStateValue = getOwn(cachedState, stateKey)
     if (
       cachedStateValue !== undefined &&
       compareQuery(getOwn(cachedQuery, urlKey) ?? fallbackValue, query)
@@ -491,12 +474,10 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   }, {} as NullableValues<KeyMap>)
 
   if (!hasChanged) {
-    // check that keyMap keys have not changed
-    const keyMapKeys = Object.keys(keyMap)
-    const cachedStateKeys = Object.keys(cachedState ?? {})
-    hasChanged =
-      keyMapKeys.length !== cachedStateKeys.length ||
-      keyMapKeys.some(key => !cachedStateKeys.includes(key))
+    // Check that keyMap keys have not changed. `state` holds every key of the
+    // key map, and each one hit the cache above, so it is present in the cached
+    // state too: the key sets can only differ by removed keys.
+    hasChanged = Object.keys(state).length !== Object.keys(cachedState).length
   }
 
   return [hasChanged, state]

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -224,7 +224,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     )
   } else {
     // Skipped on key-set changes: `stateRef` may still describe the previous
-    // key map, so restoring from it would resurrect removed keys.
+    // key map, so restoring from it would bring back removed keys.
     let didReconcileState = false
     if (onCommittedPathname && lastSyncKeyRef.current !== searchParamsSyncKey) {
       lastSyncKeyRef.current = searchParamsSyncKey
@@ -316,7 +316,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         typeof stateUpdater === 'function'
           ? stateUpdater(applyDefaultValues(stateRef.current, stableKeyMap))
           : stateUpdater
-      // A null update clears every key of the map.
+      // `null` (or an updater returning `null`) clears every key of the map.
       const newState: Partial<Nullable<KeyMap>> =
         requestedState ??
         (Object.fromEntries(
@@ -474,9 +474,9 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   }, {} as NullableValues<KeyMap>)
 
   if (!hasChanged) {
-    // Check that keyMap keys have not changed. `state` holds every key of the
-    // key map, and each one hit the cache above, so it is present in the cached
-    // state too: the key sets can only differ by removed keys.
+    // Detect removed keys.
+    // Every key of the map hit the cache above, so it exists in the cached state:
+    // the key sets can only differ by keys that were removed.
     hasChanged = Object.keys(state).length !== Object.keys(cachedState).length
   }
 

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -5,7 +5,7 @@ import {
   useAdapterProcessUrlSearchParams
 } from './adapters/lib/context'
 import type { Nullable, Options, UrlKeys } from './defs'
-import { compareQuery } from './lib/compare'
+import { compareQuery, isEqual } from './lib/compare'
 import { debug } from './lib/debug'
 import { debounceController, useQueuedQueries } from './lib/queues/debounce'
 import { defaultRateLimit } from './lib/queues/rate-limiting'
@@ -261,32 +261,15 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
 
   // Sync all hooks together & with external URL changes
   useEffect(() => {
-    const subscriptions = Object.entries(resolvedUrlKeys).map(
-      ([stateKey, urlKey]) => {
-        const handler = ({ state, query }: CrossHookSyncPayload) => {
-          setInternalState(currentState => {
-            if (Object.is(currentState[stateKey] ?? null, state)) {
-              debug(
-                2,
-                hookId,
-                stateKeys,
-                urlKey,
-                state,
-                keyMap[stateKey]?.defaultValue,
-                stateRef.current
-              )
-              // bail out by returning the current state
-              return currentState
-            }
-            // Note: cannot mutate in-place, the object ref must change
-            // for the subsequent setState to pick it up.
-            stateRef.current = {
-              ...stateRef.current,
-              [stateKey as keyof KeyMap]: state
-            }
-            queryRef.current[urlKey] = query
+    const subscriptions: Array<
+      readonly [string, (payload: CrossHookSyncPayload) => void]
+    > = []
+    for (const [stateKey, urlKey] of Object.entries(resolvedUrlKeys)) {
+      const handler = ({ state, query }: CrossHookSyncPayload) => {
+        setInternalState(currentState => {
+          if (Object.is(currentState[stateKey] ?? null, state)) {
             debug(
-              3,
+              2,
               hookId,
               stateKeys,
               urlKey,
@@ -294,14 +277,32 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
               keyMap[stateKey]?.defaultValue,
               stateRef.current
             )
-            return stateRef.current
-          })
-        }
-        debug(4, hookId, urlKey, stateKeys)
-        emitter.on(urlKey, handler)
-        return [urlKey, handler] as const
+            // bail out by returning the current state
+            return currentState
+          }
+          // Note: cannot mutate in-place, the object ref must change
+          // for the subsequent setState to pick it up.
+          stateRef.current = {
+            ...stateRef.current,
+            [stateKey as keyof KeyMap]: state
+          }
+          queryRef.current[urlKey] = query
+          debug(
+            3,
+            hookId,
+            stateKeys,
+            urlKey,
+            state,
+            keyMap[stateKey]?.defaultValue,
+            stateRef.current
+          )
+          return stateRef.current
+        })
       }
-    )
+      debug(4, hookId, urlKey, stateKeys)
+      emitter.on(urlKey, handler)
+      subscriptions.push([urlKey, handler] as const)
+    }
     return () => {
       for (const [urlKey, handler] of subscriptions) {
         debug(5, hookId, urlKey, stateKeys)
@@ -342,7 +343,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             clearOnDefault) &&
           value !== null &&
           parser.defaultValue !== undefined &&
-          (parser.eq ?? ((a, b) => a === b))(value, parser.defaultValue)
+          (parser.eq ?? isEqual)(value, parser.defaultValue)
         ) {
           value = null
         }
@@ -395,12 +396,12 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       }
       // We need to flush the throttle queue, but we may have a pending
       // debounced update that will resolve afterwards.
-      const globalPromise = debounceAborts.reduce(
-        (previous, fn) => fn(previous),
-        debounceAborts.length
-          ? globalThrottleQueue.flush(adapter, processUrlSearchParams)
-          : globalThrottleQueue.getPendingPromise(adapter)
-      )
+      let globalPromise = debounceAborts.length
+        ? globalThrottleQueue.flush(adapter, processUrlSearchParams)
+        : globalThrottleQueue.getPendingPromise(adapter)
+      for (const abort of debounceAborts) {
+        globalPromise = abort(globalPromise)
+      }
       return returnedPromise ?? globalPromise
     },
     [

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -473,12 +473,10 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
     return out
   }, {} as NullableValues<KeyMap>)
 
-  if (!hasChanged) {
-    // Detect removed keys.
-    // Every key of the map hit the cache above, so it exists in the cached state:
-    // the key sets can only differ by keys that were removed.
-    hasChanged = Object.keys(state).length !== Object.keys(cachedState).length
-  }
+  // Detect removed keys.
+  // Every key of the map hit the cache above, so it exists in the cached state:
+  // the key sets can only differ by keys that were removed.
+  hasChanged ||= Object.keys(state).length !== Object.keys(cachedState).length
 
   return [hasChanged, state]
 }


### PR DESCRIPTION
Stacked on #1553.

The render-count fix in #1553 added 40 bytes to the client bundle and left almost no headroom on the size budget (5960 of 6000 bytes). This PR gets the margin back with no change in behaviour.

The changes come from a bake-off of four agents that each restructured a part of `useQueryStates` and measured every edit with size-limit. Only edits that shrank the brotli output survived: hoisting repeated `Object.values(resolvedUrlKeys)`, building the cross-hook subscriptions as `[urlKey, handler]` pairs, a lazy null map in `update()`, a length-only key check in `parseMap`, and letting `useQueryState` pass its options straight through.