### PR TITLE
fix: compose pending React Router navigations

### DIFF
--- a/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
@@ -1,5 +1,8 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
-import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
+import {
+  countLoaderCall,
+  loadDelay
+} from 'e2e-shared/specs/react-router/repro-1563.defs'
 import {
   type LoaderFunctionArgs,
   useLoaderData,
@@ -8,10 +11,9 @@ import {
 } from 'react-router-dom'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const call = ++loaderCall
+  const call = countLoaderCall(request)
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)

--- a/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
@@ -6,6 +6,7 @@ import {
 import {
   type LoaderFunctionArgs,
   useLoaderData,
+  useNavigate,
   useNavigation,
   useNavigationType
 } from 'react-router-dom'
@@ -26,6 +27,7 @@ export default function Page() {
   return (
     <Repro1563
       loaderCall={loaderCall}
+      useNavigate={useNavigate}
       useNavigation={useNavigation}
       useNavigationType={useNavigationType}
     />

--- a/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
@@ -1,17 +1,31 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
-import { useNavigationType, type LoaderFunctionArgs } from 'react-router-dom'
+import {
+  type LoaderFunctionArgs,
+  useLoaderData,
+  useNavigation,
+  useNavigationType
+} from 'react-router-dom'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  const call = ++loaderCall
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)
   }
-  return null
+  return call
 }
 
 export default function Page() {
-  return <Repro1563 useNavigationType={useNavigationType} />
+  const loaderCall = useLoaderData() as Awaited<ReturnType<typeof loader>>
+  return (
+    <Repro1563
+      loaderCall={loaderCall}
+      useNavigation={useNavigation}
+      useNavigationType={useNavigationType}
+    />
+  )
 }

--- a/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
@@ -4,6 +4,7 @@ import {
   loadDelay
 } from 'e2e-shared/specs/react-router/repro-1563.defs'
 import {
+  useNavigate,
   useNavigation,
   useNavigationType,
   useLoaderData,
@@ -26,6 +27,7 @@ export default function Page() {
   return (
     <Repro1563
       loaderCall={loaderCall}
+      useNavigate={useNavigate}
       useNavigation={useNavigation}
       useNavigationType={useNavigationType}
     />

--- a/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
@@ -1,5 +1,8 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
-import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
+import {
+  countLoaderCall,
+  loadDelay
+} from 'e2e-shared/specs/react-router/repro-1563.defs'
 import {
   useNavigation,
   useNavigationType,
@@ -8,10 +11,9 @@ import {
 } from 'react-router'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const call = ++loaderCall
+  const call = countLoaderCall(request)
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)

--- a/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
@@ -1,17 +1,31 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
-import { useNavigationType, type LoaderFunctionArgs } from 'react-router'
+import {
+  useNavigation,
+  useNavigationType,
+  useLoaderData,
+  type LoaderFunctionArgs
+} from 'react-router'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  const call = ++loaderCall
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)
   }
-  return null
+  return call
 }
 
 export default function Page() {
-  return <Repro1563 useNavigationType={useNavigationType} />
+  const loaderCall = useLoaderData<typeof loader>()
+  return (
+    <Repro1563
+      loaderCall={loaderCall}
+      useNavigation={useNavigation}
+      useNavigationType={useNavigationType}
+    />
+  )
 }

--- a/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
@@ -4,6 +4,7 @@ import {
   loadDelay
 } from 'e2e-shared/specs/react-router/repro-1563.defs'
 import {
+  useNavigate,
   useNavigation,
   useNavigationType,
   useLoaderData,
@@ -26,6 +27,7 @@ export default function Page() {
   return (
     <Repro1563
       loaderCall={loaderCall}
+      useNavigate={useNavigate}
       useNavigation={useNavigation}
       useNavigationType={useNavigationType}
     />

--- a/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
@@ -1,5 +1,8 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
-import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
+import {
+  countLoaderCall,
+  loadDelay
+} from 'e2e-shared/specs/react-router/repro-1563.defs'
 import {
   useNavigation,
   useNavigationType,
@@ -8,10 +11,9 @@ import {
 } from 'react-router'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const call = ++loaderCall
+  const call = countLoaderCall(request)
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)

--- a/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
@@ -1,17 +1,31 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
-import { useNavigationType, type LoaderFunctionArgs } from 'react-router'
+import {
+  useNavigation,
+  useNavigationType,
+  useLoaderData,
+  type LoaderFunctionArgs
+} from 'react-router'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  const call = ++loaderCall
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)
   }
-  return null
+  return call
 }
 
 export default function Page() {
-  return <Repro1563 useNavigationType={useNavigationType} />
+  const loaderCall = useLoaderData<typeof loader>()
+  return (
+    <Repro1563
+      loaderCall={loaderCall}
+      useNavigation={useNavigation}
+      useNavigationType={useNavigationType}
+    />
+  )
 }

--- a/packages/e2e/remix/app/routes/repro-1563.tsx
+++ b/packages/e2e/remix/app/routes/repro-1563.tsx
@@ -6,6 +6,7 @@ import {
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import {
   useLoaderData,
+  useNavigate,
   useNavigation,
   useNavigationType
 } from '@remix-run/react'
@@ -26,6 +27,7 @@ export default function Page() {
   return (
     <Repro1563
       loaderCall={loaderCall}
+      useNavigate={useNavigate}
       useNavigation={useNavigation}
       useNavigationType={useNavigationType}
     />

--- a/packages/e2e/remix/app/routes/repro-1563.tsx
+++ b/packages/e2e/remix/app/routes/repro-1563.tsx
@@ -1,5 +1,8 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
-import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
+import {
+  countLoaderCall,
+  loadDelay
+} from 'e2e-shared/specs/react-router/repro-1563.defs'
 import type { LoaderFunctionArgs } from '@remix-run/node'
 import {
   useLoaderData,
@@ -8,10 +11,9 @@ import {
 } from '@remix-run/react'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const call = ++loaderCall
+  const call = countLoaderCall(request)
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)

--- a/packages/e2e/remix/app/routes/repro-1563.tsx
+++ b/packages/e2e/remix/app/routes/repro-1563.tsx
@@ -1,18 +1,31 @@
 import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { loadDelay } from 'e2e-shared/specs/react-router/repro-1563.defs'
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import { useNavigationType } from '@remix-run/react'
+import {
+  useLoaderData,
+  useNavigation,
+  useNavigationType
+} from '@remix-run/react'
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+let loaderCall = 0
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  const call = ++loaderCall
   const { delay } = loadDelay(request)
   if (delay) {
     await wait(delay)
   }
-  return null
+  return call
 }
 
 export default function Page() {
-  return <Repro1563 useNavigationType={useNavigationType} />
+  const loaderCall = useLoaderData<typeof loader>()
+  return (
+    <Repro1563
+      loaderCall={loaderCall}
+      useNavigation={useNavigation}
+      useNavigationType={useNavigationType}
+    />
+  )
 }

--- a/packages/e2e/shared/specs/react-router/repro-1563.defs.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.defs.ts
@@ -1,5 +1,14 @@
 import { createLoader, parseAsInteger } from 'nuqs/server'
 
+const loaderCalls = new Map<string, number>()
+
+export function countLoaderCall(request: Request): number {
+  const loaderId = new URL(request.url).searchParams.get('loaderId') ?? ''
+  const call = (loaderCalls.get(loaderId) ?? 0) + 1
+  loaderCalls.set(loaderId, call)
+  return call
+}
+
 export const loadDelay = createLoader({
   delay: parseAsInteger.withDefault(0)
 })

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -1,7 +1,11 @@
-import { expect, test as it } from '@playwright/test'
+import { expect, test as it, type Page } from '@playwright/test'
 import { defineTest } from '../../define-test'
 import { readHistoryIndex } from '../../playwright/history'
 import { navigateTo } from '../../playwright/navigate'
+
+async function readLoaderCall(page: Page): Promise<number> {
+  return Number(await page.locator('#loader-call').textContent())
+}
 
 export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('advances the router history index on push with shallow: false', async ({
@@ -18,6 +22,19 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expect(page.locator('#state')).toHaveText('init')
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
+
+  for (const history of ['replace', 'push'] as const) {
+    it(`does not run loaders for shallow ${history}`, async ({ page }) => {
+      await navigateTo(page, path, '?test=init')
+      const loaderCall = await page.locator('#loader-call').textContent()
+
+      await page.locator(`#shallow-${history}`).click()
+      await expect(page).toHaveURL(
+        url => url.searchParams.get('shallow') === 'pass'
+      )
+      await expect(page.locator('#loader-call')).toHaveText(loaderCall ?? '')
+    })
+  }
 
   it('lets a deep replace take over a pending deep push', async ({ page }) => {
     await navigateTo(page, path, '?test=init&delay=1000')
@@ -41,6 +58,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   }) => {
     await navigateTo(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
+    const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#push-then-shallow-replace').click()
     await expect(page).toHaveURL(
       url =>
@@ -57,8 +75,116 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expect(page.locator('#state')).toHaveText('pass')
     await expect(page.locator('#shallow-state')).toHaveText('pass')
     await expect(page.locator('#navigation-type')).toHaveText('PUSH')
+    expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
     await page.goBack()
     await expect(page.locator('#state')).toHaveText('init')
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+  })
+
+  it('keeps a shallow replace made while a deep replace is pending', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    const initialLoaderCall = await readLoaderCall(page)
+    await page.locator('#deep-replace').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#shallow-replace').click()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+    expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
+  })
+
+  it('keeps a shallow push made while a deep push is pending', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    const initialLoaderCall = await readLoaderCall(page)
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#shallow-push').click()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+    expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
+    await page.goBack()
+    await expect(page.locator('#state')).toHaveText('init')
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+  })
+
+  it('keeps a shallow push made while a deep replace is pending', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?test=init&delay=1000')
+    const initialLoaderCall = await readLoaderCall(page)
+    const initialHistoryLength = await page.evaluate(() => history.length)
+    await page.locator('#deep-replace').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#shallow-push').click()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
+    expect(await page.evaluate(() => history.length)).toBe(
+      initialHistoryLength + 1
+    )
+  })
+
+  it('does not let a pending deep replace mutate history after Back', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    await page.locator('#deep-replace').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#shallow-push').click()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await page.goBack()
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        !url.searchParams.has('shallow')
+    )
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+    await page.waitForTimeout(1100)
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        !url.searchParams.has('shallow')
+    )
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
 

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -29,6 +29,40 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
 
+  it('repairs the optimistic entry when the router replaces it before the pending push commits', async ({
+    page
+  }) => {
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    const initialHistoryLength = await page.evaluate(() => history.length)
+
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#router-replace').click()
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('redirected') === 'pass'
+    )
+
+    expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+    expect(await page.evaluate(() => history.length)).toBe(
+      initialHistoryLength + 1
+    )
+
+    await page.goBack()
+    await expect(page.locator('#state')).toHaveText('init')
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+    await page.goForward()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('redirected') === 'pass'
+    )
+    expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+  })
+
   for (const history of ['replace', 'push'] as const) {
     it(`does not run loaders for shallow ${history}`, async ({ page }) => {
       await navigateToRepro(page, path, '?test=init')

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -3,6 +3,12 @@ import { defineTest } from '../../define-test'
 import { readHistoryIndex } from '../../playwright/history'
 import { navigateTo } from '../../playwright/navigate'
 
+async function navigateToRepro(page: Page, path: string, search: string) {
+  const searchParams = new URLSearchParams(search)
+  searchParams.set('loaderId', crypto.randomUUID())
+  await navigateTo(page, path, `?${searchParams}`)
+}
+
 async function readLoaderCall(page: Page): Promise<number> {
   return Number(await page.locator('#loader-call').textContent())
 }
@@ -11,10 +17,10 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('advances the router history index on push with shallow: false', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init')
+    await navigateToRepro(page, path, '?test=init')
     const initialIndex = await readHistoryIndex(page)
     await page.locator('#push').click()
-    await expect(page).toHaveURL(url => url.search === '?test=pass')
+    await expect(page).toHaveURL(url => url.searchParams.get('test') === 'pass')
     await expect(page.locator('#state')).toHaveText('pass')
     await expect(page.locator('#navigation-type')).toHaveText('PUSH')
     expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
@@ -25,7 +31,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
 
   for (const history of ['replace', 'push'] as const) {
     it(`does not run loaders for shallow ${history}`, async ({ page }) => {
-      await navigateTo(page, path, '?test=init')
+      await navigateToRepro(page, path, '?test=init')
       const loaderCall = await page.locator('#loader-call').textContent()
 
       await page.locator(`#shallow-${history}`).click()
@@ -37,7 +43,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   }
 
   it('lets a deep replace take over a pending deep push', async ({ page }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     await page.locator('#push-then-replace').click()
     await expect(page).toHaveURL(
@@ -56,10 +62,12 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('keeps a shallow replace made while a deep push is pending', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     const initialLoaderCall = await readLoaderCall(page)
-    await page.locator('#push-then-shallow-replace').click()
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#shallow-replace').click()
     await expect(page).toHaveURL(
       url =>
         url.searchParams.get('test') === 'pass' &&
@@ -77,6 +85,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expect(page.locator('#navigation-type')).toHaveText('PUSH')
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
     await page.goBack()
+    await expect(page).toHaveURL(url => !url.searchParams.has('shallow'))
     await expect(page.locator('#state')).toHaveText('init')
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
@@ -84,7 +93,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('keeps a shallow replace made while a deep replace is pending', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#deep-replace').click()
@@ -108,7 +117,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('keeps a shallow push made while a deep push is pending', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#push').click()
@@ -135,7 +144,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('keeps a shallow push made while a deep replace is pending', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialLoaderCall = await readLoaderCall(page)
     const initialHistoryLength = await page.evaluate(() => history.length)
     await page.locator('#deep-replace').click()
@@ -161,7 +170,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('does not let a pending deep replace mutate history after Back', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     await page.locator('#deep-replace').click()
     await expect(page.locator('#navigation-state')).toHaveText('loading')
@@ -191,7 +200,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('repairs the optimistic entry when Back runs before the commit', async ({
     page
   }) => {
-    await navigateTo(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     await page.locator('#push').click()
     await expect(page).toHaveURL(url => url.searchParams.get('test') === 'pass')
@@ -220,6 +229,28 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
     await page.goBack()
     await expect(page.locator('#state')).toHaveText('init')
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+  })
+
+  it('shallow-pushes after Back cancelled a pending deep push', async ({
+    page
+  }) => {
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    await page.locator('#push').click()
+    await expect(page).toHaveURL(url => url.searchParams.get('test') === 'pass')
+    await page.goBack()
+    await expect(page.locator('#state')).toHaveText('init')
+    await page.locator('#shallow-push').click()
+    await expect(page.locator('#shallow-state')).toHaveText('pass')
+    await expect(page).toHaveURL(
+      url => url.searchParams.get('shallow') === 'pass'
+    )
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+    await page.goBack()
+    await expect(page).toHaveURL(url => url.searchParams.get('test') === 'init')
+    await expect(page.locator('#state')).toHaveText('init')
+    await expect(page.locator('#shallow-state')).toBeEmpty()
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
 })

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -36,6 +36,32 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     expect(await readHistoryIndex(page)).toBe(initialIndex)
   })
 
+  it('keeps a shallow replace made while a deep push is pending', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    await page.locator('#push-then-shallow-replace').click()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#shallow-state')).toHaveText('pass')
+    await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        url.searchParams.get('shallow') === 'pass'
+    )
+    await expect(page.locator('#state')).toHaveText('pass')
+    await expect(page.locator('#shallow-state')).toHaveText('pass')
+    await expect(page.locator('#navigation-type')).toHaveText('PUSH')
+    await page.goBack()
+    await expect(page.locator('#state')).toHaveText('init')
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+  })
+
   it('repairs the optimistic entry when Back runs before the commit', async ({
     page
   }) => {

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -41,11 +41,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expect(page.locator('#navigation-state')).toHaveText('loading')
     await page.locator('#router-replace').click()
     await expect(page.locator('#navigation-state')).toHaveText('idle')
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('redirected') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', redirected: 'pass' })
 
     expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
     expect(await page.evaluate(() => history.length)).toBe(
@@ -56,24 +52,24 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expect(page.locator('#state')).toHaveText('init')
     expect(await readHistoryIndex(page)).toBe(initialIndex)
     await page.goForward()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('redirected') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', redirected: 'pass' })
     expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
   })
 
   for (const history of ['replace', 'push'] as const) {
     it(`does not run loaders for shallow ${history}`, async ({ page }) => {
-      await navigateToRepro(page, path, '?test=init')
-      const loaderCall = await page.locator('#loader-call').textContent()
+      await navigateToRepro(page, path, '?test=init&delay=1000')
+      const initialLoaderCall = await readLoaderCall(page)
 
       await page.locator(`#shallow-${history}`).click()
-      await expect(page).toHaveURL(
-        url => url.searchParams.get('shallow') === 'pass'
-      )
-      await expect(page.locator('#loader-call')).toHaveText(loaderCall ?? '')
+      await expectSearch(page, { test: 'init', shallow: 'pass' })
+      expect(await readLoaderCall(page)).toBe(initialLoaderCall)
+
+      await page.locator('#push').click()
+      await expect(page.locator('#navigation-state')).toHaveText('loading')
+      await expect(page.locator('#navigation-state')).toHaveText('idle')
+      await expectSearch(page, { test: 'pass', shallow: 'pass' })
+      expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
     })
   }
 
@@ -90,15 +86,42 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     expect(page.url()).not.toContain(path)
   })
 
+  it('adds an entry when a deep push takes over a pending deep replace', async ({
+    page
+  }) => {
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    const initialIndex = await readHistoryIndex(page)
+    const initialHistoryLength = await page.evaluate(() => history.length)
+    await page.locator('#deep-replace').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#push-other').click()
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expectSearch(page, { test: 'pass', other: 'pass' })
+    await expect(page.locator('#navigation-type')).toHaveText('PUSH')
+    await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
+    expect(await page.evaluate(() => history.length)).toBe(
+      initialHistoryLength + 1
+    )
+    await page.goBack()
+    await expect(page).toHaveURL(
+      url =>
+        url.searchParams.get('test') === 'pass' &&
+        !url.searchParams.has('other')
+    )
+    expect(await readHistoryIndex(page)).toBe(initialIndex)
+    expect(await page.evaluate(() => history.length)).toBe(
+      initialHistoryLength + 1
+    )
+    await page.goForward()
+    await expectSearch(page, { test: 'pass', other: 'pass' })
+    expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+  })
+
   it('lets a deep replace take over a pending deep push', async ({ page }) => {
     await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
     await page.locator('#push-then-replace').click()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('other') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', other: 'pass' })
     await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
     await expect(page.locator('#state')).toHaveText('pass')
     await expect(page.locator('#navigation-type')).toHaveText('PUSH')
@@ -116,18 +139,10 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await page.locator('#push').click()
     await expect(page.locator('#navigation-state')).toHaveText('loading')
     await page.locator('#shallow-replace').click()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await expect(page.locator('#shallow-state')).toHaveText('pass')
     await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await expect(page.locator('#state')).toHaveText('pass')
     await expect(page.locator('#shallow-state')).toHaveText('pass')
     await expect(page.locator('#navigation-type')).toHaveText('PUSH')
@@ -147,17 +162,9 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await page.locator('#deep-replace').click()
     await expect(page.locator('#navigation-state')).toHaveText('loading')
     await page.locator('#shallow-replace').click()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await expect(page.locator('#navigation-state')).toHaveText('idle')
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     expect(await readHistoryIndex(page)).toBe(initialIndex)
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
   })
@@ -171,17 +178,9 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await page.locator('#push').click()
     await expect(page.locator('#navigation-state')).toHaveText('loading')
     await page.locator('#shallow-push').click()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await expect(page.locator('#navigation-state')).toHaveText('idle')
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
     await page.goBack()
@@ -198,17 +197,9 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await page.locator('#deep-replace').click()
     await expect(page.locator('#navigation-state')).toHaveText('loading')
     await page.locator('#shallow-push').click()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await expect(page.locator('#navigation-state')).toHaveText('idle')
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
     expect(await page.evaluate(() => history.length)).toBe(
       initialHistoryLength + 1
@@ -220,23 +211,16 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   }) => {
     await navigateToRepro(page, path, '?test=init&delay=1000')
     const initialIndex = await readHistoryIndex(page)
+    const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#deep-replace').click()
     await expect(page.locator('#navigation-state')).toHaveText('loading')
     await page.locator('#shallow-push').click()
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        url.searchParams.get('shallow') === 'pass'
-    )
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await page.goBack()
+    await expect
+      .poll(() => readLoaderCall(page))
+      .toBeGreaterThan(initialLoaderCall)
     await expect(page.locator('#navigation-state')).toHaveText('idle')
-    await expect(page).toHaveURL(
-      url =>
-        url.searchParams.get('test') === 'pass' &&
-        !url.searchParams.has('shallow')
-    )
-    expect(await readHistoryIndex(page)).toBe(initialIndex)
-    await page.waitForTimeout(1100)
     await expect(page).toHaveURL(
       url =>
         url.searchParams.get('test') === 'pass' &&

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -12,11 +12,17 @@ export function Repro1563({ useNavigationType }: Repro1563Props) {
     shallow: false
   })
   const [, setOther] = useQueryState('other', { shallow: false })
+  const [shallow, setShallow] = useQueryState('shallow')
   const navigationType = useNavigationType()
   const pushThenReplace = () => {
     setState('pass')
     setOther('pass', { limitUrlUpdates: debounce(100) })
   }
+  const pushThenShallowReplace = () => {
+    setState('pass')
+    setShallow('pass', { limitUrlUpdates: debounce(100) })
+  }
+
   return (
     <>
       <button id="push" onClick={() => setState('pass')}>
@@ -25,7 +31,12 @@ export function Repro1563({ useNavigationType }: Repro1563Props) {
       <button id="push-then-replace" onClick={pushThenReplace}>
         Push then replace
       </button>
+      <button id="push-then-shallow-replace" onClick={pushThenShallowReplace}>
+        Push then shallow replace
+      </button>
+
       <pre id="state">{state}</pre>
+      <pre id="shallow-state">{shallow}</pre>
       <pre id="navigation-type">{navigationType}</pre>
     </>
   )

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -4,12 +4,17 @@ import { debounce, useQueryState } from 'nuqs'
 
 type Repro1563Props = {
   loaderCall: number
+  useNavigate: () => (
+    to: string,
+    options?: { replace?: boolean }
+  ) => void | Promise<void>
   useNavigation: () => { state: string }
   useNavigationType: () => string
 }
 
 export function Repro1563({
   loaderCall,
+  useNavigate,
   useNavigation,
   useNavigationType
 }: Repro1563Props) {
@@ -19,6 +24,7 @@ export function Repro1563({
   })
   const [, setOther] = useQueryState('other', { shallow: false })
   const [shallow, setShallow] = useQueryState('shallow')
+  const navigate = useNavigate()
   const navigation = useNavigation()
   const navigationType = useNavigationType()
   const pushThenReplace = () => {
@@ -30,6 +36,16 @@ export function Repro1563({
     <>
       <button id="push" onClick={() => setState('pass')}>
         Push
+      </button>
+      <button
+        id="router-replace"
+        onClick={() => {
+          const search = new URLSearchParams(location.search)
+          search.set('redirected', 'pass')
+          navigate(`${location.pathname}?${search}`, { replace: true })
+        }}
+      >
+        Router replace
       </button>
       <button id="push-then-replace" onClick={pushThenReplace}>
         Push then replace

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -3,16 +3,23 @@
 import { debounce, useQueryState } from 'nuqs'
 
 type Repro1563Props = {
+  loaderCall: number
+  useNavigation: () => { state: string }
   useNavigationType: () => string
 }
 
-export function Repro1563({ useNavigationType }: Repro1563Props) {
+export function Repro1563({
+  loaderCall,
+  useNavigation,
+  useNavigationType
+}: Repro1563Props) {
   const [state, setState] = useQueryState('test', {
     history: 'push',
     shallow: false
   })
   const [, setOther] = useQueryState('other', { shallow: false })
   const [shallow, setShallow] = useQueryState('shallow')
+  const navigation = useNavigation()
   const navigationType = useNavigationType()
   const pushThenReplace = () => {
     setState('pass')
@@ -34,9 +41,40 @@ export function Repro1563({ useNavigationType }: Repro1563Props) {
       <button id="push-then-shallow-replace" onClick={pushThenShallowReplace}>
         Push then shallow replace
       </button>
-
+      <button
+        id="deep-replace"
+        onClick={() => setState('pass', { history: 'replace' })}
+      >
+        Deep replace
+      </button>
+      <button
+        id="shallow-replace"
+        onClick={() =>
+          setShallow('pass', {
+            history: 'replace',
+            shallow: true,
+            limitUrlUpdates: debounce(100)
+          })
+        }
+      >
+        Shallow replace
+      </button>
+      <button
+        id="shallow-push"
+        onClick={() =>
+          setShallow('pass', {
+            history: 'push',
+            shallow: true,
+            limitUrlUpdates: debounce(100)
+          })
+        }
+      >
+        Shallow push
+      </button>
       <pre id="state">{state}</pre>
       <pre id="shallow-state">{shallow}</pre>
+      <pre id="loader-call">{loaderCall}</pre>
+      <pre id="navigation-state">{navigation.state}</pre>
       <pre id="navigation-type">{navigationType}</pre>
     </>
   )

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -25,10 +25,6 @@ export function Repro1563({
     setState('pass')
     setOther('pass', { limitUrlUpdates: debounce(100) })
   }
-  const pushThenShallowReplace = () => {
-    setState('pass')
-    setShallow('pass', { limitUrlUpdates: debounce(100) })
-  }
 
   return (
     <>
@@ -37,9 +33,6 @@ export function Repro1563({
       </button>
       <button id="push-then-replace" onClick={pushThenReplace}>
         Push then replace
-      </button>
-      <button id="push-then-shallow-replace" onClick={pushThenShallowReplace}>
-        Push then shallow replace
       </button>
       <button
         id="deep-replace"

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -57,6 +57,12 @@ export function Repro1563({
         Deep replace
       </button>
       <button
+        id="push-other"
+        onClick={() => setOther('pass', { history: 'push' })}
+      >
+        Push other
+      </button>
+      <button
         id="shallow-replace"
         onClick={() =>
           setShallow('pass', {

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -1,12 +1,14 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createEmitter } from '../../lib/emitter'
 import {
+  hasPendingReplace,
   hasPendingPush,
   historyUpdateMarker,
   markPendingPush,
+  markPendingReplace,
   patchHistory,
   type SearchParamsSyncEmitterEvents,
-  updatePendingPushUrl
+  updatePendingNavigationUrl
 } from './patch-history'
 
 const pushState = vi.spyOn(history, 'pushState')
@@ -44,7 +46,7 @@ function traverse(action: () => void): Promise<void> {
   })
 }
 
-describe('patchHistory: pending push', () => {
+describe('patchHistory: pending navigation', () => {
   beforeAll(() => {
     patchHistory(emitter, 'test')
   })
@@ -155,6 +157,46 @@ describe('patchHistory: pending push', () => {
     expect(hasPendingPush()).toBe(true)
   })
 
+  it('keeps a shallow replacement when the router commits the pending push', () => {
+    const pendingUrl = new URL('?a=1', location.href)
+    history.replaceState(
+      markPendingPush(pendingUrl),
+      historyUpdateMarker,
+      pendingUrl
+    )
+    updatePendingNavigationUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    replaceState.mockClear()
+    routerPush('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?a=1&shallow=pass', location.href)
+    )
+    expect(pushState).not.toHaveBeenCalled()
+  })
+
+  it('does not retarget a pending push from a shallow replace after Back', async () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?')
+    const pendingUrl = new URL('?a=1', location.href)
+    history.pushState(
+      markPendingPush(pendingUrl),
+      historyUpdateMarker,
+      pendingUrl
+    )
+    await traverse(() => history.back())
+    updatePendingNavigationUrl(new URL('?shallow=pass', location.href))
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?shallow=pass')
+    await traverse(() => history.forward())
+    expect(location.search).toBe('?a=1')
+    expect(history.state).toEqual({ idx: 1 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
   it('repairs a pending push committed by a router replace', () => {
     history.replaceState({ idx: 3 }, historyUpdateMarker, '?')
     const pendingUrl = new URL('?a=1', location.href)
@@ -174,43 +216,48 @@ describe('patchHistory: pending push', () => {
     expect(hasPendingPush()).toBe(false)
   })
 
-  it('keeps a shallow replacement when the router commits the pending push', () => {
+  it('keeps a shallow replacement when a pending replace commits', () => {
     history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
-    optimisticPush('?a=1')
-    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
-    history.replaceState(
-      history.state,
-      historyUpdateMarker,
-      '?a=1&shallow=pass'
-    )
+    markPendingReplace(new URL('?a=1', location.href))
+    updatePendingNavigationUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1&shallow=pass')
     replaceState.mockClear()
-    routerPush('?a=1')
+    routerReplace('?a=1')
     expect(replaceState).toHaveBeenCalledExactlyOnceWith(
       { idx: 1 },
       '',
       new URL('?a=1&shallow=pass', location.href)
     )
-    expect(pushState).not.toHaveBeenCalled()
   })
 
-  it('does not retarget a pending push from a shallow replace after Back', async () => {
+  it('preserves an unrelated replacement while a replace is pending', () => {
     history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
-    optimisticPush('?a=1')
-    await traverse(() => history.back())
-    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
-    history.replaceState(
-      history.state,
-      historyUpdateMarker,
-      '?a=1&shallow=pass'
+    markPendingReplace(new URL('?a=1', location.href))
+    updatePendingNavigationUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1&shallow=pass')
+    replaceState.mockClear()
+    history.replaceState({ custom: true }, '', '?third-party=pass')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { custom: true },
+      '',
+      '?third-party=pass'
     )
-    await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 1 })
-    expect(hasPendingPush()).toBe(false)
+    expect(hasPendingReplace()).toBe(false)
   })
 
-  it('clears the pending push on a router replace', () => {
-    markPendingPush(new URL('?a=1', location.href))
-    routerReplace('?a=1')
-    expect(hasPendingPush()).toBe(false)
+  it('clears a pending replace when a pop supersedes it', () => {
+    history.replaceState({ idx: 4 }, historyUpdateMarker, '?a=1')
+    markPendingReplace(new URL('?a=1', location.href))
+    updatePendingNavigationUrl(new URL('?a=1&b=1', location.href))
+    history.pushState({ idx: 5 }, historyUpdateMarker, '?a=1&b=1')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+    expect(hasPendingReplace()).toBe(false)
+    replaceState.mockClear()
+    routerReplace('?next=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      '?next=1'
+    )
   })
 })

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -163,6 +163,18 @@ describe('patchHistory: pending navigation', () => {
     expect(hasPendingPush()).toBe(false)
   })
 
+  it('repairs the pending entry after a deep replace on its predecessor', async () => {
+    history.replaceState({ idx: 4 }, historyUpdateMarker, '?')
+    optimisticPush('?a=1')
+    await traverse(() => history.back())
+    markPendingReplace(new URL('?b=1', location.href))
+    history.replaceState(history.state, historyUpdateMarker, '?b=1')
+    history.replaceState({ idx: 4 }, '', '?b=1')
+    await traverse(() => history.forward())
+    expect(history.state).toEqual({ idx: 5 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
   it('repairs the pending entry after a marked replace changed its URL', async () => {
     history.replaceState({ idx: 4 }, historyUpdateMarker, '?')
     optimisticPush('?a=1')

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -5,7 +5,8 @@ import {
   historyUpdateMarker,
   markPendingPush,
   patchHistory,
-  type SearchParamsSyncEmitterEvents
+  type SearchParamsSyncEmitterEvents,
+  updatePendingPushUrl
 } from './patch-history'
 
 const pushState = vi.spyOn(history, 'pushState')
@@ -170,6 +171,46 @@ describe('patchHistory: pending push', () => {
       '?b=1'
     )
     expect(history.state).toEqual({ usr: null, key: 'router', idx: 4 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('keeps a shallow replacement when the router commits the pending push', () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
+    optimisticPush('?a=1')
+    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    replaceState.mockClear()
+    routerPush('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 1 },
+      '',
+      new URL('?a=1&shallow=pass', location.href)
+    )
+    expect(pushState).not.toHaveBeenCalled()
+  })
+
+  it('does not retarget a pending push from a shallow replace after Back', async () => {
+    history.replaceState({ idx: 0 }, historyUpdateMarker, '?a=1')
+    optimisticPush('?a=1')
+    await traverse(() => history.back())
+    updatePendingPushUrl(new URL('?a=1&shallow=pass', location.href))
+    history.replaceState(
+      history.state,
+      historyUpdateMarker,
+      '?a=1&shallow=pass'
+    )
+    await traverse(() => history.forward())
+    expect(history.state).toEqual({ idx: 1 })
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('clears the pending push on a router replace', () => {
+    markPendingPush(new URL('?a=1', location.href))
+    routerReplace('?a=1')
     expect(hasPendingPush()).toBe(false)
   })
 })

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -2,7 +2,6 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createEmitter } from '../../lib/emitter'
 import {
   hasPendingPush,
-  hasPendingReplace,
   historyUpdateMarker,
   markPendingPush,
   markPendingReplace,
@@ -500,7 +499,6 @@ describe('patchHistory: pending navigation', () => {
       '',
       new URL('?a=1&shallow=pass', location.href).href
     )
-    expect(hasPendingReplace()).toBe(false)
   })
 
   it('keeps a shallow push when a pending replace commits', () => {
@@ -514,7 +512,6 @@ describe('patchHistory: pending navigation', () => {
       '',
       new URL('?a=1&shallow=pass', location.href).href
     )
-    expect(hasPendingReplace()).toBe(false)
   })
 
   it('preserves an unrelated replacement while a replace is pending', () => {
@@ -526,9 +523,11 @@ describe('patchHistory: pending navigation', () => {
     expect(replaceState).toHaveBeenCalledExactlyOnceWith(
       { custom: true },
       '',
-      '?third-party=pass'
+      new URL('?third-party=pass', location.href).href
     )
-    expect(hasPendingReplace()).toBe(false)
+    replaceState.mockClear()
+    routerReplace('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith({ idx: 1 }, '', '?a=1')
   })
 
   it('clears a pending replace when a pop supersedes it', () => {
@@ -536,13 +535,8 @@ describe('patchHistory: pending navigation', () => {
     markPendingReplace(new URL('?a=1', location.href))
     history.pushState({ idx: 5 }, historyUpdateMarker, '?a=1&b=1')
     window.dispatchEvent(new PopStateEvent('popstate'))
-    expect(hasPendingReplace()).toBe(false)
     replaceState.mockClear()
-    routerReplace('?next=1')
-    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
-      { idx: 1 },
-      '',
-      '?next=1'
-    )
+    routerReplace('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith({ idx: 1 }, '', '?a=1')
   })
 })

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -25,12 +25,18 @@ type PendingPushState = {
 type PendingNavigationBase = {
   href: string
   currentHref: string
-  routerIndex: number | undefined
-  poppedSince: boolean
 }
 
 type PendingNavigation = PendingNavigationBase &
-  ({ history: 'push'; id: number } | { history: 'replace' })
+  (
+    | {
+        history: 'push'
+        id: number
+        routerIndex: number | undefined
+        poppedSince: boolean
+      }
+    | { history: 'replace' }
+  )
 
 const pendingNavigation = globalSingleton('pending-navigation', () => ({
   current: null as PendingNavigation | null,
@@ -58,9 +64,7 @@ export function markPendingReplace(url: URL): void {
   pendingNavigation.current = {
     history: 'replace',
     href: url.href,
-    currentHref: url.href,
-    routerIndex: history.state?.idx,
-    poppedSince: false
+    currentHref: url.href
   }
 }
 
@@ -92,10 +96,6 @@ export function hasPendingPush(): boolean {
   return pending?.history === 'push' && !pending.poppedSince
 }
 
-export function hasPendingReplace(): boolean {
-  return pendingNavigation.current?.history === 'replace'
-}
-
 function clearPendingNavigation(): void {
   pendingNavigation.current = null
 }
@@ -124,6 +124,16 @@ function handlePopOnPendingNavigation(): void {
   pending.poppedSince = true
 }
 
+function retargetPendingCommit(
+  pending: PendingNavigationBase,
+  url: string | URL
+): string {
+  const href = new URL(url, location.href).href
+  return withoutEmptyFragment(href) === withoutEmptyFragment(pending.href)
+    ? pending.currentHref
+    : href
+}
+
 function pendingPushCommitUrl(url: string | URL): string | null {
   const pending = pendingNavigation.current
   if (
@@ -133,19 +143,14 @@ function pendingPushCommitUrl(url: string | URL): string | null {
   ) {
     return null
   }
-  const href = new URL(url, location.href).href
-  return withoutEmptyFragment(href) === withoutEmptyFragment(pending.href)
-    ? pending.currentHref
-    : href
+  return retargetPendingCommit(pending, url)
 }
 
 function pendingReplaceCommit(url: string | URL): string | URL {
   const pending = pendingNavigation.current
-  if (pending?.history !== 'replace') {
-    return url
-  }
-  const href = new URL(url, location.href).href
-  return href === pending.href ? pending.currentHref : url
+  return pending?.history === 'replace'
+    ? retargetPendingCommit(pending, url)
+    : url
 }
 
 // React Router reads the optimistic entry's idx into its private index before

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -22,62 +22,85 @@ type PendingPushState = {
   [historyUpdateMarker]: number
 }
 
-type PendingPush = {
+type PendingNavigationBase = {
   href: string
-  id: number
   currentHref: string
   routerIndex: number | undefined
   poppedSince: boolean
 }
 
-const pendingPush = globalSingleton('pending-navigation', () => ({
-  current: null as PendingPush | null,
+type PendingNavigation = PendingNavigationBase &
+  ({ history: 'push'; id: number } | { history: 'replace' })
+
+const pendingNavigation = globalSingleton('pending-navigation', () => ({
+  current: null as PendingNavigation | null,
   // Identifies the exact optimistic entry that belongs to a pending push.
   nextId: 0
 }))
 
 export function markPendingPush(url: URL): PendingPushState {
-  const id = ++pendingPush.nextId
-  pendingPush.current = {
+  const id = ++pendingNavigation.nextId
+  pendingNavigation.current = {
+    history: 'push',
     href: url.href,
-    id,
     currentHref: url.href,
+    id,
     routerIndex: history.state?.idx,
     poppedSince: false
   }
   return { ...history.state, [historyUpdateMarker]: id }
 }
 
-function isOnPendingPushEntry(pending: PendingPush): boolean {
+export function markPendingReplace(url: URL): void {
+  pendingNavigation.current = {
+    history: 'replace',
+    href: url.href,
+    currentHref: url.href,
+    routerIndex: history.state?.idx,
+    poppedSince: false
+  }
+}
+
+function isOnPendingPushEntry(
+  pending: PendingNavigation & { history: 'push' }
+): boolean {
   return history.state?.[historyUpdateMarker] === pending.id
 }
 
-export function updatePendingPushUrl(url: URL): void {
-  const pending = pendingPush.current
+export function updatePendingNavigationUrl(url: URL): void {
+  const pending = pendingNavigation.current
   if (
     pending &&
     location.href === pending.currentHref &&
-    isOnPendingPushEntry(pending)
+    (pending.history === 'replace' || isOnPendingPushEntry(pending))
   ) {
     pending.currentHref = url.href
   }
 }
 
 export function hasPendingPush(): boolean {
-  const pending = pendingPush.current
-  return pending !== null && !pending.poppedSince
+  const pending = pendingNavigation.current
+  return pending?.history === 'push' && !pending.poppedSince
 }
 
-function clearPendingPush(): void {
-  pendingPush.current = null
+export function hasPendingReplace(): boolean {
+  return pendingNavigation.current?.history === 'replace'
+}
+
+function clearPendingNavigation(): void {
+  pendingNavigation.current = null
 }
 
 // Traversing forward onto an entry the router never committed leaves it
 // with the index nuqs cloned from its predecessor. Repair it before
 // the router reads it, so traversal deltas stay right (#1563).
-function repairOrNotePopOnPendingPush(): void {
-  const pending = pendingPush.current
+function handlePopOnPendingNavigation(): void {
+  const pending = pendingNavigation.current
   if (!pending) {
+    return
+  }
+  if (pending.history === 'replace') {
+    clearPendingNavigation()
     return
   }
   if (
@@ -90,15 +113,20 @@ function repairOrNotePopOnPendingPush(): void {
       { ...state, idx: pending.routerIndex + 1 },
       historyUpdateMarker
     )
-    pendingPush.current = null
+    pendingNavigation.current = null
     return
   }
   pending.poppedSince = true
 }
 
 function pendingPushCommitUrl(url: string | URL): string | URL | null {
-  const pending = pendingPush.current
-  if (!pending || pending.poppedSince || !isOnPendingPushEntry(pending)) {
+  const pending = pendingNavigation.current
+  if (
+    !pending ||
+    pending.history !== 'push' ||
+    pending.poppedSince ||
+    !isOnPendingPushEntry(pending)
+  ) {
     return null
   }
   const href = new URL(url, location.href).href
@@ -109,6 +137,16 @@ function pendingPushCommitUrl(url: string | URL): string | URL | null {
   }
   return url
 }
+function pendingReplaceCommit(url: string | URL): string | URL {
+  const pending = pendingNavigation.current
+  if (!pending || pending.history !== 'replace') {
+    return url
+  }
+  const href = new URL(url, location.href).href
+  return href === pending.href && pending.currentHref !== pending.href
+    ? new URL(pending.currentHref)
+    : url
+}
 
 // A router replace has already copied the optimistic entry's index into
 // private state. Repair the persisted entry here; the router catches up on
@@ -116,8 +154,8 @@ function pendingPushCommitUrl(url: string | URL): string | URL | null {
 function repairPendingPushReplaceState(
   state: History['state']
 ): History['state'] {
-  const pending = pendingPush.current
-  return pending &&
+  const pending = pendingNavigation.current
+  return pending?.history === 'push' &&
     !pending.poppedSince &&
     isOnPendingPushEntry(pending) &&
     typeof pending.routerIndex === 'number' &&
@@ -175,7 +213,7 @@ export function patchHistory(
     'popstate',
     () => {
       lastSearchSeen = location.search
-      repairOrNotePopOnPendingPush()
+      handlePopOnPendingNavigation()
       resetQueues()
     },
     { capture: true }
@@ -207,19 +245,20 @@ export function patchHistory(
     // a second entry (#1563).
     const commitUrl = pendingPushCommitUrl(url)
     const commit = commitUrl ? originalReplaceState : originalPushState
-    clearPendingPush()
+    clearPendingNavigation()
     commit.call(history, state, '', commitUrl ?? url)
     sync(commitUrl ?? url)
   }
   history.replaceState = function nuqs_replaceState(state, marker, url) {
-    const commitState =
-      url && marker !== historyUpdateMarker
-        ? repairPendingPushReplaceState(state)
-        : state
-    originalReplaceState.call(history, commitState, '', url)
+    const isRouterCommit = url && marker !== historyUpdateMarker
+    const commitUrl = isRouterCommit ? pendingReplaceCommit(url) : url
+    const commitState = isRouterCommit
+      ? repairPendingPushReplaceState(state)
+      : state
+    originalReplaceState.call(history, commitState, '', commitUrl)
     if (url && marker !== historyUpdateMarker) {
-      clearPendingPush()
-      sync(url)
+      clearPendingNavigation()
+      sync(commitUrl ?? url)
     }
   }
   markHistoryAsPatched(adapter)

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -27,19 +27,18 @@ type PendingNavigationBase = {
   currentHref: string
 }
 
-type PendingNavigation = PendingNavigationBase &
-  (
-    | {
-        history: 'push'
-        id: number
-        routerIndex: number | undefined
-        poppedSince: boolean
-      }
-    | { history: 'replace' }
-  )
+type PendingPush = PendingNavigationBase & {
+  history: 'push'
+  id: number
+  routerIndex: number | undefined
+}
+
+type PendingNavigation =
+  PendingPush | (PendingNavigationBase & { history: 'replace' })
 
 const pendingNavigation = globalSingleton('pending-navigation', () => ({
   current: null as PendingNavigation | null,
+  popped: null as PendingPush | null,
   nextId: 0
 }))
 
@@ -54,8 +53,7 @@ export function markPendingPush(url: URL): PendingPushState {
     href: url.href,
     currentHref: url.href,
     id,
-    routerIndex: history.state?.idx,
-    poppedSince: false
+    routerIndex: history.state?.idx
   }
   return { ...history.state, [historyUpdateMarker]: id }
 }
@@ -68,15 +66,18 @@ export function markPendingReplace(url: URL): void {
   }
 }
 
-function isOnPendingPushEntry(): boolean {
-  const pending = pendingNavigation.current
+function isPendingPushEntry(pending: PendingPush): boolean {
   return (
-    pending?.history === 'push' &&
     history.state?.[historyUpdateMarker] === pending.id &&
     // Shallow updates pass the starting state to pushState or replaceState.
     // The URL distinguishes the pending entry from the resulting marker copies.
     location.href === pending.currentHref
   )
+}
+
+function isOnPendingPushEntry(): boolean {
+  const pending = pendingNavigation.current
+  return pending?.history === 'push' && isPendingPushEntry(pending)
 }
 
 function isOnPendingReplaceEntry(): boolean {
@@ -92,36 +93,42 @@ function movePendingHref(): void {
 }
 
 export function hasPendingPush(): boolean {
-  const pending = pendingNavigation.current
-  return pending?.history === 'push' && !pending.poppedSince
+  return pendingNavigation.current?.history === 'push'
 }
 
 function clearPendingNavigation(): void {
   pendingNavigation.current = null
+  pendingNavigation.popped = null
+}
+
+function repairPendingPushIndex(pending: PendingPush): void {
+  if (typeof pending.routerIndex !== 'number') {
+    return
+  }
+  const { [historyUpdateMarker]: _, ...state } = history.state
+  history.replaceState(
+    { ...state, idx: pending.routerIndex + 1 },
+    historyUpdateMarker
+  )
 }
 
 // Traversing forward onto an entry the router never committed leaves it
 // with the index nuqs cloned from its predecessor. Repair it before
 // the router reads it, so traversal deltas stay right (#1563).
 function handlePopOnPendingNavigation(): void {
-  const pending = pendingNavigation.current
-  if (!pending) {
-    return
+  const { current, popped } = pendingNavigation
+  if (popped && isPendingPushEntry(popped)) {
+    repairPendingPushIndex(popped)
+    pendingNavigation.popped = null
   }
-  if (pending.history === 'replace') {
-    clearPendingNavigation()
-    return
+  if (current?.history === 'push') {
+    if (isPendingPushEntry(current)) {
+      repairPendingPushIndex(current)
+    } else {
+      pendingNavigation.popped = current
+    }
   }
-  if (isOnPendingPushEntry() && typeof pending.routerIndex === 'number') {
-    const { [historyUpdateMarker]: _, ...state } = history.state
-    history.replaceState(
-      { ...state, idx: pending.routerIndex + 1 },
-      historyUpdateMarker
-    )
-    pendingNavigation.current = null
-    return
-  }
-  pending.poppedSince = true
+  pendingNavigation.current = null
 }
 
 function retargetPendingCommit(
@@ -136,14 +143,9 @@ function retargetPendingCommit(
 
 function pendingPushCommitUrl(url: string | URL): string | null {
   const pending = pendingNavigation.current
-  if (
-    pending?.history !== 'push' ||
-    pending.poppedSince ||
-    !isOnPendingPushEntry()
-  ) {
-    return null
-  }
-  return retargetPendingCommit(pending, url)
+  return pending?.history === 'push' && isPendingPushEntry(pending)
+    ? retargetPendingCommit(pending, url)
+    : null
 }
 
 function pendingReplaceCommit(url: string | URL): string | URL {
@@ -164,8 +166,7 @@ function repairPendingPushReplaceState(
 ): History['state'] {
   const pending = pendingNavigation.current
   return pending?.history === 'push' &&
-    !pending.poppedSince &&
-    isOnPendingPushEntry() &&
+    isPendingPushEntry(pending) &&
     typeof pending.routerIndex === 'number' &&
     state?.idx === pending.routerIndex
     ? { ...state, idx: pending.routerIndex + 1 }
@@ -277,11 +278,7 @@ export function patchHistory(
       '',
       commitUrl
     )
-    // Back leaves the pending entry ahead; a replace elsewhere keeps its record.
-    // Forward needs it to repair its index; every other replace spends it.
-    if (onPendingEntry || hasPendingPush()) {
-      clearPendingNavigation()
-    }
+    pendingNavigation.current = null
     sync(commitUrl)
   }
   markHistoryAsPatched(adapter)

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -25,6 +25,7 @@ type PendingPushState = {
 type PendingPush = {
   href: string
   id: number
+  currentHref: string
   routerIndex: number | undefined
   poppedSince: boolean
 }
@@ -40,6 +41,7 @@ export function markPendingPush(url: URL): PendingPushState {
   pendingPush.current = {
     href: url.href,
     id,
+    currentHref: url.href,
     routerIndex: history.state?.idx,
     poppedSince: false
   }
@@ -48,6 +50,17 @@ export function markPendingPush(url: URL): PendingPushState {
 
 function isOnPendingPushEntry(pending: PendingPush): boolean {
   return history.state?.[historyUpdateMarker] === pending.id
+}
+
+export function updatePendingPushUrl(url: URL): void {
+  const pending = pendingPush.current
+  if (
+    pending &&
+    location.href === pending.currentHref &&
+    isOnPendingPushEntry(pending)
+  ) {
+    pending.currentHref = url.href
+  }
 }
 
 export function hasPendingPush(): boolean {
@@ -68,7 +81,7 @@ function repairOrNotePopOnPendingPush(): void {
     return
   }
   if (
-    location.href === pending.href &&
+    location.href === pending.currentHref &&
     isOnPendingPushEntry(pending) &&
     typeof pending.routerIndex === 'number'
   ) {
@@ -81,6 +94,20 @@ function repairOrNotePopOnPendingPush(): void {
     return
   }
   pending.poppedSince = true
+}
+
+function pendingPushCommitUrl(url: string | URL): string | URL | null {
+  const pending = pendingPush.current
+  if (!pending || pending.poppedSince || !isOnPendingPushEntry(pending)) {
+    return null
+  }
+  const href = new URL(url, location.href).href
+  if (href === pending.href) {
+    return pending.currentHref === pending.href
+      ? url
+      : new URL(pending.currentHref)
+  }
+  return url
 }
 
 // A router replace has already copied the optimistic entry's index into
@@ -178,14 +205,11 @@ export function patchHistory(
     }
     // The router committing an optimistic deep push must not add
     // a second entry (#1563).
-    const pending = pendingPush.current
-    const commit =
-      hasPendingPush() && pending && isOnPendingPushEntry(pending)
-        ? originalReplaceState
-        : originalPushState
+    const commitUrl = pendingPushCommitUrl(url)
+    const commit = commitUrl ? originalReplaceState : originalPushState
     clearPendingPush()
-    commit.call(history, state, '', url)
-    sync(url)
+    commit.call(history, state, '', commitUrl ?? url)
+    sync(commitUrl ?? url)
   }
   history.replaceState = function nuqs_replaceState(state, marker, url) {
     const commitState =

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -10,8 +10,9 @@ import {
   hasPendingPush,
   historyUpdateMarker,
   markPendingPush,
+  markPendingReplace,
   patchHistory as applyHistoryPatch,
-  updatePendingPushUrl
+  updatePendingNavigationUrl
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -67,20 +68,28 @@ export function createReactRouterBasedAdapter({
         // First, update the URL locally without triggering a network request,
         // this allows keeping a reactive URL if the network is slow.
         //
-        // A deep push marks its optimistic entry pending until the router
-        // commits it. Until then, further deep updates take that entry over
-        // instead of stacking on it, and they commit as a push (#1563).
+        // While a deep push is pending, later writes must target the same top
+        // entry: shallow pushes fold as replaces and deep replaces keep push
+        // semantics. Otherwise the router commit would overwrite an entry
+        // stacked above its optimistic entry (#1563).
         const isDeep = options.shallow === false
         const takesOverPendingPush = isDeep && hasPendingPush()
+        const coalescesIntoPendingPush = !isDeep && hasPendingPush()
         const commitsAsPush =
           isDeep && (options.history === 'push' || takesOverPendingPush)
+        const navigates = isDeep
         const updateMethod =
-          options.history === 'push' && !takesOverPendingPush
+          options.history === 'push' &&
+          !takesOverPendingPush &&
+          !coalescesIntoPendingPush
             ? history.pushState
             : history.replaceState
-        setQueueResetMutex(options.shallow ? 1 : 2)
-        if (!isDeep && options.history !== 'push') {
-          updatePendingPushUrl(url)
+        setQueueResetMutex(navigates ? 2 : 1)
+        // Standalone shallow pushes bypass the router to avoid running loaders.
+        // They cannot advance its private index, so the first blocked traversal
+        // may compute a delta of zero.
+        if (!isDeep) {
+          updatePendingNavigationUrl(url)
         }
         const historyState = commitsAsPush
           ? markPendingPush(url)
@@ -92,7 +101,10 @@ export function createReactRouterBasedAdapter({
           url
         )
         let navigationSettled: Promise<void> | undefined
-        if (isDeep) {
+        if (navigates) {
+          if (!commitsAsPush) {
+            markPendingReplace(url)
+          }
           const maybePromise = navigate(
             {
               // Somehow passing the full URL object here strips the search params

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -10,7 +10,8 @@ import {
   hasPendingPush,
   historyUpdateMarker,
   markPendingPush,
-  patchHistory as applyHistoryPatch
+  patchHistory as applyHistoryPatch,
+  updatePendingPushUrl
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -78,6 +79,9 @@ export function createReactRouterBasedAdapter({
             ? history.pushState
             : history.replaceState
         setQueueResetMutex(options.shallow ? 1 : 2)
+        if (!isDeep && options.history !== 'push') {
+          updatePendingPushUrl(url)
+        }
         const historyState = commitsAsPush
           ? markPendingPush(url)
           : history.state

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -11,8 +11,7 @@ import {
   historyUpdateMarker,
   markPendingPush,
   markPendingReplace,
-  patchHistory as applyHistoryPatch,
-  updatePendingNavigationUrl
+  patchHistory as applyHistoryPatch
 } from './patch-history'
 
 // Abstract away the types for the useNavigate hook from react-router-based frameworks
@@ -73,24 +72,14 @@ export function createReactRouterBasedAdapter({
         // semantics. Otherwise the router commit would overwrite an entry
         // stacked above its optimistic entry (#1563).
         const isDeep = options.shallow === false
-        const takesOverPendingPush = isDeep && hasPendingPush()
-        const coalescesIntoPendingPush = !isDeep && hasPendingPush()
+        const pendingPush = hasPendingPush()
         const commitsAsPush =
-          isDeep && (options.history === 'push' || takesOverPendingPush)
-        const navigates = isDeep
+          isDeep && (options.history === 'push' || pendingPush)
         const updateMethod =
-          options.history === 'push' &&
-          !takesOverPendingPush &&
-          !coalescesIntoPendingPush
+          options.history === 'push' && !pendingPush
             ? history.pushState
             : history.replaceState
-        setQueueResetMutex(navigates ? 2 : 1)
-        // Standalone shallow pushes bypass the router to avoid running loaders.
-        // They cannot advance its private index, so the first blocked traversal
-        // may compute a delta of zero.
-        if (!isDeep) {
-          updatePendingNavigationUrl(url)
-        }
+        setQueueResetMutex(isDeep ? 2 : 1)
         const historyState = commitsAsPush
           ? markPendingPush(url)
           : history.state
@@ -101,7 +90,11 @@ export function createReactRouterBasedAdapter({
           url
         )
         let navigationSettled: Promise<void> | undefined
-        if (navigates) {
+        // A shallow push with no deep navigation skips the router and its loaders.
+        // It cannot advance the router's private history index.
+        // On the first blocked traversal, React Router computes a zero delta.
+        // It calls history.go(0), which reloads the page.
+        if (isDeep) {
           if (!commitsAsPush) {
             markPendingReplace(url)
           }

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1493,6 +1493,24 @@ describe('useQueryStates: adapter defaults', () => {
     expect(onUrlUpdate).toHaveBeenCalledOnce()
     expect(onUrlUpdate.mock.calls[0]![0].options.scroll).toBe(true)
   })
+  it('should let call-level `scroll` override parser and adapter defaults', async () => {
+    const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
+    const useTestHook = () =>
+      useQueryStates({
+        test: parseAsString.withOptions({ scroll: false })
+      })
+    const { result, act } = await renderHook(useTestHook, {
+      wrapper: withNuqsTestingAdapter({
+        defaultOptions: {
+          scroll: false
+        },
+        onUrlUpdate
+      })
+    })
+    await act(() => result.current[1]({ test: 'update' }, { scroll: true }))
+    expect(onUrlUpdate).toHaveBeenCalledOnce()
+    expect(onUrlUpdate.mock.calls[0]![0].options.scroll).toBe(true)
+  })
   it('should use adapter default value for `clearOnDefault` when provided', async () => {
     const onUrlUpdate = vi.fn<OnUrlUpdateFunction>()
     const useTestHook = () =>


### PR DESCRIPTION
Stacked on #1565. Review only the final commit in this PR.

## Summary

- generalize pending push tracking to pending React Router navigations so stale push and replace commits preserve newer URL state
- compose supported shallow updates into pending deep navigations without triggering client-side loaders
- expand the shared regression suite across React Router v6–v8 and Remix, including loader-count assertions and the supported update sequences
- document internally why standalone shallow pushes cannot synchronize React Router's private history index without running loaders

## Stack

- #1564 — deep push/index synchronization
- #1565 — shallow replaces during pending deep pushes
- this PR — pending push/replace composition and expanded regression coverage

## Verification

- shared `repro-1563` Playwright suite: 10/10 passed sequentially on React Router v6, v7, v8, and Remix
- `pnpm test --filter=nuqs`: unit, browser, type, and size checks passed
- React Router v6 E2E typecheck passed
- commit and push hooks passed formatting, type generation, Knip, Sherif, and Prettier checks
