### PR TITLE
test: verify reduced mutation debt

### DIFF
--- a/packages/nuqs/src/lib/compare.test.ts
+++ b/packages/nuqs/src/lib/compare.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from 'vitest'
 import type { Query } from './search-params'
-import { compareQuery } from './compare'
+import { compareArrays, compareQuery } from './compare'
 
 describe('compare', () => {
+  it('short-circuits array comparison for the same reference', () => {
+    const values = ['a']
+    let comparisons = 0
+
+    expect(
+      compareArrays(values, values, () => {
+        comparisons++
+        return false
+      })
+    ).toBe(true)
+    expect(comparisons).toBe(0)
+  })
+
   describe('strings', () => {
     it('should return true for equal values', () => {
       expect(compareQuery('a', 'a')).toBe(true)


### PR DESCRIPTION
## Purpose

Add a focused regression test for `compareArrays`: comparing the same array reference must return immediately without invoking the element comparator.

This also verifies #1560's relative mutation-debt path on a real stacked change.

## GitHub validation

- [x] mutation relevance detected the test change
- [x] exact stacked base measured
- [x] mutation inputs accepted as comparable
- [x] mutation debt decreased by one: **117 → 116**
- [x] complete `Mutation debt` job finished in **3m37s**

Run: https://github.com/47ng/nuqs/actions/runs/33338969984
