### PR TITLE
fix: keep pending query state in its transition lane

### DIFF
--- a/packages/e2e/next/src/app/app/(shared)/lane-priority/page.tsx
+++ b/packages/e2e/next/src/app/app/(shared)/lane-priority/page.tsx
@@ -1,0 +1,10 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense>
+      <LanePriority />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/pages/pages/lane-priority.tsx
+++ b/packages/e2e/next/src/pages/pages/lane-priority.tsx
@@ -1,0 +1,4 @@
+import { withPagesReadyWrapper } from '@/components/pages-ready-wrapper'
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default withPagesReadyWrapper(LanePriority)

--- a/packages/e2e/react-router/v5/src/react-router.tsx
+++ b/packages/e2e/react-router/v5/src/react-router.tsx
@@ -14,6 +14,7 @@ const routes = {
   '/form/useQueryStates':                       lazy(() => import('./routes/form.useQueryStates')),
   '/hash-preservation':                         lazy(() => import('./routes/hash-preservation')),
   '/history-sync':                              lazy(() => import('./routes/history-sync')),
+  '/lane-priority':                             lazy(() => import('./routes/lane-priority')),
   '/json':                                      lazy(() => import('./routes/json')),
   '/life-and-death':                            lazy(() => import('./routes/life-and-death')),
   '/linking/useQueryState':                     lazy(() => import('./routes/linking.useQueryState')),

--- a/packages/e2e/react-router/v5/src/routes/lane-priority.tsx
+++ b/packages/e2e/react-router/v5/src/routes/lane-priority.tsx
@@ -1,0 +1,3 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default LanePriority

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -29,6 +29,7 @@ const router = createBrowserRouter(
       <Route path="form/useQueryStates"                       lazy={load(import('./routes/form.useQueryStates'))} />
       <Route path="hash-preservation"                         lazy={load(import('./routes/hash-preservation'))} />
       <Route path="history-sync"                              lazy={load(import('./routes/history-sync'))} />
+      <Route path="lane-priority"                             lazy={load(import('./routes/lane-priority'))} />
       <Route path="json"                                      lazy={load(import('./routes/json'))} />
       <Route path="life-and-death"                            lazy={load(import('./routes/life-and-death'))} />
       <Route path="linking/useQueryState"                     lazy={load(import('./routes/linking.useQueryState'))} />

--- a/packages/e2e/react-router/v6/src/routes/lane-priority.tsx
+++ b/packages/e2e/react-router/v6/src/routes/lane-priority.tsx
@@ -1,0 +1,3 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default LanePriority

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -12,6 +12,7 @@ export default [
     route('/form/useQueryStates',                       './routes/form.useQueryStates.tsx'),
     route('/hash-preservation',                         './routes/hash-preservation.tsx'),
     route('/history-sync',                              './routes/history-sync.tsx'),
+    route('/lane-priority',                             './routes/lane-priority.tsx'),
     route('/json',                                      './routes/json.tsx'),
     route('/life-and-death',                            './routes/life-and-death.tsx'),
     route('/linking/useQueryState',                     './routes/linking.useQueryState.tsx'),

--- a/packages/e2e/react-router/v7/app/routes/lane-priority.tsx
+++ b/packages/e2e/react-router/v7/app/routes/lane-priority.tsx
@@ -1,0 +1,3 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default LanePriority

--- a/packages/e2e/react-router/v8/app/routes.ts
+++ b/packages/e2e/react-router/v8/app/routes.ts
@@ -12,6 +12,7 @@ export default [
     route('/form/useQueryStates',                       './routes/form.useQueryStates.tsx'),
     route('/hash-preservation',                         './routes/hash-preservation.tsx'),
     route('/history-sync',                              './routes/history-sync.tsx'),
+    route('/lane-priority',                             './routes/lane-priority.tsx'),
     route('/json',                                      './routes/json.tsx'),
     route('/life-and-death',                            './routes/life-and-death.tsx'),
     route('/linking/useQueryState',                     './routes/linking.useQueryState.tsx'),

--- a/packages/e2e/react-router/v8/app/routes/lane-priority.tsx
+++ b/packages/e2e/react-router/v8/app/routes/lane-priority.tsx
@@ -1,0 +1,3 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default LanePriority

--- a/packages/e2e/react/src/routes.tsx
+++ b/packages/e2e/react/src/routes.tsx
@@ -11,6 +11,7 @@ const routes: Record<string, React.LazyExoticComponent<() => JSX.Element>> = {
   '/form/useQueryStates':                   lazy(() => import('./routes/form.useQueryStates')),
   '/hash-preservation':                     lazy(() => import('./routes/hash-preservation')),
   '/history-sync':                          lazy(() => import('./routes/history-sync')),
+  '/lane-priority':                         lazy(() => import('./routes/lane-priority')),
   '/json':                                  lazy(() => import('./routes/json')),
   '/life-and-death':                        lazy(() => import('./routes/life-and-death')),
   '/linking/useQueryState':                 lazy(() => import('./routes/linking.useQueryState')),

--- a/packages/e2e/react/src/routes/lane-priority.tsx
+++ b/packages/e2e/react/src/routes/lane-priority.tsx
@@ -1,0 +1,3 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default LanePriority

--- a/packages/e2e/remix/app/routes/lane-priority.tsx
+++ b/packages/e2e/remix/app/routes/lane-priority.tsx
@@ -1,0 +1,3 @@
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export default LanePriority

--- a/packages/e2e/shared/playwright/url-spy.ts
+++ b/packages/e2e/shared/playwright/url-spy.ts
@@ -10,15 +10,18 @@ export type UrlSpy = {
 
 export function setupUrlSpy(page: Page): UrlSpy {
   const urls: string[] = []
+  let lastSeenUrl: string | undefined
   const handler = (frame: Frame) => {
-    if (frame === page.mainFrame()) {
-      // ignore if the url is identical to the last record
-      if (urls.length > 0 && urls[urls.length - 1] === frame.url()) {
-        return
-      }
-      console.log('Navigated to', frame.url())
-      urls.push(frame.url())
+    if (frame !== page.mainFrame()) {
+      return
     }
+    const url = frame.url()
+    if (url === lastSeenUrl) {
+      return
+    }
+    lastSeenUrl = url
+    console.log('Navigated to', url)
+    urls.push(url)
   }
   page.on('framenavigated', handler)
 

--- a/packages/e2e/shared/playwright/url-spy.ts
+++ b/packages/e2e/shared/playwright/url-spy.ts
@@ -52,6 +52,7 @@ export function setupUrlSpy(page: Page): UrlSpy {
   return {
     reset() {
       urls.length = 0
+      lastSeenUrl = undefined
     },
     assertSearches,
     [Symbol.dispose]() {

--- a/packages/e2e/shared/playwright/url-spy.ts
+++ b/packages/e2e/shared/playwright/url-spy.ts
@@ -1,8 +1,10 @@
 import { type Frame, type Page, expect } from '@playwright/test'
 
+type ExpectedSearch = Record<string, string | string[]>
+
 export type UrlSpy = {
   reset(): void
-  assertSearches(expected: Array<Record<string, string>>): Promise<void>
+  assertSearches(expected: ExpectedSearch[]): Promise<void>
   [Symbol.dispose]: () => void
 }
 
@@ -20,34 +22,28 @@ export function setupUrlSpy(page: Page): UrlSpy {
   }
   page.on('framenavigated', handler)
 
-  async function assertSearches(expected: Array<Record<string, string>>) {
+  async function assertSearches(expected: ExpectedSearch[]) {
     return expect
       .poll(
-        () => {
-          if (urls.length !== expected.length) {
-            console.debug(
-              `Expected ${expected.length} navigations, but got ${urls.length}:\n  ${urls.join('\n  ')}`
+        () =>
+          urls.map((url, index) => {
+            const searchParams = new URL(url).searchParams
+            return Object.fromEntries(
+              Object.entries(expected[index] ?? {}).map(([key, value]) => [
+                key,
+                Array.isArray(value)
+                  ? searchParams.getAll(key)
+                  : searchParams.get(key)
+              ])
             )
-            return false
-          }
-          return expected.every((expectedSearch, index) => {
-            const url = new URL(urls[index])
-            return Object.entries(expectedSearch).every(([key, value]) => {
-              const expected = value
-              const received = url.searchParams.get(key)
-              if (url.searchParams.get(key) !== value) {
-                console.debug(
-                  `Expected navigation ${index} (${url}) to have search param ${key}=${expected}, but got ${received} instead`
-                )
-                return false
-              }
-              return true
-            })
-          })
-        },
-        { intervals: Array.from({ length: 40 }, _ => 50), timeout: 2000 }
+          }),
+        {
+          intervals: Array.from({ length: 40 }, _ => 50),
+          timeout: 2000,
+          message: 'Expected recorded URL navigations to match'
+        }
       )
-      .toBe(true)
+      .toEqual(expected)
   }
 
   return {

--- a/packages/e2e/shared/shared.spec.ts
+++ b/packages/e2e/shared/shared.spec.ts
@@ -11,6 +11,7 @@ import { testPrettyUrls } from './specs/pretty-urls.spec'
 import { testReferentialStability } from './specs/referential-stability.spec'
 import { testRouting } from './specs/routing.spec'
 import { testHistorySync } from './specs/history-sync.spec'
+import { testLanePriority } from './specs/lane-priority.spec'
 import { testScroll } from './specs/scroll.spec'
 
 export function runSharedTests(
@@ -132,6 +133,13 @@ export function runSharedTests(
 
   testHistorySync({
     path: `${pathPrefix}/history-sync`,
+    ...config
+  })
+
+  // --
+
+  testLanePriority({
+    path: `${pathPrefix}/lane-priority`,
     ...config
   })
 

--- a/packages/e2e/shared/specs/debounce.spec.ts
+++ b/packages/e2e/shared/specs/debounce.spec.ts
@@ -12,7 +12,7 @@ export function testDebounce(config: TestDebounceConfig) {
     it('should debounce the input', async ({ page }) => {
       const DEBOUNCE_TIME = 200
       await navigateTo(page, getUrl(path, { debounceTime: DEBOUNCE_TIME }))
-      await page.locator('input[type="text"]').pressSequentially('pass')
+      await page.locator('input[type="text"]').fill('pass')
       await expect(page.locator('#client-state')).toHaveText(
         '{"search":"pass","pageIndex":0}'
       )
@@ -39,7 +39,7 @@ export function testDebounce(config: TestDebounceConfig) {
     }) => {
       const DEBOUNCE_TIME = 400
       await navigateTo(page, getUrl(path, { debounceTime: DEBOUNCE_TIME }))
-      await page.locator('input[type="text"]').pressSequentially('pass')
+      await page.locator('input[type="text"]').fill('pass')
       const incrementButton = page.locator('button#increment-page-index')
       await incrementButton.click()
       await incrementButton.click()

--- a/packages/e2e/shared/specs/flush-after-navigate.spec.ts
+++ b/packages/e2e/shared/specs/flush-after-navigate.spec.ts
@@ -7,6 +7,16 @@ async function expectPathname(page: Page, pathname: string) {
   await expect(page).toHaveURL(url => url.pathname.endsWith(pathname))
 }
 
+async function queueUpdateAndNavigate(page: Page) {
+  await page.locator('#test').click()
+  await page.locator('a').click()
+}
+
+async function installPausedClock(page: Page) {
+  await page.clock.install({ time: 0 })
+  await page.clock.pauseAt(1)
+}
+
 export function testFlushAfterNavigate(config: TestConfig) {
   const shallows = [true, false]
   const histories = ['push', 'replace'] as const
@@ -26,14 +36,14 @@ export function testFlushAfterNavigate(config: TestConfig) {
               page,
               getUrl(path + '/start', { shallow, history, debounce: timeMs })
             )
+            await installPausedClock(page)
             async function runTest() {
-              await page.locator('#test').click()
-              await page.locator('a').click()
+              await queueUpdateAndNavigate(page)
               await expectPathname(page, path + '/end')
               await expect(page.locator('#client-useQueryState')).toBeEmpty()
               await expect(page.locator('#client-useQueryStates')).toBeEmpty()
               await expect(page).toHaveURL(url => url.search === '')
-              await page.waitForTimeout(timeMs)
+              await page.clock.fastForward(timeMs)
               await expect(page.locator('#client-useQueryState')).toBeEmpty()
               await expect(page.locator('#client-useQueryStates')).toBeEmpty()
               await expect(page).toHaveURL(url => url.search === '')
@@ -54,9 +64,9 @@ export function testFlushAfterNavigate(config: TestConfig) {
                 linkState: 'nav'
               })
             )
+            await installPausedClock(page)
             async function runTest() {
-              await page.locator('#test').click()
-              await page.locator('a').click()
+              await queueUpdateAndNavigate(page)
               await expectPathname(page, path + '/end')
               await expect(page.locator('#client-useQueryState')).toHaveText(
                 'nav'
@@ -65,7 +75,7 @@ export function testFlushAfterNavigate(config: TestConfig) {
                 'nav'
               )
               await expect(page).toHaveURL(url => url.search === '?test=nav')
-              await page.waitForTimeout(timeMs)
+              await page.clock.fastForward(timeMs)
               await expect(page.locator('#client-useQueryState')).toHaveText(
                 'nav'
               )
@@ -91,13 +101,13 @@ export function testFlushAfterNavigate(config: TestConfig) {
                 linkState: 'nav'
               })
             )
+            await installPausedClock(page)
             async function runTest() {
-              await page.locator('#test').click()
-              await page.locator('a').click()
+              await queueUpdateAndNavigate(page)
               await expectPathname(page, path + '/start')
               await expect(page).toHaveURL(url => url.search === '?test=nav')
               await expect(page.locator('#client-state')).toHaveText('nav')
-              await page.waitForTimeout(timeMs)
+              await page.clock.fastForward(timeMs)
               await expect(page.locator('#client-state')).toHaveText('nav')
               await expect(page).toHaveURL(url => url.search === '?test=nav')
             }
@@ -112,15 +122,15 @@ export function testFlushAfterNavigate(config: TestConfig) {
               page,
               getUrl(path + '/start', { shallow, history, throttle: timeMs })
             )
+            await installPausedClock(page)
             async function runTest() {
               await page.locator('#preflush').click() // Trigger an immediate flush to enable the throttling queue
-              await page.locator('#test').click() // Queue the change
-              await page.locator('a').click() // Navigate
+              await queueUpdateAndNavigate(page)
               await expectPathname(page, path + '/end')
               await expect(page.locator('#client-useQueryState')).toBeEmpty()
               await expect(page.locator('#client-useQueryStates')).toBeEmpty()
               await expect(page).toHaveURL(url => url.search === '')
-              await page.waitForTimeout(timeMs)
+              await page.clock.fastForward(timeMs)
               await expect(page.locator('#client-useQueryState')).toBeEmpty()
               await expect(page.locator('#client-useQueryStates')).toBeEmpty()
               await expect(page).toHaveURL(url => url.search === '')
@@ -141,10 +151,10 @@ export function testFlushAfterNavigate(config: TestConfig) {
                 linkState: 'nav'
               })
             )
+            await installPausedClock(page)
             async function runTest() {
               await page.locator('#preflush').click() // Trigger an immediate flush to enable the throttling queue
-              await page.locator('#test').click() // Queue the change
-              await page.locator('a').click() // Navigate
+              await queueUpdateAndNavigate(page)
               await expectPathname(page, path + '/end')
               await expect(page.locator('#client-useQueryState')).toHaveText(
                 'nav'
@@ -153,7 +163,7 @@ export function testFlushAfterNavigate(config: TestConfig) {
                 'nav'
               )
               await expect(page).toHaveURL(url => url.search === '?test=nav')
-              await page.waitForTimeout(timeMs)
+              await page.clock.fastForward(timeMs)
               await expect(page.locator('#client-useQueryState')).toHaveText(
                 'nav'
               )
@@ -179,14 +189,14 @@ export function testFlushAfterNavigate(config: TestConfig) {
                 linkState: 'nav'
               })
             )
+            await installPausedClock(page)
             async function runTest() {
               await page.locator('#preflush').click() // Trigger an immediate flush to enable the throttling queue
-              await page.locator('#test').click() // Queue the change
-              await page.locator('a').click() // Navigate
+              await queueUpdateAndNavigate(page)
               await expectPathname(page, path + '/start')
               await expect(page.locator('#client-state')).toHaveText('nav')
               await expect(page).toHaveURL(url => url.search === '?test=nav')
-              await page.waitForTimeout(timeMs)
+              await page.clock.fastForward(timeMs)
               await expect(page.locator('#client-state')).toHaveText('nav')
               await expect(page).toHaveURL(url => url.search === '?test=nav')
             }

--- a/packages/e2e/shared/specs/lane-priority.spec.ts
+++ b/packages/e2e/shared/specs/lane-priority.spec.ts
@@ -25,6 +25,9 @@ export const testLanePriority = defineTest('Lane priority', ({ path }) => {
 
     await expect(page).toHaveURL(/\?value=B$/)
     await expect(value).toHaveText('B')
-    await expect(renderedValues).toHaveText('null,B')
+    await expect(renderedValues).toContainText('B')
+    const renders = (await renderedValues.textContent())?.split(',')
+    expect(renders?.[1]).toBe('null')
+    expect(renders?.at(-1)).toBe('B')
   })
 })

--- a/packages/e2e/shared/specs/lane-priority.spec.ts
+++ b/packages/e2e/shared/specs/lane-priority.spec.ts
@@ -12,6 +12,8 @@ export const testLanePriority = defineTest('Lane priority', ({ path }) => {
     await expect(value).toHaveText('null')
     await expect(renderedValues).toHaveText('null')
 
+    // Keep both discrete events in one browser task. Awaiting separate clicks
+    // would let the transition commit before the urgent update can interrupt it.
     await page.evaluate(`
       document.querySelector('[data-testid="write"]').dispatchEvent(
         new MouseEvent('click', { bubbles: true })

--- a/packages/e2e/shared/specs/lane-priority.spec.ts
+++ b/packages/e2e/shared/specs/lane-priority.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test as it } from '@playwright/test'
+import { defineTest } from '../define-test'
+import { navigateTo } from '../playwright/navigate'
+
+export const testLanePriority = defineTest('Lane priority', ({ path }) => {
+  it('keeps pending query state on its transition lane', async ({ page }) => {
+    await navigateTo(page, path)
+
+    const value = page.getByLabel('Value', { exact: true })
+    const renderedValues = page.getByLabel('Rendered values', { exact: true })
+
+    await expect(value).toHaveText('null')
+    await expect(renderedValues).toHaveText('null')
+
+    await page.evaluate(`
+      document.querySelector('[data-testid="write"]').dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+      document.querySelector('[data-testid="tick"]').dispatchEvent(
+        new MouseEvent('click', { bubbles: true })
+      )
+    `)
+
+    await expect(page).toHaveURL(/\?value=B$/)
+    await expect(value).toHaveText('B')
+    await expect(renderedValues).toHaveText('null,B')
+  })
+})

--- a/packages/e2e/shared/specs/lane-priority.tsx
+++ b/packages/e2e/shared/specs/lane-priority.tsx
@@ -10,15 +10,10 @@ export function LanePriority() {
   const [, setMeasured] = useState<string | null>(null)
   const [, setTick] = useState(0)
   const renderCount = useRef(0)
-  const renderedValues = useRef<Array<string | null>>([])
-
-  renderCount.current++
-  const previous = renderedValues.current[renderedValues.current.length - 1]
-  if (!Object.is(previous, value)) {
-    renderedValues.current.push(value)
-  }
+  const renderedValues = useRenderLog(value)
 
   useLayoutEffect(() => {
+    renderCount.current++
     if (renderCount.current < renderLimit) {
       setMeasured(value)
     }
@@ -45,9 +40,21 @@ export function LanePriority() {
       <p>
         Rendered values:{' '}
         <output aria-label="Rendered values">
-          {renderedValues.current.map(String).join(',')}
+          {renderedValues.map(String).join(',')}
         </output>
       </p>
     </main>
   )
+}
+
+function useRenderLog(value: string | null) {
+  'use no memo'
+  // Intentionally records render-phase values, including renders React abandons.
+  // Keep this side effect isolated from the compiled component.
+  const renderedValues = useRef<Array<string | null>>([])
+  const previous = renderedValues.current[renderedValues.current.length - 1]
+  if (!Object.is(previous, value)) {
+    renderedValues.current.push(value)
+  }
+  return [...renderedValues.current]
 }

--- a/packages/e2e/shared/specs/lane-priority.tsx
+++ b/packages/e2e/shared/specs/lane-priority.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { parseAsString, useQueryState } from 'nuqs'
+import { startTransition, useLayoutEffect, useRef, useState } from 'react'
+
+const renderLimit = 60
+
+export function LanePriority() {
+  const [value, setValue] = useQueryState('value', parseAsString)
+  const [, setMeasured] = useState<string | null>(null)
+  const [, setTick] = useState(0)
+  const renderCount = useRef(0)
+  const renderedValues = useRef<Array<string | null>>([])
+
+  renderCount.current++
+  const previous = renderedValues.current[renderedValues.current.length - 1]
+  if (!Object.is(previous, value)) {
+    renderedValues.current.push(value)
+  }
+
+  useLayoutEffect(() => {
+    if (renderCount.current < renderLimit) {
+      setMeasured(value)
+    }
+  }, [value])
+
+  return (
+    <main>
+      <button
+        data-testid="write"
+        onClick={() => {
+          startTransition(() => {
+            setValue('B')
+          })
+        }}
+      >
+        Write in transition
+      </button>
+      <button data-testid="tick" onClick={() => setTick(tick => tick + 1)}>
+        Urgent update
+      </button>
+      <p>
+        Value: <output aria-label="Value">{String(value)}</output>
+      </p>
+      <p>
+        Rendered values:{' '}
+        <output aria-label="Rendered values">
+          {renderedValues.current.map(String).join(',')}
+        </output>
+      </p>
+    </main>
+  )
+}

--- a/packages/e2e/shared/specs/lane-priority.tsx
+++ b/packages/e2e/shared/specs/lane-priority.tsx
@@ -52,9 +52,6 @@ function useRenderLog(value: string | null) {
   // Intentionally records render-phase values, including renders React abandons.
   // Keep this side effect isolated from the compiled component.
   const renderedValues = useRef<Array<string | null>>([])
-  const previous = renderedValues.current[renderedValues.current.length - 1]
-  if (!Object.is(previous, value)) {
-    renderedValues.current.push(value)
-  }
+  renderedValues.current.push(value)
   return [...renderedValues.current]
 }

--- a/packages/e2e/shared/specs/stitching.spec.ts
+++ b/packages/e2e/shared/specs/stitching.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test as it } from '@playwright/test'
+import { expect, type Page, test as it } from '@playwright/test'
 import { defineTest, type TestConfig } from '../define-test'
 import { navigateTo } from '../playwright/navigate'
 import { setupUrlSpy } from '../playwright/url-spy'
@@ -6,6 +6,10 @@ import { getUrl } from './stitching.defs'
 
 type Config = TestConfig & {
   enableShallowFalse?: boolean
+}
+
+async function expectNoStitchingError(page: Page) {
+  await expect(page.locator('#stitching-error')).toBeEmpty()
 }
 
 export function testStitching({
@@ -36,6 +40,7 @@ export function testStitching({
                 { a: '1', b: '1' },
                 { a: '1', b: '1', c: '1' }
               ])
+              await expectNoStitchingError(page)
               urlSpy.reset()
               await page.locator('#same-tick').click()
               await expect(page.locator('#client-state')).toHaveText('2,2,2')
@@ -44,6 +49,7 @@ export function testStitching({
                 { a: '2', b: '2', c: '1' },
                 { a: '2', b: '2', c: '2' }
               ])
+              await expectNoStitchingError(page)
               urlSpy.reset()
               await page.locator('#same-tick-overlap').click()
               await expect(page.locator('#client-state')).toHaveText('4,4,4')
@@ -53,6 +59,7 @@ export function testStitching({
                 { a: '4', b: '4', c: '2' },
                 { a: '4', b: '4', c: '4' }
               ])
+              await expectNoStitchingError(page)
             })
 
             it('should sequence updates when staggered', async ({ page }) => {
@@ -65,6 +72,7 @@ export function testStitching({
                 { a: '1', b: '1' },
                 { a: '1', b: '1', c: '1' }
               ])
+              await expectNoStitchingError(page)
               urlSpy.reset()
               await page.locator('#staggered').click()
               await expect(page.locator('#client-state')).toHaveText('2,2,2')
@@ -73,6 +81,7 @@ export function testStitching({
                 { a: '2', b: '2', c: '1' },
                 { a: '2', b: '2', c: '2' }
               ])
+              await expectNoStitchingError(page)
               urlSpy.reset()
               await page.locator('#staggered-overlap').click()
               await expect(page.locator('#client-state')).toHaveText('4,4,4')
@@ -82,6 +91,7 @@ export function testStitching({
                 { a: '4', b: '4', c: '2' },
                 { a: '4', b: '4', c: '4' }
               ])
+              await expectNoStitchingError(page)
             })
           }
         )

--- a/packages/e2e/shared/specs/stitching.spec.ts
+++ b/packages/e2e/shared/specs/stitching.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test as it } from '@playwright/test'
 import { defineTest, type TestConfig } from '../define-test'
-import { expectSearch } from '../playwright/expect-url'
 import { navigateTo } from '../playwright/navigate'
+import { setupUrlSpy } from '../playwright/url-spy'
 import { getUrl } from './stitching.defs'
 
 type Config = TestConfig & {
@@ -28,48 +28,60 @@ export function testStitching({
               page
             }) => {
               await navigateTo(page, getUrl(path, { hook, shallow, history }))
+              using urlSpy = setupUrlSpy(page)
               await page.locator('#same-tick').click()
               await expect(page.locator('#client-state')).toHaveText('1,1,1')
-              await expectSearch(page, { a: '1' })
-              await expectSearch(page, { a: '1', b: '1' })
-              await expectSearch(page, { a: '1', b: '1', c: '1' })
+              await urlSpy.assertSearches([
+                { a: '1' },
+                { a: '1', b: '1' },
+                { a: '1', b: '1', c: '1' }
+              ])
+              urlSpy.reset()
               await page.locator('#same-tick').click()
               await expect(page.locator('#client-state')).toHaveText('2,2,2')
-              await expectSearch(page, { a: '2', b: '1', c: '1' })
-              await expectSearch(page, { a: '2', b: '2', c: '1' })
-              await expectSearch(page, { a: '2', b: '2', c: '2' })
-              await page.locator('#same-tick').click()
-              await expect(page.locator('#client-state')).toHaveText('3,3,3')
-              await expectSearch(page, { a: '3', b: '2', c: '2' })
-              // Don't wait till completion, queue an update before the debounced resolve
-              await page.locator('#same-tick').click()
+              await urlSpy.assertSearches([
+                { a: '2', b: '1', c: '1' },
+                { a: '2', b: '2', c: '1' },
+                { a: '2', b: '2', c: '2' }
+              ])
+              urlSpy.reset()
+              await page.locator('#same-tick-overlap').click()
               await expect(page.locator('#client-state')).toHaveText('4,4,4')
-              await expectSearch(page, { a: '4', b: '2', c: '2' })
-              await expectSearch(page, { a: '4', b: '4', c: '2' })
-              await expectSearch(page, { a: '4', b: '4', c: '4' })
+              await urlSpy.assertSearches([
+                { a: '3', b: '2', c: '2' },
+                { a: '4', b: '2', c: '2' },
+                { a: '4', b: '4', c: '2' },
+                { a: '4', b: '4', c: '4' }
+              ])
             })
 
             it('should sequence updates when staggered', async ({ page }) => {
               await navigateTo(page, getUrl(path, { hook, shallow, history }))
+              using urlSpy = setupUrlSpy(page)
               await page.locator('#staggered').click()
               await expect(page.locator('#client-state')).toHaveText('1,1,1')
-              await expectSearch(page, { a: '1' })
-              await expectSearch(page, { a: '1', b: '1' })
-              await expectSearch(page, { a: '1', b: '1', c: '1' })
+              await urlSpy.assertSearches([
+                { a: '1' },
+                { a: '1', b: '1' },
+                { a: '1', b: '1', c: '1' }
+              ])
+              urlSpy.reset()
               await page.locator('#staggered').click()
               await expect(page.locator('#client-state')).toHaveText('2,2,2')
-              await expectSearch(page, { a: '2', b: '1', c: '1' })
-              await expectSearch(page, { a: '2', b: '2', c: '1' })
-              await expectSearch(page, { a: '2', b: '2', c: '2' })
-              await page.locator('#staggered').click()
-              await expect(page.locator('#client-state')).toHaveText('3,3,3')
-              await expectSearch(page, { a: '3', b: '2', c: '2' })
-              // Don't wait till completion, queue an update before the debounced resolve
-              await page.locator('#staggered').click()
+              await urlSpy.assertSearches([
+                { a: '2', b: '1', c: '1' },
+                { a: '2', b: '2', c: '1' },
+                { a: '2', b: '2', c: '2' }
+              ])
+              urlSpy.reset()
+              await page.locator('#staggered-overlap').click()
               await expect(page.locator('#client-state')).toHaveText('4,4,4')
-              await expectSearch(page, { a: '4', b: '2', c: '2' })
-              await expectSearch(page, { a: '4', b: '4', c: '2' })
-              await expectSearch(page, { a: '4', b: '4', c: '4' })
+              await urlSpy.assertSearches([
+                { a: '3', b: '2', c: '2' },
+                { a: '4', b: '2', c: '2' },
+                { a: '4', b: '4', c: '2' },
+                { a: '4', b: '4', c: '4' }
+              ])
             })
           }
         )

--- a/packages/e2e/shared/specs/stitching.tsx
+++ b/packages/e2e/shared/specs/stitching.tsx
@@ -31,18 +31,24 @@ function StitchingUseQueryState() {
   )
 
   const testOnSameTick = () => {
-    setA(x => x + 1)
+    const flushed = setA(x => x + 1)
     setB(x => x + 1, { limitUrlUpdates: debounce(250) })
     setC(x => x + 1, { limitUrlUpdates: debounce(500) })
+    return flushed
   }
-  const testStaggered = () => {
-    setC(x => x + 1, { limitUrlUpdates: debounce(500) })
-    setTimeout(() => {
-      setB(x => x + 1, { limitUrlUpdates: debounce(250) })
+  const testStaggered = () =>
+    new Promise<void>(resolve => {
+      setC(x => x + 1, { limitUrlUpdates: debounce(500) })
       setTimeout(() => {
-        setA(x => x + 1)
+        setB(x => x + 1, { limitUrlUpdates: debounce(250) })
+        setTimeout(() => {
+          void setA(x => x + 1).then(() => resolve())
+        }, 0)
       }, 0)
-    }, 0)
+    })
+  const testOverlap = async (test: () => Promise<unknown>) => {
+    await test()
+    void test()
   }
 
   return (
@@ -52,6 +58,15 @@ function StitchingUseQueryState() {
       </button>
       <button id="staggered" onClick={testStaggered}>
         Test staggered
+      </button>
+      <button
+        id="same-tick-overlap"
+        onClick={() => testOverlap(testOnSameTick)}
+      >
+        Test overlapping same-tick updates
+      </button>
+      <button id="staggered-overlap" onClick={() => testOverlap(testStaggered)}>
+        Test overlapping staggered updates
       </button>
       <Display environment="client" state={[a, b, c].join(',')} />
     </>
@@ -66,26 +81,32 @@ function StitchingUseQueryStates() {
   })
 
   const testOnSameTick = () => {
-    setSearchParams(old => ({ a: old.a + 1 }))
+    const flushed = setSearchParams(old => ({ a: old.a + 1 }))
     setSearchParams(old => ({ b: old.b + 1 }), {
       limitUrlUpdates: debounce(250)
     })
     setSearchParams(old => ({ c: old.c + 1 }), {
       limitUrlUpdates: debounce(500)
     })
+    return flushed
   }
-  const testStaggered = () => {
-    setSearchParams(old => ({ c: old.c + 1 }), {
-      limitUrlUpdates: debounce(500)
-    })
-    setTimeout(() => {
-      setSearchParams(old => ({ b: old.b + 1 }), {
-        limitUrlUpdates: debounce(250)
+  const testStaggered = () =>
+    new Promise<void>(resolve => {
+      setSearchParams(old => ({ c: old.c + 1 }), {
+        limitUrlUpdates: debounce(500)
       })
       setTimeout(() => {
-        setSearchParams(old => ({ a: old.a + 1 }))
+        setSearchParams(old => ({ b: old.b + 1 }), {
+          limitUrlUpdates: debounce(250)
+        })
+        setTimeout(() => {
+          void setSearchParams(old => ({ a: old.a + 1 })).then(() => resolve())
+        }, 0)
       }, 0)
-    }, 0)
+    })
+  const testOverlap = async (test: () => Promise<unknown>) => {
+    await test()
+    void test()
   }
 
   return (
@@ -95,6 +116,15 @@ function StitchingUseQueryStates() {
       </button>
       <button id="staggered" onClick={testStaggered}>
         Test staggered
+      </button>
+      <button
+        id="same-tick-overlap"
+        onClick={() => testOverlap(testOnSameTick)}
+      >
+        Test overlapping same-tick updates
+      </button>
+      <button id="staggered-overlap" onClick={() => testOverlap(testStaggered)}>
+        Test overlapping staggered updates
       </button>
       <Display environment="client" state={[a, b, c].join(',')} />
     </>

--- a/packages/e2e/shared/specs/stitching.tsx
+++ b/packages/e2e/shared/specs/stitching.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { debounce, useQueryState, useQueryStates } from 'nuqs'
 import { Display } from '../components/display'
 import { optionsSearchParams, searchParams } from './stitching.defs'
@@ -15,7 +16,19 @@ export function Stitching() {
   return <>Invalid hook</>
 }
 
+function useTestRunner() {
+  const [error, setError] = useState('')
+  const run = (test: () => Promise<unknown>) => {
+    setError('')
+    void test().catch(error => {
+      setError(error instanceof Error ? error.message : String(error))
+    })
+  }
+  return { error, run }
+}
+
 function StitchingUseQueryState() {
+  const { error, run } = useTestRunner()
   const [{ history, shallow }] = useQueryStates(optionsSearchParams)
   const [a, setA] = useQueryState(
     'a',
@@ -37,43 +50,48 @@ function StitchingUseQueryState() {
     return flushed
   }
   const testStaggered = () =>
-    new Promise<void>(resolve => {
+    new Promise<void>((resolve, reject) => {
       setC(x => x + 1, { limitUrlUpdates: debounce(500) })
       setTimeout(() => {
         setB(x => x + 1, { limitUrlUpdates: debounce(250) })
         setTimeout(() => {
-          void setA(x => x + 1).then(() => resolve())
+          void setA(x => x + 1).then(() => resolve(), reject)
         }, 0)
       }, 0)
     })
-  const testOverlap = async (test: () => Promise<unknown>) => {
+  const testSequentially = async (test: () => Promise<unknown>) => {
     await test()
-    void test()
+    await test()
   }
 
   return (
     <>
-      <button id="same-tick" onClick={testOnSameTick}>
+      <button id="same-tick" onClick={() => run(testOnSameTick)}>
         Test on same tick
       </button>
-      <button id="staggered" onClick={testStaggered}>
+      <button id="staggered" onClick={() => run(testStaggered)}>
         Test staggered
       </button>
       <button
         id="same-tick-overlap"
-        onClick={() => testOverlap(testOnSameTick)}
+        onClick={() => run(() => testSequentially(testOnSameTick))}
       >
         Test overlapping same-tick updates
       </button>
-      <button id="staggered-overlap" onClick={() => testOverlap(testStaggered)}>
+      <button
+        id="staggered-overlap"
+        onClick={() => run(() => testSequentially(testStaggered))}
+      >
         Test overlapping staggered updates
       </button>
       <Display environment="client" state={[a, b, c].join(',')} />
+      <output id="stitching-error">{error}</output>
     </>
   )
 }
 
 function StitchingUseQueryStates() {
+  const { error, run } = useTestRunner()
   const [{ history, shallow }] = useQueryStates(optionsSearchParams)
   const [{ a, b, c }, setSearchParams] = useQueryStates(searchParams, {
     history,
@@ -91,7 +109,7 @@ function StitchingUseQueryStates() {
     return flushed
   }
   const testStaggered = () =>
-    new Promise<void>(resolve => {
+    new Promise<void>((resolve, reject) => {
       setSearchParams(old => ({ c: old.c + 1 }), {
         limitUrlUpdates: debounce(500)
       })
@@ -100,33 +118,40 @@ function StitchingUseQueryStates() {
           limitUrlUpdates: debounce(250)
         })
         setTimeout(() => {
-          void setSearchParams(old => ({ a: old.a + 1 })).then(() => resolve())
+          void setSearchParams(old => ({ a: old.a + 1 })).then(
+            () => resolve(),
+            reject
+          )
         }, 0)
       }, 0)
     })
-  const testOverlap = async (test: () => Promise<unknown>) => {
+  const testSequentially = async (test: () => Promise<unknown>) => {
     await test()
-    void test()
+    await test()
   }
 
   return (
     <>
-      <button id="same-tick" onClick={testOnSameTick}>
+      <button id="same-tick" onClick={() => run(testOnSameTick)}>
         Test on same tick
       </button>
-      <button id="staggered" onClick={testStaggered}>
+      <button id="staggered" onClick={() => run(testStaggered)}>
         Test staggered
       </button>
       <button
         id="same-tick-overlap"
-        onClick={() => testOverlap(testOnSameTick)}
+        onClick={() => run(() => testSequentially(testOnSameTick))}
       >
         Test overlapping same-tick updates
       </button>
-      <button id="staggered-overlap" onClick={() => testOverlap(testStaggered)}>
+      <button
+        id="staggered-overlap"
+        onClick={() => run(() => testSequentially(testStaggered))}
+      >
         Test overlapping staggered updates
       </button>
       <Display environment="client" state={[a, b, c].join(',')} />
+      <output id="stitching-error">{error}</output>
     </>
   )
 }

--- a/packages/e2e/tanstack-router/src/routes/lane-priority.tsx
+++ b/packages/e2e/tanstack-router/src/routes/lane-priority.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { LanePriority } from 'e2e-shared/specs/lane-priority'
+
+export const Route = createFileRoute('/lane-priority')({
+  component: LanePriority
+})

--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -602,21 +602,21 @@ describe('useQueryState: multi-parsers', () => {
   })
 })
 
-// --- SyncLane / transition-lane leak ----------------------------------------
+// --- SyncLane / transition-lane leak (#1567) --------------------------------
 
 /**
- * A URL write made inside `startTransition` lands on a transition lane, but a
+ * A URL write made inside `startTransition` landed on a transition lane, but a
  * discrete event dispatched before that transition commits forces a SyncLane
- * render, which skips that lane. nuqs hands the sync render the pending value
- * anyway (it mutates `stateRef.current` outside the render that consumes it,
- * then the "lag-sync" line feeds it back in), so the sync render sees 'B' while
- * the component state still holds null. A layout effect that dispatches off
- * that value then re-renders into the same sync commit, and the two values
- * alternate instead of settling.
+ * render, which skips that lane. nuqs used to hand the sync render the pending
+ * value anyway: it mutated `stateRef.current` outside the render that consumed
+ * it, then render-time recovery fed it back in. The sync render saw 'B' while
+ * the component state still held null. A layout effect dispatching from that
+ * value then re-rendered into the same sync commit, and the two values
+ * alternated instead of settling.
  *
  * The sandwich is deterministic, not raced:
- *   1. `startTransition(() => setTime('B'))` — throttle(0) keeps the queue
- *      flush synchronous, so nuqs's own commit happens inside the transition.
+ *   1. `startTransition(() => setTime('B'))` — the cross-hook emitter runs
+ *      synchronously, so nuqs's state update lands inside the transition.
  *   2. a click dispatched synchronously right after — discrete, so React
  *      flushes it before the transition commits.
  *   3. the probe records the value each render was handed.
@@ -627,7 +627,7 @@ describe('useQueryState: multi-parsers', () => {
  */
 
 // A react-router-shaped adapter, faithful to src/adapters/lib/react-router.ts:
-// both the emitter handler and the URL write are wrapped in startTransition.
+// the emitter update is wrapped in startTransition; the history write is not.
 type Listener = (search: URLSearchParams) => void
 const listeners = new Set<Listener>()
 
@@ -656,7 +656,7 @@ const adapters = {
   react: ReactAdapter
 }
 
-/** Stops a genuine runaway from hanging the browser, so the test can report. */
+/** Safety cap in case a future regression turns the alternation into a runaway. */
 const RENDER_LIMIT = 60
 
 function Probe({
@@ -668,8 +668,8 @@ function Probe({
 }) {
   const [time, setTime] = useQueryState(
     'time',
-    // throttle(0) keeps the queue flush synchronous, so nuqs's own commit
-    // happens inside the transition rather than after it.
+    // Minimise delayed URL work; the synchronous emitter above determines the
+    // state update's lane, not the throttled queue flush.
     parseAsString.withOptions({ limitUrlUpdates: throttle(0) })
   )
   const [, setMeasured] = useState<string | null>(null)
@@ -718,8 +718,8 @@ function distinctValues(renders: Array<string | null>) {
 describe('useQueryState: SyncLane / transition-lane leak', () => {
   // nuqs's queues and the adapter emitter are module-level singletons, and the
   // react adapter writes to the real URL, so both need explicit teardown.
-  // Only drop our own key: the vitest runner keeps its sessionId/iframeId in
-  // this same URL, and clearing the whole search string breaks the run.
+  // Only drop our own key so teardown leaves the runner's sessionId/iframeId
+  // parameters untouched.
   beforeEach(clearTimeParam)
   afterEach(clearTimeParam)
 
@@ -763,7 +763,6 @@ describe('useQueryState: SyncLane / transition-lane leak', () => {
 
       // The URL moved once, so the rendered value must move once: null -> 'B'.
       expect(distinctValues(probe.renders)).toEqual([null, 'B'])
-      expect(probe.renders.length).toBeLessThan(12)
     })
 
     // Control. The write is discrete here (it happens in a click handler), so
@@ -777,7 +776,6 @@ describe('useQueryState: SyncLane / transition-lane leak', () => {
       await sleep(300)
 
       expect(distinctValues(probe.renders)).toEqual([null, 'B'])
-      expect(probe.renders.length).toBeLessThan(12)
     })
   }
 })

--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -761,6 +761,8 @@ describe('useQueryState: SyncLane / transition-lane leak', () => {
       probe.tick() // discrete click -> SyncLane, before the transition commits
       await sleep(300)
 
+      // The sync render must not leak the pending transition value.
+      expect(probe.renders[1]).toBe(null)
       // The URL moved once, so the rendered value must move once: null -> 'B'.
       expect(distinctValues(probe.renders)).toEqual([null, 'B'])
     })

--- a/packages/nuqs/src/useQueryState.browser.test.tsx
+++ b/packages/nuqs/src/useQueryState.browser.test.tsx
@@ -1,16 +1,28 @@
-import React, { useState } from 'react'
-import { describe, expect, it, vi } from 'vitest'
-import { render, renderHook } from 'vitest-browser-react'
+import React, {
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState
+} from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, renderHook } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
 import {
   NullDetector,
   useFakeLoadingState
 } from '../tests/components/repro-1099'
 import {
+  unstable_createAdapterProvider,
+  type unstable_AdapterInterface
+} from './adapters/custom'
+import { NuqsAdapter as ReactAdapter } from './adapters/react'
+import {
   withNuqsTestingAdapter,
   type OnUrlUpdateFunction
 } from './adapters/testing'
 import { debounce, throttle } from './lib/queues/rate-limiting'
+import { resetQueues } from './lib/queues/reset'
 import {
   parseAsArrayOf,
   parseAsInteger,
@@ -588,4 +600,184 @@ describe('useQueryState: multi-parsers', () => {
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].queryString).toEqual('?test=')
   })
+})
+
+// --- SyncLane / transition-lane leak ----------------------------------------
+
+/**
+ * A URL write made inside `startTransition` lands on a transition lane, but a
+ * discrete event dispatched before that transition commits forces a SyncLane
+ * render, which skips that lane. nuqs hands the sync render the pending value
+ * anyway (it mutates `stateRef.current` outside the render that consumes it,
+ * then the "lag-sync" line feeds it back in), so the sync render sees 'B' while
+ * the component state still holds null. A layout effect that dispatches off
+ * that value then re-renders into the same sync commit, and the two values
+ * alternate instead of settling.
+ *
+ * The sandwich is deterministic, not raced:
+ *   1. `startTransition(() => setTime('B'))` — throttle(0) keeps the queue
+ *      flush synchronous, so nuqs's own commit happens inside the transition.
+ *   2. a click dispatched synchronously right after — discrete, so React
+ *      flushes it before the transition commits.
+ *   3. the probe records the value each render was handed.
+ *
+ * Both adapters are exercised: `lagging` models react-router (searchParams is
+ * React state written inside startTransition), `react` is the shipped adapter
+ * (searchParams comes from useSyncExternalStore, so it is lane-independent).
+ */
+
+// A react-router-shaped adapter, faithful to src/adapters/lib/react-router.ts:
+// both the emitter handler and the URL write are wrapped in startTransition.
+type Listener = (search: URLSearchParams) => void
+const listeners = new Set<Listener>()
+
+function useLaggingAdapter(): unstable_AdapterInterface {
+  const [searchParams, setSearchParams] = useState(
+    () => new URLSearchParams(location.search)
+  )
+  useEffect(() => {
+    const onUpdate: Listener = search => {
+      startTransition(() => setSearchParams(new URLSearchParams(search)))
+    }
+    listeners.add(onUpdate)
+    return () => void listeners.delete(onUpdate)
+  }, [])
+  const updateUrl = useCallback((search: URLSearchParams) => {
+    startTransition(() => listeners.forEach(l => l(search)))
+    const url = new URL(location.href)
+    url.search = search.toString()
+    history.replaceState(history.state, '', url)
+  }, [])
+  return { searchParams, updateUrl, autoResetQueueOnUpdate: false }
+}
+
+const adapters = {
+  lagging: unstable_createAdapterProvider(useLaggingAdapter),
+  react: ReactAdapter
+}
+
+/** Stops a genuine runaway from hanging the browser, so the test can report. */
+const RENDER_LIMIT = 60
+
+function Probe({
+  renders,
+  wrapped
+}: {
+  renders: Array<string | null>
+  wrapped: boolean
+}) {
+  const [time, setTime] = useQueryState(
+    'time',
+    // throttle(0) keeps the queue flush synchronous, so nuqs's own commit
+    // happens inside the transition rather than after it.
+    parseAsString.withOptions({ limitUrlUpdates: throttle(0) })
+  )
+  const [, setMeasured] = useState<string | null>(null)
+  // The tick lives in this component on purpose: a discrete click on a sibling
+  // marks only the sibling's fiber, and this component would never re-render.
+  const [, setTick] = useState(0)
+  renders.push(time)
+  // Virtuoso-ish: measure during the commit and dispatch synchronously.
+  // Convergent on its own — React bails out (Object.is) once `time` holds
+  // still, so an unbounded render count means the value alternated.
+  useLayoutEffect(() => {
+    if (renders.length < RENDER_LIMIT) {
+      setMeasured(time)
+    }
+  }, [time])
+  return (
+    <>
+      <button
+        data-testid="write"
+        onClick={() => {
+          if (wrapped) {
+            startTransition(() => {
+              setTime('B')
+            })
+          } else {
+            setTime('B')
+          }
+        }}
+      >
+        write
+      </button>
+      <button data-testid="tick" onClick={() => setTick(t => t + 1)}>
+        {String(time)}
+      </button>
+    </>
+  )
+}
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
+
+/** Compresses the renders to the sequence of distinct values, in order. */
+function distinctValues(renders: Array<string | null>) {
+  return renders.filter((v, i, a) => i === 0 || !Object.is(v, a[i - 1]))
+}
+
+describe('useQueryState: SyncLane / transition-lane leak', () => {
+  // nuqs's queues and the adapter emitter are module-level singletons, and the
+  // react adapter writes to the real URL, so both need explicit teardown.
+  // Only drop our own key: the vitest runner keeps its sessionId/iframeId in
+  // this same URL, and clearing the whole search string breaks the run.
+  beforeEach(clearTimeParam)
+  afterEach(clearTimeParam)
+
+  function clearTimeParam() {
+    cleanup()
+    listeners.clear()
+    resetQueues()
+    const url = new URL(location.href)
+    url.searchParams.delete('time')
+    history.replaceState(history.state, '', url)
+  }
+
+  async function mount(adapter: keyof typeof adapters, wrapped: boolean) {
+    const Adapter = adapters[adapter]
+    const renders: Array<string | null> = []
+    await render(
+      <Adapter>
+        <Probe renders={renders} wrapped={wrapped} />
+      </Adapter>
+    )
+    await sleep(50)
+    // Keep the last mount render as the baseline, so the value sequence shows
+    // the move out of the pre-write value rather than starting after it.
+    renders.splice(0, renders.length - 1)
+    // Dispatched directly rather than through userEvent, which awaits between
+    // clicks and would let the transition commit before the tick lands.
+    const click = (testId: string) => () =>
+      page
+        .getByTestId(testId)
+        .element()
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    return { renders, write: click('write'), tick: click('tick') }
+  }
+
+  for (const adapter of ['lagging', 'react'] as const) {
+    it(`converges when a sync render interrupts a transition (${adapter} adapter)`, async () => {
+      const probe = await mount(adapter, true)
+      probe.write() // click handler starts the transition, as an app would
+      probe.tick() // discrete click -> SyncLane, before the transition commits
+      await sleep(300)
+
+      // The URL moved once, so the rendered value must move once: null -> 'B'.
+      expect(distinctValues(probe.renders)).toEqual([null, 'B'])
+      expect(probe.renders.length).toBeLessThan(12)
+    })
+
+    // Control. The write is discrete here (it happens in a click handler), so
+    // nuqs's setInternalState commits at the end of that click, before the tick
+    // renders — there is no pending lane for a sync render to skip. Renders go
+    // [null, 'B', 'B'] rather than alternating.
+    it(`converges when a sync render interrupts a plain update (${adapter} adapter)`, async () => {
+      const probe = await mount(adapter, false)
+      probe.write()
+      probe.tick()
+      await sleep(300)
+
+      expect(distinctValues(probe.renders)).toEqual([null, 'B'])
+      expect(probe.renders.length).toBeLessThan(12)
+    })
+  }
 })

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -568,9 +568,12 @@ describe('useQueryStates: rendering & bail-out', () => {
     expect(onUrlUpdate).toHaveBeenCalledTimes(0)
 
     await user.click(page.getByRole('button', { name: 'Start' }))
-
     expect(renderCount).toBe(1) // same render count as before
     expect(onUrlUpdate).toHaveBeenCalledTimes(1) // url update is still called
+
+    await user.click(page.getByRole('button', { name: 'Start' }))
+    expect(renderCount).toBe(1)
+    expect(onUrlUpdate).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -1905,10 +1908,10 @@ describe('useQueryStates: transition lane feedback', () => {
   it('converges when a later sync render feeds back through layout effects', async () => {
     const renders = await mount()
     click('write')
-    await sleep(0)
     click('tick')
     await sleep(100)
 
+    expect(renders[1]).toBe(null)
     expect(distinct(renders)).toEqual([null, 'B'])
   })
 
@@ -1916,10 +1919,10 @@ describe('useQueryStates: transition lane feedback', () => {
     feedbackUpdateLimit = Infinity
     const renders = await mount()
     click('write')
-    await sleep(0)
     click('tick')
     await sleep(100)
 
+    expect(renders[1]).toBe(null)
     expect(distinct(renders)).toEqual([null, 'B'])
     expect(feedbackUpdates).toBeLessThanOrEqual(2)
   })

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1820,6 +1820,7 @@ describe('useQueryStates: transition lane feedback', () => {
   const feedbackListeners = new Set<() => void>()
   let feedbackState: string | null | undefined
   let feedbackUpdates = 0
+  let feedbackUpdateLimit = 20
 
   function subscribeFeedback(listener: () => void) {
     feedbackListeners.add(listener)
@@ -1827,7 +1828,8 @@ describe('useQueryStates: transition lane feedback', () => {
   }
 
   function publishFeedback(value: string | null) {
-    if (feedbackState === value || feedbackUpdates >= 20) return
+    if (feedbackState === value || feedbackUpdates >= feedbackUpdateLimit)
+      return
     feedbackState = value
     feedbackUpdates++
     feedbackListeners.forEach(listener => listener())
@@ -1882,6 +1884,7 @@ describe('useQueryStates: transition lane feedback', () => {
     feedbackListeners.clear()
     feedbackState = undefined
     feedbackUpdates = 0
+    feedbackUpdateLimit = 20
     const url = new URL(location.href)
     url.searchParams.delete('value')
     history.replaceState(history.state, '', url)
@@ -1907,6 +1910,18 @@ describe('useQueryStates: transition lane feedback', () => {
     await sleep(100)
 
     expect(distinct(renders)).toEqual([null, 'B'])
+  })
+
+  it('does not overflow with uncapped external-store feedback (#1567)', async () => {
+    feedbackUpdateLimit = Infinity
+    const renders = await mount()
+    click('write')
+    await sleep(0)
+    click('tick')
+    await sleep(100)
+
+    expect(distinct(renders)).toEqual([null, 'B'])
+    expect(feedbackUpdates).toBeLessThanOrEqual(2)
   })
 
   it('promotes a repeated transition value to the sync lane', async () => {

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1,12 +1,15 @@
 import React, {
   createElement,
+  startTransition,
   Suspense,
   useEffect,
+  useLayoutEffect,
   useState,
+  useSyncExternalStore,
   type ReactNode
 } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { render, renderHook } from 'vitest-browser-react'
+import { cleanup, render, renderHook } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
 import { createReactRouterBasedAdapter } from './adapters/lib/react-router'
 import {
@@ -20,6 +23,7 @@ import {
 } from './adapters/testing'
 import { debounce, throttle } from './lib/queues/rate-limiting'
 import { resetQueues } from './lib/queues/reset'
+import { globalThrottleQueue } from './lib/queues/throttle'
 import {
   createParser,
   parseAsArrayOf,
@@ -1804,5 +1808,114 @@ describe('useQueryStates: discarded renders', () => {
     await expect
       .element(page.getByTestId('value'))
       .toHaveTextContent('incoming')
+  })
+})
+
+describe('useQueryStates: transition lane feedback', () => {
+  const { NuqsAdapter } = createReactRouterBasedAdapter({
+    adapter: 'test-transition-lane-feedback',
+    useNavigate: () => () => {},
+    useSearchParams: initial => [initial, {}]
+  })
+  const feedbackListeners = new Set<() => void>()
+  let feedbackState: string | null | undefined
+  let feedbackUpdates = 0
+
+  function subscribeFeedback(listener: () => void) {
+    feedbackListeners.add(listener)
+    return () => feedbackListeners.delete(listener)
+  }
+
+  function publishFeedback(value: string | null) {
+    if (feedbackState === value || feedbackUpdates >= 20) return
+    feedbackState = value
+    feedbackUpdates++
+    feedbackListeners.forEach(listener => listener())
+  }
+
+  function Probe({ renders }: { renders: Array<string | null> }) {
+    const [{ value }, setState] = useQueryStates({
+      value: parseAsString.withOptions({
+        history: 'replace',
+        limitUrlUpdates: throttle(500)
+      })
+    })
+    useSyncExternalStore(
+      subscribeFeedback,
+      () => feedbackState,
+      () => feedbackState
+    )
+    const [, setTick] = useState(0)
+    renders.push(value)
+
+    useLayoutEffect(() => publishFeedback(value), [value])
+
+    return (
+      <>
+        <button
+          data-testid="write"
+          onClick={() => {
+            startTransition(() => void setState({ value: 'B' }))
+          }}
+        />
+        <button
+          data-testid="sync-write"
+          onClick={() => void setState({ value: 'B' })}
+        />
+        <button data-testid="tick" onClick={() => setTick(tick => tick + 1)} />
+      </>
+    )
+  }
+
+  const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+  const distinct = (values: Array<string | null>) =>
+    values.filter((value, index) => index === 0 || value !== values[index - 1])
+  const click = (testId: string) =>
+    page
+      .getByTestId(testId)
+      .element()
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+  afterEach(() => {
+    cleanup()
+    resetQueues()
+    feedbackListeners.clear()
+    feedbackState = undefined
+    feedbackUpdates = 0
+    const url = new URL(location.href)
+    url.searchParams.delete('value')
+    history.replaceState(history.state, '', url)
+  })
+
+  async function mount() {
+    globalThrottleQueue.lastFlushedAt = performance.now()
+    const renders: Array<string | null> = []
+    await render(
+      <NuqsAdapter>
+        <Probe renders={renders} />
+      </NuqsAdapter>
+    )
+    renders.splice(0, renders.length - 1)
+    return renders
+  }
+
+  it('converges when a later sync render feeds back through layout effects', async () => {
+    const renders = await mount()
+    click('write')
+    await sleep(0)
+    click('tick')
+    await sleep(100)
+
+    expect(distinct(renders)).toEqual([null, 'B'])
+  })
+
+  it('promotes a repeated transition value to the sync lane', async () => {
+    const renders = await mount()
+    click('write')
+    click('sync-write')
+    click('tick')
+    await sleep(100)
+
+    expect(renders[1]).toBe('B')
   })
 })

--- a/packages/nuqs/src/useQueryStates.discarded-reconcile.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.discarded-reconcile.browser.test.tsx
@@ -1,0 +1,239 @@
+import React, { startTransition, Suspense, useEffect, useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { NuqsAdapter } from './adapters/react'
+import { resetQueues } from './lib/queues/reset'
+import { parseAsString } from './parsers'
+import { useQueryStates } from './useQueryStates'
+
+const click = (testId: string) =>
+  page
+    .getByTestId(testId)
+    .element()
+    .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+describe('useQueryStates: discarded URL reconciliation', () => {
+  const originalUrl = location.href
+
+  afterEach(async () => {
+    await cleanup()
+    resetQueues()
+    history.replaceState(history.state, '', originalUrl)
+  })
+
+  // Regression for https://github.com/47ng/nuqs/issues/1567
+  it('preserves a URL-derived sibling when a write interrupts reconciliation', async () => {
+    let release!: () => void
+    let didSuspend = false
+    let suspended = true
+    const hold = new Promise<void>(resolve => {
+      release = resolve
+    }).then(() => {
+      suspended = false
+    })
+
+    function Suspender({ tick }: { tick: number }) {
+      if (tick % 2 === 1 && suspended) {
+        didSuspend = true
+        throw hold
+      }
+      return null
+    }
+
+    function Probe() {
+      const [{ a, b }, setValues] = useQueryStates({
+        a: parseAsString,
+        b: parseAsString
+      })
+      const [tick, setTick] = useState(0)
+      return (
+        <>
+          <button
+            data-testid="transition"
+            onClick={() => startTransition(() => setTick(t => t + 1))}
+          />
+          <button
+            data-testid="write-a"
+            onClick={() => void setValues({ a: '5' })}
+          />
+          <output data-testid="a">{a}</output>
+          <output data-testid="b">{b}</output>
+          <Suspense fallback={null}>
+            <Suspender tick={tick} />
+          </Suspense>
+        </>
+      )
+    }
+
+    const url = new URL(location.href)
+    url.searchParams.set('a', '1')
+    url.searchParams.set('b', '1')
+    history.replaceState(history.state, '', url)
+    await render(
+      <NuqsAdapter>
+        <Probe />
+      </NuqsAdapter>
+    )
+    await expect.element(page.getByTestId('b')).toHaveTextContent('1')
+
+    url.searchParams.set('b', '2')
+    history.replaceState(history.state, '', url)
+    click('transition')
+    await expect.poll(() => didSuspend).toBe(true)
+    click('write-a')
+    await expect.element(page.getByTestId('a')).toHaveTextContent('5')
+    await expect.element(page.getByTestId('b')).toHaveTextContent('2')
+    release()
+
+    await expect.element(page.getByTestId('a')).toHaveTextContent('5')
+    await expect.element(page.getByTestId('b')).toHaveTextContent('2')
+  })
+
+  it('preserves a URL-derived sibling when the interrupt matches committed state', async () => {
+    let release!: () => void
+    let didSuspend = false
+    let suspended = true
+    const hold = new Promise<void>(resolve => {
+      release = resolve
+    }).then(() => {
+      suspended = false
+    })
+
+    function Suspender({ tick }: { tick: number }) {
+      if (tick % 2 === 1 && suspended) {
+        didSuspend = true
+        throw hold
+      }
+      return null
+    }
+
+    function Probe() {
+      const [{ a, b }, setValues] = useQueryStates({
+        a: parseAsString,
+        b: parseAsString
+      })
+      const [tick, setTick] = useState(0)
+      return (
+        <>
+          <button
+            data-testid="transition"
+            onClick={() => startTransition(() => setTick(t => t + 1))}
+          />
+          <button
+            data-testid="write-a"
+            onClick={() => void setValues({ a: '1' })}
+          />
+          <output data-testid="a">{a}</output>
+          <output data-testid="b">{b}</output>
+          <Suspense fallback={null}>
+            <Suspender tick={tick} />
+          </Suspense>
+        </>
+      )
+    }
+
+    const url = new URL(location.href)
+    url.searchParams.set('a', '1')
+    url.searchParams.set('b', '1')
+    history.replaceState(history.state, '', url)
+    await render(
+      <NuqsAdapter>
+        <Probe />
+      </NuqsAdapter>
+    )
+    await expect.element(page.getByTestId('b')).toHaveTextContent('1')
+
+    url.searchParams.set('a', '2')
+    url.searchParams.set('b', '2')
+    history.replaceState(history.state, '', url)
+    click('transition')
+    await expect.poll(() => didSuspend).toBe(true)
+    click('write-a')
+
+    await expect.element(page.getByTestId('a')).toHaveTextContent('1')
+    await expect.element(page.getByTestId('b')).toHaveTextContent('2')
+    release()
+    await expect.element(page.getByTestId('b')).toHaveTextContent('2')
+  })
+
+  it('does not resurrect a cancelled transition before a derived write', async () => {
+    let release!: () => void
+    let didSuspend = false
+    let didReconcile = false
+    let suspended = true
+    const hold = new Promise<void>(resolve => {
+      release = resolve
+    }).then(() => {
+      suspended = false
+    })
+
+    function Suspender({ value }: { value: string | null }) {
+      if (value === '2' && suspended) {
+        didSuspend = true
+        throw hold
+      }
+      return null
+    }
+
+    function Probe() {
+      const [{ a, b, c }, setValues] = useQueryStates({
+        a: parseAsString,
+        b: parseAsString,
+        c: parseAsString
+      })
+      useEffect(() => {
+        void setValues({ c: b }).then(() => {
+          if (b === '0') didReconcile = true
+        })
+      }, [b])
+      return (
+        <>
+          <button
+            data-testid="transition-a"
+            onClick={() => startTransition(() => void setValues({ a: '2' }))}
+          />
+          <output data-testid="a">{a}</output>
+          <output data-testid="b">{b}</output>
+          <output data-testid="c">{c}</output>
+          <Suspense fallback={null}>
+            <Suspender value={a} />
+          </Suspense>
+        </>
+      )
+    }
+
+    const url = new URL(location.href)
+    url.searchParams.set('a', '1')
+    url.searchParams.set('b', '1')
+    history.replaceState(history.state, '', url)
+    await render(
+      <NuqsAdapter>
+        <Probe />
+      </NuqsAdapter>
+    )
+    await expect.element(page.getByTestId('c')).toHaveTextContent('1')
+
+    click('transition-a')
+    await expect.poll(() => didSuspend).toBe(true)
+
+    const back = new URL(location.href)
+    back.searchParams.set('a', '1')
+    back.searchParams.set('b', '0')
+    history.replaceState(history.state, '', back)
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    await expect.poll(() => didReconcile).toBe(true)
+    release()
+
+    await expect.element(page.getByTestId('a')).toHaveTextContent('1')
+    await expect.element(page.getByTestId('b')).toHaveTextContent('0')
+    await expect.element(page.getByTestId('c')).toHaveTextContent('0')
+    expect(
+      Object.fromEntries(new URL(location.href).searchParams)
+    ).toMatchObject({
+      a: '1',
+      b: '0',
+      c: '0'
+    })
+  })
+})

--- a/packages/nuqs/src/useQueryStates.mutation.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.mutation.browser.test.tsx
@@ -1,0 +1,213 @@
+import React, {
+  createElement,
+  startTransition,
+  Suspense,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react'
+import { flushSync } from 'react-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render } from 'vitest-browser-react'
+import { page } from 'vitest/browser'
+import { context } from './adapters/lib/context'
+import type { AdapterInterface } from './adapters/lib/defs'
+import { NuqsTestingAdapter } from './adapters/testing'
+import { resetQueues } from './lib/queues/reset'
+import { emitter } from './lib/sync'
+import { parseAsString } from './parsers'
+import { useQueryStates } from './useQueryStates'
+
+const click = (testId: string) =>
+  page
+    .getByTestId(testId)
+    .element()
+    .dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+function ControlledAdapter({
+  children,
+  pathname,
+  search
+}: {
+  children: ReactNode
+  pathname: string | undefined
+  search: string
+}) {
+  const adapter = useMemo<AdapterInterface>(
+    () => ({
+      pathname,
+      searchParams: new URLSearchParams(search),
+      updateUrl: () => {}
+    }),
+    [pathname, search]
+  )
+  return createElement(
+    context.Provider,
+    { value: { useAdapter: () => adapter } },
+    children
+  )
+}
+
+describe('useQueryStates: mutation qualification', () => {
+  const originalUrl = location.href
+
+  afterEach(async () => {
+    await cleanup()
+    resetQueues()
+    history.replaceState(history.state, '', originalUrl)
+  })
+
+  it.each([
+    {
+      name: 'a pathname-aware adapter with a matching live search',
+      pathnameAware: true
+    },
+    {
+      name: 'a pathname-less adapter with a stale live search',
+      pathnameAware: false
+    }
+  ])(
+    'blocks abandoned-render recovery for $name',
+    async ({ pathnameAware }) => {
+      let didSuspend = false
+      const hold = new Promise<never>(() => {})
+      const commits: Array<string | null> = []
+
+      function Probe() {
+        const [{ value }] = useQueryStates({ value: parseAsString })
+        useLayoutEffect(() => {
+          commits.push(value)
+        })
+        return <output data-testid="value">{value}</output>
+      }
+
+      function Suspender({ search }: { search: string }) {
+        if (search.includes('incoming')) {
+          didSuspend = true
+          throw hold
+        }
+        return null
+      }
+
+      function App() {
+        const [search, setSearch] = useState('?value=old')
+        const [pathname, setPathname] = useState<string | undefined>(
+          pathnameAware ? '/page' : undefined
+        )
+        const [, setTick] = useState(0)
+        return (
+          <>
+            <button
+              data-testid="reconcile"
+              onClick={() => {
+                history.replaceState(history.state, '', '/page?value=incoming')
+                startTransition(() => setSearch('?value=incoming'))
+              }}
+            />
+            <button
+              data-testid="interrupt"
+              onClick={() => {
+                if (pathnameAware) {
+                  setPathname('/elsewhere')
+                } else {
+                  history.replaceState(
+                    history.state,
+                    '',
+                    '/elsewhere?value=stale'
+                  )
+                  setTick(tick => tick + 1)
+                }
+              }}
+            />
+            <ControlledAdapter pathname={pathname} search={search}>
+              <Probe />
+              <Suspense fallback={null}>
+                <Suspender search={search} />
+              </Suspense>
+            </ControlledAdapter>
+          </>
+        )
+      }
+
+      history.replaceState(history.state, '', '/page?value=old')
+      await render(<App />)
+      expect(commits).toEqual(['old'])
+
+      click('reconcile')
+      await expect.poll(() => didSuspend).toBe(true)
+
+      flushSync(() => click('interrupt'))
+
+      expect(commits).toEqual(['old', 'old'])
+      expect(page.getByTestId('value').element().textContent).toBe('old')
+    }
+  )
+
+  it('keeps optimistic transition state out of urgent rebases and same-value bailouts', async () => {
+    let didSuspend = false
+    const hold = new Promise<never>(() => {})
+    const commits: Array<{ a: string | null; b: string | null }> = []
+
+    function Suspender({ value }: { value: string | null }) {
+      if (value === '2') {
+        didSuspend = true
+        throw hold
+      }
+      return null
+    }
+
+    function Probe() {
+      const [state] = useQueryStates({
+        a: parseAsString,
+        b: parseAsString
+      })
+      useLayoutEffect(() => {
+        commits.push(state)
+      })
+      return (
+        <>
+          <button
+            data-testid="transition-a"
+            onClick={() =>
+              startTransition(() =>
+                emitter.emit('a', { state: '2', query: '2' })
+              )
+            }
+          />
+          <button
+            data-testid="same-b"
+            onClick={() => emitter.emit('b', { state: '1', query: '1' })}
+          />
+          <button
+            data-testid="change-b"
+            onClick={() => emitter.emit('b', { state: '2', query: '2' })}
+          />
+          <output data-testid="state">{`${state.a},${state.b}`}</output>
+          <Suspense fallback={null}>
+            <Suspender value={state.a} />
+          </Suspense>
+        </>
+      )
+    }
+
+    await render(
+      <NuqsTestingAdapter searchParams="?a=1&b=1">
+        <Probe />
+      </NuqsTestingAdapter>
+    )
+    const initialState = commits.at(-1)
+    expect(initialState).toEqual({ a: '1', b: '1' })
+
+    click('transition-a')
+    await expect.poll(() => didSuspend).toBe(true)
+
+    flushSync(() => click('same-b'))
+    expect(commits.at(-1)).toBe(initialState)
+
+    flushSync(() => click('change-b'))
+    expect(commits.at(-1)).toEqual({ a: '1', b: '2' })
+    expect(commits.at(-1)).not.toBe(initialState)
+    expect(page.getByTestId('state').element().textContent).toBe('1,2')
+  })
+})

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -163,6 +163,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const [internalState, setInternalState] = useState<V>(initial[0])
 
   const stateRef = useRef(internalState)
+  const committedStateRef = useRef(internalState)
   // Only URL-derived state is safe to recover across React lanes. Optimistic
   // state stays in React's update queue until its own lane renders it.
   const urlStateRef = useRef(internalState)
@@ -267,6 +268,10 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     reconcile()
   }, [searchParamsSyncKey, adapter.pathname])
 
+  useEffect(() => {
+    committedStateRef.current = internalState
+  }, [internalState])
+
   // Sync all hooks together & with external URL changes
   useEffect(() => {
     const subscriptions: Array<
@@ -274,8 +279,23 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     > = []
     for (const [stateKey, urlKey] of Object.entries(resolvedUrlKeys)) {
       const handler = ({ state, query }: CrossHookSyncPayload) => {
+        const wasCommitted = Object.is(
+          committedStateRef.current[stateKey] ?? null,
+          state
+        )
+        // Update the cache before scheduling React state. A higher-priority
+        // render may run before React evaluates the updater below; it must see
+        // this optimistic value as cached state, not adopt it as URL state.
+        queryRef.current[urlKey] = query
+        stateRef.current = {
+          ...stateRef.current,
+          [stateKey as keyof KeyMap]: state
+        }
         setInternalState(currentState => {
-          if (Object.is(currentState[stateKey] ?? null, state)) {
+          if (
+            wasCommitted &&
+            Object.is(currentState[stateKey] ?? null, state)
+          ) {
             debug(
               2,
               hookId,
@@ -290,11 +310,10 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           }
           // Note: cannot mutate in-place, the object ref must change
           // for the subsequent setState to pick it up.
-          stateRef.current = {
-            ...stateRef.current,
+          const nextState = {
+            ...currentState,
             [stateKey as keyof KeyMap]: state
           }
-          queryRef.current[urlKey] = query
           debug(
             3,
             hookId,
@@ -302,9 +321,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
             urlKey,
             state,
             keyMap[stateKey]?.defaultValue,
-            stateRef.current
+            nextState
           )
-          return stateRef.current
+          return nextState
         })
       }
       debug(4, hookId, urlKey, stateKeys)

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -275,13 +275,15 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     for (const [stateKey, urlKey] of Object.entries(resolvedUrlKeys)) {
       const handler = ({ state, query }: CrossHookSyncPayload) => {
         const previousState = stateRef.current
-        const wasCached = Object.is(previousState[stateKey] ?? null, state)
         const wasUrlState = previousState === urlStateRef.current
         // Update the cache before scheduling React state. A higher-priority
         // render may run before React evaluates the updater below; it must see
         // this optimistic value as cached state, not adopt it as URL state.
         queryRef.current[urlKey] = query
-        const nextCachedState = wasCached
+        const nextCachedState = Object.is(
+          previousState[stateKey] ?? null,
+          state
+        )
           ? previousState
           : {
               ...previousState,
@@ -291,7 +293,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
         setInternalState(currentState => {
           if (
             Object.is(currentState[stateKey] ?? null, state) &&
-            !(wasUrlState && currentState !== previousState)
+            (currentState === previousState || !wasUrlState)
           ) {
             debug(
               2,
@@ -311,7 +313,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
               ? nextCachedState
               : {
                   ...currentState,
-                  ...(wasUrlState ? previousState : {}),
+                  ...(wasUrlState && previousState),
                   [stateKey as keyof KeyMap]: state
                 }
           debug(

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -1,12 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import {
   useAdapter,
   useAdapterDefaultOptions,
@@ -171,13 +163,9 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const [internalState, setInternalState] = useState<V>(initial[0])
 
   const stateRef = useRef(internalState)
-  // Recovery may run during a higher-priority render that intentionally skips a
-  // pending state update. Only expose state that either came from the URL or
-  // reached the commit phase; speculative updater state must keep its lane.
-  const recoveryStateRef = useRef(internalState)
-  useLayoutEffect(() => {
-    recoveryStateRef.current = internalState
-  }, [internalState])
+  // Only URL-derived state is safe to recover across React lanes. Optimistic
+  // state stays in React's update queue until its own lane renders it.
+  const urlStateRef = useRef(internalState)
 
   // Identifies the current URL source (resolved search params + queued queries).
   // Mirrors the dependencies of the URL sync effect below so that render-time
@@ -203,7 +191,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     if (hasChanged) {
       debug(1, hookId, stateKeys, state)
       stateRef.current = state
-      recoveryStateRef.current = state
+      urlStateRef.current = state
       setInternalState(state)
     }
     return hasChanged
@@ -249,12 +237,10 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     if (
       !didReconcileState &&
       internalState !== stateRef.current &&
-      stateRef.current === recoveryStateRef.current
+      stateRef.current === urlStateRef.current
     ) {
-      // Recover state from an abandoned URL reconciliation or from a concurrent
-      // rebase after the optimistic value has already committed. If the latest
-      // state has not committed yet, it belongs to a pending React lane and must
-      // not be restored into this render.
+      // Recover URL-derived state from a render React abandoned. Optimistic
+      // state is excluded above because React must preserve its update lane.
       if (
         onCommittedPathname ||
         (adapter.pathname === undefined &&

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -163,7 +163,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const [internalState, setInternalState] = useState<V>(initial[0])
 
   const stateRef = useRef(internalState)
-  const committedStateRef = useRef(internalState)
   // Only URL-derived state is safe to recover across React lanes. Optimistic
   // state stays in React's update queue until its own lane renders it.
   const urlStateRef = useRef(internalState)
@@ -268,10 +267,6 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     reconcile()
   }, [searchParamsSyncKey, adapter.pathname])
 
-  useEffect(() => {
-    committedStateRef.current = internalState
-  }, [internalState])
-
   // Sync all hooks together & with external URL changes
   useEffect(() => {
     const subscriptions: Array<
@@ -279,23 +274,19 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     > = []
     for (const [stateKey, urlKey] of Object.entries(resolvedUrlKeys)) {
       const handler = ({ state, query }: CrossHookSyncPayload) => {
-        const wasCommitted = Object.is(
-          committedStateRef.current[stateKey] ?? null,
-          state
-        )
+        const previousState = stateRef.current
+        const wasCached = Object.is(previousState[stateKey] ?? null, state)
         // Update the cache before scheduling React state. A higher-priority
         // render may run before React evaluates the updater below; it must see
         // this optimistic value as cached state, not adopt it as URL state.
         queryRef.current[urlKey] = query
-        stateRef.current = {
-          ...stateRef.current,
+        const nextCachedState = {
+          ...previousState,
           [stateKey as keyof KeyMap]: state
         }
+        stateRef.current = nextCachedState
         setInternalState(currentState => {
-          if (
-            wasCommitted &&
-            Object.is(currentState[stateKey] ?? null, state)
-          ) {
+          if (wasCached && currentState === previousState) {
             debug(
               2,
               hookId,
@@ -310,10 +301,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
           }
           // Note: cannot mutate in-place, the object ref must change
           // for the subsequent setState to pick it up.
-          const nextState = {
-            ...currentState,
-            [stateKey as keyof KeyMap]: state
-          }
+          const nextState =
+            currentState === previousState
+              ? nextCachedState
+              : {
+                  ...currentState,
+                  [stateKey as keyof KeyMap]: state
+                }
           debug(
             3,
             hookId,

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import {
   useAdapter,
   useAdapterDefaultOptions,
@@ -163,6 +171,13 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const [internalState, setInternalState] = useState<V>(initial[0])
 
   const stateRef = useRef(internalState)
+  // Recovery may run during a higher-priority render that intentionally skips a
+  // pending state update. Only expose state that either came from the URL or
+  // reached the commit phase; speculative updater state must keep its lane.
+  const recoveryStateRef = useRef(internalState)
+  useLayoutEffect(() => {
+    recoveryStateRef.current = internalState
+  }, [internalState])
 
   // Identifies the current URL source (resolved search params + queued queries).
   // Mirrors the dependencies of the URL sync effect below so that render-time
@@ -188,6 +203,7 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
     if (hasChanged) {
       debug(1, hookId, stateKeys, state)
       stateRef.current = state
+      recoveryStateRef.current = state
       setInternalState(state)
     }
     return hasChanged
@@ -230,9 +246,15 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       lastSyncKeyRef.current = searchParamsSyncKey
       didReconcileState = reconcile()
     }
-    if (!didReconcileState && internalState !== stateRef.current) {
-      // Recover a render-phase state update lost with an abandoned render or a
-      // concurrent rebase whose URL source is already reflected in the cache.
+    if (
+      !didReconcileState &&
+      internalState !== stateRef.current &&
+      stateRef.current === recoveryStateRef.current
+    ) {
+      // Recover state from an abandoned URL reconciliation or from a concurrent
+      // rebase after the optimistic value has already committed. If the latest
+      // state has not committed yet, it belongs to a pending React lane and must
+      // not be restored into this render.
       if (
         onCommittedPathname ||
         (adapter.pathname === undefined &&

--- a/packages/nuqs/src/useQueryStates.ts
+++ b/packages/nuqs/src/useQueryStates.ts
@@ -163,8 +163,8 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
   const [internalState, setInternalState] = useState<V>(initial[0])
 
   const stateRef = useRef(internalState)
-  // Only URL-derived state is safe to recover across React lanes. Optimistic
-  // state stays in React's update queue until its own lane renders it.
+  // Tracks the latest state parsed from the URL. Matching identity marks the
+  // cache as URL-derived; optimistic state stays in React's update queue.
   const urlStateRef = useRef(internalState)
 
   // Identifies the current URL source (resolved search params + queued queries).
@@ -276,17 +276,23 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
       const handler = ({ state, query }: CrossHookSyncPayload) => {
         const previousState = stateRef.current
         const wasCached = Object.is(previousState[stateKey] ?? null, state)
+        const wasUrlState = previousState === urlStateRef.current
         // Update the cache before scheduling React state. A higher-priority
         // render may run before React evaluates the updater below; it must see
         // this optimistic value as cached state, not adopt it as URL state.
         queryRef.current[urlKey] = query
-        const nextCachedState = {
-          ...previousState,
-          [stateKey as keyof KeyMap]: state
-        }
+        const nextCachedState = wasCached
+          ? previousState
+          : {
+              ...previousState,
+              [stateKey as keyof KeyMap]: state
+            }
         stateRef.current = nextCachedState
         setInternalState(currentState => {
-          if (wasCached && currentState === previousState) {
+          if (
+            Object.is(currentState[stateKey] ?? null, state) &&
+            !(wasUrlState && currentState !== previousState)
+          ) {
             debug(
               2,
               hookId,
@@ -294,18 +300,18 @@ export function useQueryStates<KeyMap extends UseQueryStatesKeysMap>(
               urlKey,
               state,
               keyMap[stateKey]?.defaultValue,
-              stateRef.current
+              currentState
             )
             // bail out by returning the current state
             return currentState
           }
-          // Note: cannot mutate in-place, the object ref must change
-          // for the subsequent setState to pick it up.
+          // Rebased updates need a new object reference.
           const nextState =
             currentState === previousState
               ? nextCachedState
               : {
                   ...currentState,
+                  ...(wasUrlState ? previousState : {}),
                   [stateKey as keyof KeyMap]: state
                 }
           debug(


### PR DESCRIPTION
## Summary

- add the reporter's regression test for interrupted transition writes
- keep optimistic query state on its React transition lane
- preserve recovery after discarded URL reconciliations

## Root cause

`stateRef` had two jobs: it tracked the latest optimistic value and also acted as the recovery source. A synchronous render can skip a pending transition update, but the old recovery condition copied the optimistic value from `stateRef` into that synchronous render. This leaked the transition value across lanes and produced `null → B → null → B` commits.

The fix adds `urlStateRef`, which tracks only values parsed from the URL. Render-time recovery now runs only when the latest state is URL-derived. Optimistic state never becomes a recovery source, so React remains responsible for rendering it on its original lane.

This narrows the recovery added in #1558 rather than removing it. The same patch was also tested on top of #1564 and #1565.

## Verification

- 273 unit tests passed
- 56 type tests passed
- 175 browser tests passed, 1 skipped
- client bundle: 5.89 kB, size limit passed
- #1506 E2E regression passed
- #1567 repro passed for both adapters
- shared lane-priority E2E passed on Next.js app/pages, React SPA, React Router v5-v8, Remix, and TanStack Router
- discarded navigation recovery passed
- on top of #1564 and #1565: 273 unit, 56 type, 185 browser, and 16 sequential React Router/Remix repro tests passed
- pre-push lint hook passed

Fixes #1567
