### PR TITLE
fix: recover state after discarded navigation render

### DIFF
--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1,12 +1,14 @@
 import React, {
   createElement,
+  Suspense,
   useEffect,
   useState,
   type ReactNode
 } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, renderHook } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
+import { createReactRouterBasedAdapter } from './adapters/lib/react-router'
 import {
   NullDetector,
   useFakeLoadingState
@@ -1674,5 +1676,76 @@ describe('useQueryStates: edge cases & repros', () => {
     await expect
       .element(page.getByTestId('null-detector'))
       .toHaveTextContent('pass')
+  })
+})
+
+describe('useQueryStates: discarded renders', () => {
+  const { NuqsAdapter, useOptimisticSearchParams } =
+    createReactRouterBasedAdapter({
+      adapter: 'test-discarded-render',
+      useNavigate: () => () => {},
+      useSearchParams: (initial): [URLSearchParams, {}] => [initial, {}]
+    })
+
+  const originalUrl = location.href
+
+  afterEach(() => {
+    history.replaceState(null, '', originalUrl)
+  })
+
+  it('recovers after an external navigation discards a render', async () => {
+    const hold = new Promise<never>(() => {})
+
+    function Value() {
+      const [value] = useQueryState('test')
+      return <div data-testid="value">{String(value)}</div>
+    }
+
+    function SuspendOnIncomingParams() {
+      const searchParams = useOptimisticSearchParams()
+      if (searchParams.get('test') === 'incoming') {
+        throw hold
+      }
+      return null
+    }
+
+    function App() {
+      const [count, setCount] = useState(0)
+      return (
+        <NuqsAdapter>
+          <button onClick={() => setCount(count => count + 1)}>
+            Count ({count})
+          </button>
+          <Value />
+          <Suspense fallback={null}>
+            <SuspendOnIncomingParams />
+          </Suspense>
+        </NuqsAdapter>
+      )
+    }
+
+    history.replaceState(null, '', '/page?test=old')
+    render(<App />)
+    await expect.element(page.getByTestId('value')).toHaveTextContent('old')
+
+    history.pushState(null, '', '/page?test=incoming')
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await expect.element(page.getByTestId('value')).toHaveTextContent('old')
+
+    history.pushState(null, '', '/elsewhere?test=incoming')
+
+    const user = userEvent.setup()
+    const count = page.getByRole('button', { name: /Count/ })
+    await user.click(count)
+    await expect.element(count).toHaveTextContent('Count (1)')
+    await expect
+      .element(page.getByTestId('value'), { timeout: 2000 })
+      .toHaveTextContent('incoming')
+
+    await user.click(count)
+    await expect.element(count).toHaveTextContent('Count (2)')
+    await expect
+      .element(page.getByTestId('value'))
+      .toHaveTextContent('incoming')
   })
 })

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1,12 +1,15 @@
 import React, {
   createElement,
+  Suspense,
   useEffect,
   useState,
   type ReactNode
 } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, renderHook } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
+import { historyUpdateMarker } from './adapters/lib/patch-history'
+import { createReactRouterBasedAdapter } from './adapters/lib/react-router'
 import {
   NullDetector,
   useFakeLoadingState
@@ -1674,5 +1677,73 @@ describe('useQueryStates: edge cases & repros', () => {
     await expect
       .element(page.getByTestId('null-detector'))
       .toHaveTextContent('pass')
+  })
+})
+
+describe('useQueryStates: discarded renders', () => {
+  const { NuqsAdapter, useOptimisticSearchParams } =
+    createReactRouterBasedAdapter({
+      adapter: 'test-discarded-render',
+      useNavigate: () => () => {},
+      useSearchParams: (initial): [URLSearchParams, {}] => [initial, {}]
+    })
+
+  const originalUrl = location.href
+
+  afterEach(() => {
+    history.replaceState(null, historyUpdateMarker, originalUrl)
+  })
+
+  it('recovers after an external navigation discards a render', async () => {
+    const hold = new Promise<never>(() => {})
+
+    function Value() {
+      const [value] = useQueryState('test', parseAsString)
+      return <div data-testid="value">{String(value)}</div>
+    }
+
+    function SuspendOnIncomingParams() {
+      const searchParams = useOptimisticSearchParams()
+      if (searchParams.get('test') === 'incoming') {
+        throw hold
+      }
+      return null
+    }
+
+    function App() {
+      const [pokes, poke] = useState(0)
+      return (
+        <NuqsAdapter>
+          <button onClick={() => poke(count => count + 1)}>
+            Poke ({pokes})
+          </button>
+          <Value />
+          <Suspense fallback={null}>
+            <SuspendOnIncomingParams />
+          </Suspense>
+        </NuqsAdapter>
+      )
+    }
+
+    history.replaceState(null, historyUpdateMarker, '/page?test=old')
+    render(<App />)
+    await expect.element(page.getByTestId('value')).toHaveTextContent('old')
+
+    history.pushState(null, '', '/page?test=incoming')
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await expect.element(page.getByTestId('value')).toHaveTextContent('old')
+
+    history.pushState(null, '', '/elsewhere?test=incoming')
+
+    const user = userEvent.setup()
+    await user.click(page.getByRole('button', { name: /Poke/ }))
+    await expect
+      .element(page.getByTestId('value'), { timeout: 2000 })
+      .toHaveTextContent('incoming')
+
+    await user.click(page.getByRole('button', { name: /Poke/ }))
+    await expect
+      .element(page.getByTestId('value'))
+      .toHaveTextContent('incoming')
   })
 })

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -200,6 +200,20 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const onCommittedPathname =
     committedPathnameRef.current === null ||
     committedPathnameRef.current === (adapter.pathname ?? location.pathname)
+  const locationSearchParams =
+    typeof location === 'undefined'
+      ? null
+      : new URLSearchParams(location.search)
+  const lastSyncMatchesLocation =
+    locationSearchParams !== null &&
+    lastSyncKeyRef.current ===
+      JSON.stringify([
+        Object.values(resolvedUrlKeys).map(key => [
+          key,
+          locationSearchParams.getAll(key)
+        ]),
+        queuedQueries
+      ])
   let didReconcileState = false
   if (
     keysChanged ||
@@ -226,7 +240,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   if (
     !keysChanged &&
     !didReconcileState &&
-    onCommittedPathname &&
+    (onCommittedPathname ||
+      (adapter.pathname === undefined && lastSyncMatchesLocation)) &&
     internalState !== stateRef.current
   ) {
     // Recover a render-phase state update lost with an abandoned render or a

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -145,8 +145,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const queuedQueries = useQueuedQueries(Object.values(resolvedUrlKeys))
   const [internalState, setInternalState] = useState<V>(
     () =>
-      parseMap(keyMap, resolvedUrlKeys, initialSearchParams, queuedQueries)
-        .state
+      parseMap(keyMap, resolvedUrlKeys, initialSearchParams, queuedQueries)[1]
   )
 
   const stateRef = useRef(internalState)
@@ -155,17 +154,19 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   // Mirrors the dependencies of the URL sync effect below so that render-time
   // reconciliation reacts to the same external changes, and never to internal
   // (optimistic) updates which don't immediately alter the URL source.
-  const searchParamsSyncKey = JSON.stringify([
-    Object.values(resolvedUrlKeys).map(key => [
-      key,
-      initialSearchParams.getAll(key)
-    ]),
-    queuedQueries
-  ])
+  const getSearchParamsSyncKey = (searchParams: URLSearchParams) =>
+    JSON.stringify([
+      Object.values(resolvedUrlKeys).map(key => [
+        key,
+        searchParams.getAll(key)
+      ]),
+      queuedQueries
+    ])
+  const searchParamsSyncKey = getSearchParamsSyncKey(initialSearchParams)
   // Adopts the current URL value into the internal state when it has changed.
   // Used both during render (below) and from the effect backstop further down.
   const reconcile = () => {
-    const { state, hasChanged } = parseMap(
+    const [hasChanged, state] = parseMap(
       keyMap,
       resolvedUrlKeys,
       initialSearchParams,
@@ -200,20 +201,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const onCommittedPathname =
     committedPathnameRef.current === null ||
     committedPathnameRef.current === (adapter.pathname ?? location.pathname)
-  const locationSearchParams =
-    typeof location === 'undefined'
-      ? null
-      : new URLSearchParams(location.search)
-  const lastSyncMatchesLocation =
-    locationSearchParams !== null &&
-    lastSyncKeyRef.current ===
-      JSON.stringify([
-        Object.values(resolvedUrlKeys).map(key => [
-          key,
-          locationSearchParams.getAll(key)
-        ]),
-        queuedQueries
-      ])
   let didReconcileState = false
   if (
     keysChanged ||
@@ -240,13 +227,19 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   if (
     !keysChanged &&
     !didReconcileState &&
-    (onCommittedPathname ||
-      (adapter.pathname === undefined && lastSyncMatchesLocation)) &&
     internalState !== stateRef.current
   ) {
     // Recover a render-phase state update lost with an abandoned render or a
     // concurrent rebase whose URL source is already reflected in the cache.
-    setInternalState(stateRef.current)
+    if (onCommittedPathname) {
+      setInternalState(stateRef.current)
+    } else if (
+      adapter.pathname === undefined &&
+      lastSyncKeyRef.current ===
+        getSearchParamsSyncKey(new URLSearchParams(location.search))
+    ) {
+      setInternalState(stateRef.current)
+    }
   }
 
   // Backstop for the render-time reconciliation above: covers external changes
@@ -451,10 +444,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
   queuedQueries: Record<string, Query | null | undefined>,
   cachedQuery?: Record<string, Query | null>,
   cachedState?: NullableValues<KeyMap>
-): {
-  state: NullableValues<KeyMap>
-  hasChanged: boolean
-} {
+): [hasChanged: boolean, state: NullableValues<KeyMap>] {
   let hasChanged = false
   const state = Object.entries(keyMap).reduce((out, [stateKey, parser]) => {
     const urlKey = resolvedUrlKeys[stateKey]!
@@ -499,7 +489,7 @@ function parseMap<KeyMap extends UseQueryStatesKeysMap>(
       keyMapKeys.some(key => !cachedStateKeys.includes(key))
   }
 
-  return { state, hasChanged }
+  return [hasChanged, state]
 }
 
 function applyDefaultValues<KeyMap extends UseQueryStatesKeysMap>(


### PR DESCRIPTION
## Summary

- recover query state after React discards a navigation render while retaining render-phase refs
- preserve pathname-gated reconciliation without adding an effect or an extra committed render
- add a React regression test covering the stale committed value

## Root cause

Render-time reconciliation advances the URL-source and state refs before scheduling a state update. React can discard that update while the ref mutations survive, leaving later renders with a stale committed state and no apparent adapter change to reconcile.

Closes #1557