### PR TITLE
fix: preserve shallow replaces during pending deep pushes

### DIFF
--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -50,6 +50,32 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
 
+  it('keeps a shallow replace made while a deep push is pending', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    await page.locator('#push-then-shallow-replace').click()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#shallow-state')).toHaveText('pass')
+    await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#state')).toHaveText('pass')
+    await expect(page.locator('#shallow-state')).toHaveText('pass')
+    await expect(page.locator('#navigation-type')).toHaveText('PUSH')
+    await page.goBack()
+    await expect(page.locator('#state')).toHaveText('init')
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+  })
+
   it('repairs the optimistic entry when Back runs before the commit', async ({
     page
   }) => {

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -12,12 +12,18 @@ export function Repro1563({ useNavigationType }: Repro1563Props) {
     shallow: false
   })
   const [, setOther] = useQueryState('other', { shallow: false })
+  const [shallow, setShallow] = useQueryState('shallow')
   const [, setNote] = useQueryState('note')
   const navigationType = useNavigationType()
   const pushThenReplace = () => {
     setState('pass')
     setOther('pass', { limitUrlUpdates: debounce(100) })
   }
+  const pushThenShallowReplace = () => {
+    setState('pass')
+    setShallow('pass', { limitUrlUpdates: debounce(100) })
+  }
+
   return (
     <>
       <button id="push" onClick={() => setState('pass')}>
@@ -26,6 +32,9 @@ export function Repro1563({ useNavigationType }: Repro1563Props) {
       <button id="push-then-replace" onClick={pushThenReplace}>
         Push then replace
       </button>
+      <button id="push-then-shallow-replace" onClick={pushThenShallowReplace}>
+        Push then shallow replace
+      </button>
       <button id="replace" onClick={() => setOther('pass')}>
         Replace
       </button>
@@ -33,6 +42,7 @@ export function Repro1563({ useNavigationType }: Repro1563Props) {
         Shallow replace
       </button>
       <pre id="state">{state}</pre>
+      <pre id="shallow-state">{shallow}</pre>
       <pre id="navigation-type">{navigationType}</pre>
     </>
   )

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -5,8 +5,7 @@ import {
   historyUpdateMarker,
   markPendingPush,
   patchHistory,
-  type SearchParamsSyncEmitterEvents,
-  updatePendingPushUrl
+  type SearchParamsSyncEmitterEvents
 } from './patch-history'
 
 const pushState = vi.spyOn(history, 'pushState')
@@ -291,7 +290,6 @@ describe('patchHistory: pending push', () => {
   it('keeps a shallow replacement when the router commits the pending push', () => {
     history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
     optimisticPush('?a=1')
-    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
     history.replaceState(
       history.state,
       historyUpdateMarker,
@@ -311,7 +309,6 @@ describe('patchHistory: pending push', () => {
     history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
     optimisticPush('?a=1')
     await traverse(() => history.back())
-    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
     history.replaceState(
       history.state,
       historyUpdateMarker,

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -71,7 +71,11 @@ describe('patchHistory: pending push', () => {
   it('turns the router commit of a pending push into a replace', () => {
     optimisticPush('?a=1')
     routerPush('?a=1')
-    expect(replaceState).toHaveBeenCalledExactlyOnceWith({ idx: 1 }, '', '?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?a=1', location.href).href
+    )
     expect(pushState).not.toHaveBeenCalled()
     expect(onUpdate).toHaveBeenCalledExactlyOnceWith(
       new URLSearchParams('?a=1')
@@ -85,7 +89,7 @@ describe('patchHistory: pending push', () => {
     expect(replaceState).toHaveBeenCalledExactlyOnceWith(
       { idx: 1 },
       '',
-      '?redirected=true'
+      new URL('?redirected=true', location.href).href
     )
     expect(pushState).not.toHaveBeenCalled()
   })
@@ -300,9 +304,116 @@ describe('patchHistory: pending push', () => {
     expect(replaceState).toHaveBeenCalledExactlyOnceWith(
       { idx: 1 },
       '',
-      new URL('?a=1&shallow=pass', location.href)
+      new URL('?a=1&shallow=pass', location.href).href
     )
     expect(pushState).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith(
+      new URLSearchParams('a=1&shallow=pass')
+    )
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('keeps the last of several shallow replacements', () => {
+    optimisticPush('?a=1')
+    history.replaceState(history.state, historyUpdateMarker, '?a=1&s=1')
+    history.replaceState(history.state, historyUpdateMarker, '?a=1&s=2')
+    replaceState.mockClear()
+    routerPush('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?a=1&s=2', location.href).href
+    )
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith(
+      new URLSearchParams('a=1&s=2')
+    )
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('keeps the takeover URL when the router commits a taken-over push', () => {
+    optimisticPush('?a=1')
+    const takeoverUrl = new URL('?a=1&b=2', location.href)
+    history.replaceState(
+      markPendingPush(takeoverUrl),
+      historyUpdateMarker,
+      takeoverUrl
+    )
+    replaceState.mockClear()
+    routerPush('?a=1&b=2')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      takeoverUrl.href
+    )
+    expect(pushState).not.toHaveBeenCalled()
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('lets a redirected commit win over a shallow replacement', () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
+    optimisticPush('?a=1')
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    replaceState.mockClear()
+    routerPush('?redirected=true')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?redirected=true', location.href).href
+    )
+    expect(pushState).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith(
+      new URLSearchParams('redirected=true')
+    )
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('repairs the retargeted pending entry traversed forward onto', async () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
+    optimisticPush('?a=1')
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    await traverse(() => history.back())
+    await traverse(() => history.forward())
+    expect(history.state).toEqual({ idx: 1 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('keeps a shallow replacement when the router commit drops a bare fragment', () => {
+    optimisticPush('?a=1#')
+    const shallowUrl = new URL('?a=1&shallow=pass#', location.href)
+    history.replaceState(history.state, historyUpdateMarker, shallowUrl)
+    replaceState.mockClear()
+    routerPush('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      shallowUrl.href
+    )
+    expect(pushState).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith(
+      new URLSearchParams('a=1&shallow=pass')
+    )
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('folds a router commit that carries a bare fragment', () => {
+    optimisticPush('?a=1')
+    routerPush('?a=1#')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?a=1', location.href).href
+    )
+    expect(pushState).not.toHaveBeenCalled()
+    expect(onUpdate).toHaveBeenCalledExactlyOnceWith(new URLSearchParams('a=1'))
+    expect(hasPendingPush()).toBe(false)
   })
 
   it('does not retarget a pending push from a shallow replace after Back', async () => {

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -5,7 +5,8 @@ import {
   historyUpdateMarker,
   markPendingPush,
   patchHistory,
-  type SearchParamsSyncEmitterEvents
+  type SearchParamsSyncEmitterEvents,
+  updatePendingPushUrl
 } from './patch-history'
 
 const pushState = vi.spyOn(history, 'pushState')
@@ -284,6 +285,46 @@ describe('patchHistory: pending push', () => {
       '?b=1'
     )
     expect(history.state).toEqual({ usr: null, key: 'router', idx: 4 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('keeps a shallow replacement when the router commits the pending push', () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
+    optimisticPush('?a=1')
+    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    replaceState.mockClear()
+    routerPush('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?a=1&shallow=pass', location.href)
+    )
+    expect(pushState).not.toHaveBeenCalled()
+  })
+
+  it('does not retarget a pending push from a shallow replace after Back', async () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
+    optimisticPush('?a=1')
+    await traverse(() => history.back())
+    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    await traverse(() => history.forward())
+    expect(history.state).toEqual({ idx: 1 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('clears the pending push on a router replace', () => {
+    markPendingPush(new URL('?a=1', location.href))
+    routerReplace('?a=1')
     expect(hasPendingPush()).toBe(false)
   })
 })

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -385,6 +385,57 @@ describe('patchHistory: pending push', () => {
     expect(hasPendingPush()).toBe(false)
   })
 
+  it.each([
+    ['#chapter#', '#chapter'],
+    ['#chapter', '#chapter#'],
+    ['##', '#'],
+    ['#', '##']
+  ])(
+    'keeps distinct fragments %s and %s distinct',
+    (pendingHash, targetHash) => {
+      optimisticPush('?pending=1' + pendingHash)
+      const target = new URL('?pending=1' + targetHash, location.href)
+      routerPush(target.href)
+      expect(location.href).toBe(target.href)
+      expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+        { idx: 1 },
+        '',
+        target.href
+      )
+      expect(pushState).not.toHaveBeenCalled()
+      expect(hasPendingPush()).toBe(false)
+    }
+  )
+
+  it.each([
+    ['#chapter#', '#chapter'],
+    ['#chapter', '#chapter#']
+  ])(
+    'lets a fragment change from %s to %s win over a shallow replacement',
+    (pendingHash, targetHash) => {
+      optimisticPush('?pending=1' + pendingHash)
+      history.replaceState(
+        history.state,
+        historyUpdateMarker,
+        '?pending=1&shallow=pass' + pendingHash
+      )
+      replaceState.mockClear()
+      const target = new URL('?pending=1' + targetHash, location.href)
+      routerPush(target.href)
+      expect(location.href).toBe(target.href)
+      expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+        { idx: 1 },
+        '',
+        target.href
+      )
+      expect(pushState).not.toHaveBeenCalled()
+      expect(onUpdate).toHaveBeenCalledExactlyOnceWith(
+        new URLSearchParams('pending=1')
+      )
+      expect(hasPendingPush()).toBe(false)
+    }
+  )
+
   it('keeps a shallow replacement when the router commit drops a bare fragment', () => {
     optimisticPush('?a=1#')
     const shallowUrl = new URL('?a=1&shallow=pass#', location.href)

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -65,13 +65,6 @@ function movePendingPushHref(): void {
   }
 }
 
-export function updatePendingPushUrl(url: URL): void {
-  const pending = pendingPush.current
-  if (pending && isOnPendingPushEntry()) {
-    pending.currentHref = url.href
-  }
-}
-
 export function hasPendingPush(): boolean {
   const pending = pendingPush.current
   return pending !== null && !pending.poppedSince

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -35,6 +35,10 @@ const pendingPush = globalSingleton('pending-navigation', () => ({
   nextId: 0
 }))
 
+function withoutEmptyFragment(href: string): string {
+  return href.endsWith('#') ? href.slice(0, -1) : href
+}
+
 export function markPendingPush(url: URL): PendingPushState {
   const id = ++pendingPush.nextId
   pendingPush.current = {
@@ -94,18 +98,15 @@ function repairOrNotePopOnPendingPush(): void {
   pending.poppedSince = true
 }
 
-function pendingPushCommitUrl(url: string | URL): string | URL | null {
+function pendingPushCommitUrl(url: string | URL): string | null {
   const pending = pendingPush.current
   if (!pending || pending.poppedSince || !isOnPendingPushEntry()) {
     return null
   }
   const href = new URL(url, location.href).href
-  if (href === pending.href) {
-    return pending.currentHref === pending.href
-      ? url
-      : new URL(pending.currentHref)
-  }
-  return url
+  return withoutEmptyFragment(href) === withoutEmptyFragment(pending.href)
+    ? pending.currentHref
+    : href
 }
 
 // React Router reads the optimistic entry's idx into its private index before

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -25,6 +25,7 @@ type PendingPushState = {
 type PendingPush = {
   href: string
   id: number
+  currentHref: string
   routerIndex: number | undefined
   poppedSince: boolean
 }
@@ -39,6 +40,7 @@ export function markPendingPush(url: URL): PendingPushState {
   pendingPush.current = {
     href: url.href,
     id,
+    currentHref: url.href,
     routerIndex: history.state?.idx,
     poppedSince: false
   }
@@ -52,14 +54,21 @@ function isOnPendingPushEntry(): boolean {
     history.state?.[historyUpdateMarker] === pending.id &&
     // Shallow updates pass the starting state to pushState or replaceState.
     // The URL distinguishes the pending entry from the resulting marker copies.
-    location.href === pending.href
+    location.href === pending.currentHref
   )
 }
 
 function movePendingPushHref(): void {
   const pending = pendingPush.current
   if (pending) {
-    pending.href = location.href
+    pending.currentHref = location.href
+  }
+}
+
+export function updatePendingPushUrl(url: URL): void {
+  const pending = pendingPush.current
+  if (pending && isOnPendingPushEntry()) {
+    pending.currentHref = url.href
   }
 }
 
@@ -90,6 +99,20 @@ function repairOrNotePopOnPendingPush(): void {
     return
   }
   pending.poppedSince = true
+}
+
+function pendingPushCommitUrl(url: string | URL): string | URL | null {
+  const pending = pendingPush.current
+  if (!pending || pending.poppedSince || !isOnPendingPushEntry()) {
+    return null
+  }
+  const href = new URL(url, location.href).href
+  if (href === pending.href) {
+    return pending.currentHref === pending.href
+      ? url
+      : new URL(pending.currentHref)
+  }
+  return url
 }
 
 // React Router reads the optimistic entry's idx into its private index before
@@ -190,13 +213,11 @@ export function patchHistory(
     }
     // The router committing an optimistic deep push must not add
     // a second entry (#1563).
-    const commit =
-      hasPendingPush() && isOnPendingPushEntry()
-        ? originalReplaceState
-        : originalPushState
+    const commitUrl = pendingPushCommitUrl(url)
+    const commit = commitUrl ? originalReplaceState : originalPushState
     clearPendingPush()
-    commit.call(history, state, '', url)
-    sync(url)
+    commit.call(history, state, '', commitUrl ?? url)
+    sync(commitUrl ?? url)
   }
   history.replaceState = function nuqs_replaceState(state, marker, url) {
     const onPendingPushEntry = isOnPendingPushEntry()

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -36,7 +36,7 @@ const pendingPush = globalSingleton('pending-navigation', () => ({
 }))
 
 function withoutEmptyFragment(href: string): string {
-  return href.endsWith('#') ? href.slice(0, -1) : href
+  return href.replace(/^([^#]*)#$/, '$1')
 }
 
 export function markPendingPush(url: URL): PendingPushState {

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -10,7 +10,8 @@ import {
   hasPendingPush,
   historyUpdateMarker,
   markPendingPush,
-  patchHistory as applyHistoryPatch
+  patchHistory as applyHistoryPatch,
+  updatePendingPushUrl
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -78,6 +79,9 @@ export function createReactRouterBasedAdapter({
             ? history.pushState
             : history.replaceState
         setQueueResetMutex(options.shallow ? 1 : 2)
+        if (!isDeep && options.history !== 'push') {
+          updatePendingPushUrl(url)
+        }
         const historyState = commitsAsPush
           ? markPendingPush(url)
           : history.state

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -10,8 +10,7 @@ import {
   hasPendingPush,
   historyUpdateMarker,
   markPendingPush,
-  patchHistory as applyHistoryPatch,
-  updatePendingPushUrl
+  patchHistory as applyHistoryPatch
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -79,9 +78,6 @@ export function createReactRouterBasedAdapter({
             ? history.pushState
             : history.replaceState
         setQueueResetMutex(options.shallow ? 1 : 2)
-        if (!isDeep && options.history !== 'push') {
-          updatePendingPushUrl(url)
-        }
         const historyState = commitsAsPush
           ? markPendingPush(url)
           : history.state


### PR DESCRIPTION
Stacked on #1564. Merge that PR first.

## Summary

- Preserve a shallow replace made while a slow deep push is pending.
- Keep the latest optimistic URL when React Router commits its original target.
- Do not retarget the pending entry after Back navigation.
- Add E2E and browser regressions for the commit and Back/Forward paths.

## Validation

- React Router v6 repro: 4 passed sequentially
- React Router v7 repro: 4 passed sequentially
- React Router v8 repro: 4 passed sequentially
- Remix repro: 4 passed sequentially
- Unit: 273 passed
- Types: 56 passed
- Browser: 181 passed, 1 skipped
- Size limits passed
- Pre-push hooks passed
