### PR TITLE
fix: support React Compiler in Activity trees

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -230,30 +230,30 @@ jobs:
         next-version:
           # Only keep versions where there were relevant changes in the app router core,
           # and the previous one to use as a baseline.
-          - "14.2.0"
+          - '14.2.0'
           # - '14.2.3' # before vercel/next.js#66755
-          - "14.2.4" # after vercel/next.js#66755
+          - '14.2.4' # after vercel/next.js#66755
           # - '14.2.7' # before vercel/next.js#69509
-          - "14.2.8" # after vercel/next.js#69509
-          - "15.0.0"
-          - "15.1.0"
-          - "15.2.0"
+          - '14.2.8' # after vercel/next.js#69509
+          - '15.0.0'
+          - '15.1.0'
+          - '15.2.0'
           - latest
         include:
-          - next-version: "14.2.0"
-            base-path: "/base"
-          - next-version: "15.0.0"
-            base-path: "/base"
-          - next-version: "latest"
-            base-path: "/base"
-          - next-version: "latest"
+          - next-version: '14.2.0'
+            base-path: '/base'
+          - next-version: '15.0.0'
+            base-path: '/base'
+          - next-version: 'latest'
+            base-path: '/base'
+          - next-version: 'latest'
             react-compiler: true
-          - next-version: "latest"
-            base-path: "/base"
+          - next-version: 'latest'
+            base-path: '/base'
             react-compiler: true
-          - next-version: "latest"
+          - next-version: 'latest'
             cache-components: true
-          - next-version: "latest"
+          - next-version: 'latest'
             cache-components: true
             react-compiler: true
     steps:
@@ -304,13 +304,17 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   e2e-react:
-    name: E2E (react-fpn-${{ matrix.full-page-nav-on-shallow-false }})
+    name: E2E (react-fpn-${{ matrix.full-page-nav-on-shallow-false }}${{ matrix.react-compiler && ' ⚛️' || '' }})
     runs-on: ubuntu-24.04-arm
     needs: [ci-core]
     strategy:
       fail-fast: false
       matrix:
         full-page-nav-on-shallow-false: [false, true]
+        react-compiler: [false]
+        include:
+          - full-page-nav-on-shallow-false: false
+            react-compiler: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -329,33 +333,35 @@ jobs:
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           E2E_NO_CACHE_ON_RERUN: ${{ github.run_attempt }}
           FULL_PAGE_NAV_ON_SHALLOW_FALSE: ${{ matrix.full-page-nav-on-shallow-false }}
+          REACT_COMPILER: ${{ matrix.react-compiler }}
       - name: Save Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: failure()
         with:
           path: packages/e2e/react/.playwright/*
-          name: playwright-react-fpn-${{ matrix.full-page-nav-on-shallow-false }}
+          name: playwright-react-fpn-${{ matrix.full-page-nav-on-shallow-false }}${{ matrix.react-compiler && '-react-compiler' || '' }}
           include-hidden-files: true
       - uses: 47ng/actions-slack-notify@df42545060c07ca99a040d0a520ab8457ce3c222
         name: Notify on Slack
         if: failure()
         with:
           status: ${{ job.status }}
-          jobName: react-fpn-${{ matrix.full-page-nav-on-shallow-false }}
+          jobName: react-fpn-${{ matrix.full-page-nav-on-shallow-false }}${{ matrix.react-compiler && ' react-compiler' || '' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   e2e-react-router:
-    name: E2E (react-router ${{ matrix.react-router-version }})
+    name: E2E (react-router ${{ matrix.react-router-version }}${{ matrix.react-compiler && ' ⚛️' || '' }})
     runs-on: ubuntu-24.04-arm
     needs: [ci-core]
     strategy:
       fail-fast: false
       matrix:
         react-router-version:
-          - "v6"
-          - "v7"
-          - "v8"
+          - 'v6'
+          - 'v7'
+          - 'v8'
+        react-compiler: [false, true]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -373,19 +379,20 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           E2E_NO_CACHE_ON_RERUN: ${{ github.run_attempt }}
+          REACT_COMPILER: ${{ matrix.react-compiler }}
       - name: Save Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: failure()
         with:
           path: packages/e2e/react-router/${{ matrix.react-router-version }}/.playwright/*
-          name: playwright-react-router-${{ matrix.react-router-version }}
+          name: playwright-react-router-${{ matrix.react-router-version }}${{ matrix.react-compiler && '-react-compiler' || '' }}
           include-hidden-files: true
       - uses: 47ng/actions-slack-notify@df42545060c07ca99a040d0a520ab8457ce3c222
         name: Notify on Slack
         if: failure()
         with:
           status: ${{ job.status }}
-          jobName: react-router-${{ matrix.react-router-version }}
+          jobName: react-router-${{ matrix.react-router-version }}${{ matrix.react-compiler && ' react-compiler' || '' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -427,9 +434,13 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   e2e-tanstack-router:
-    name: E2E (tanstack-router)
+    name: E2E (tanstack-router${{ matrix.react-compiler && ' ⚛️' || '' }})
     runs-on: ubuntu-22.04-arm
     needs: [ci-core]
+    strategy:
+      fail-fast: false
+      matrix:
+        react-compiler: [false, true]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -447,19 +458,20 @@ jobs:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
           E2E_NO_CACHE_ON_RERUN: ${{ github.run_attempt }}
+          REACT_COMPILER: ${{ matrix.react-compiler }}
       - name: Save Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: failure()
         with:
           path: packages/e2e/tanstack-router/.playwright/*
-          name: playwright-tanstack-router
+          name: playwright-tanstack-router${{ matrix.react-compiler && '-react-compiler' || '' }}
           include-hidden-files: true
       - uses: 47ng/actions-slack-notify@df42545060c07ca99a040d0a520ab8457ce3c222
         name: Notify on Slack
         if: failure()
         with:
           status: ${{ job.status }}
-          jobName: tanstack-router
+          jobName: tanstack-router${{ matrix.react-compiler && ' react-compiler' || '' }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/packages/e2e/next/package.json
+++ b/packages/e2e/next/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^24.13.3",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:react-compiler",
     "e2e-shared": "workspace:*",
     "typescript": "catalog:typescript6"
   }

--- a/packages/e2e/react-router/v6/package.json
+++ b/packages/e2e/react-router/v6/package.json
@@ -22,8 +22,9 @@
     "@types/node": "^24.13.3",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "catalog:react-compiler",
     "e2e-shared": "workspace:*",
+    "oxc-transform-react": "catalog:react-compiler",
     "typescript": "catalog:typescript",
     "vite": "catalog:vite"
   }

--- a/packages/e2e/react-router/v6/vite.config.ts
+++ b/packages/e2e/react-router/v6/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
-  plugins: [react()],
+  plugins: [react({ compiler: process.env.REACT_COMPILER === 'true' })],
   build: {
     target: 'es2022',
     sourcemap: true

--- a/packages/e2e/react-router/v7/package.json
+++ b/packages/e2e/react-router/v7/package.json
@@ -21,18 +21,22 @@
     "react-router": "catalog:react-router7"
   },
   "devDependencies": {
+    "@babel/core": "catalog:react-compiler",
+    "@babel/preset-typescript": "catalog:react-compiler",
     "@playwright/test": "catalog:e2e",
     "@react-router/dev": "catalog:react-router7",
     "@react-router/express": "catalog:react-router7",
     "@types/node": "^24.13.3",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
+    "babel-plugin-react-compiler": "catalog:react-compiler",
     "compression": "^1.8.1",
     "cross-env": "^10.1.0",
     "e2e-shared": "workspace:*",
     "express": "^4.22.2",
     "typescript": "catalog:typescript",
     "vite": "catalog:vite",
+    "vite-plugin-babel": "catalog:react-compiler",
     "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/packages/e2e/react-router/v7/vite.config.ts
+++ b/packages/e2e/react-router/v7/vite.config.ts
@@ -1,9 +1,27 @@
 import { reactRouter } from '@react-router/dev/vite'
 import { defineConfig } from 'vite'
+import babel from 'vite-plugin-babel'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
-  plugins: [reactRouter(), tsconfigPaths()],
+  plugins: [
+    reactRouter(),
+    tsconfigPaths(),
+    ...(process.env.REACT_COMPILER === 'true'
+      ? [
+          babel({
+            include: [
+              /\/app\/.*\.[jt]sx?$/,
+              /\/packages\/e2e\/shared\/specs\/.*\.tsx$/
+            ],
+            babelConfig: {
+              presets: ['@babel/preset-typescript'],
+              plugins: ['babel-plugin-react-compiler']
+            }
+          })
+        ]
+      : [])
+  ],
   build: {
     sourcemap: false, // Disable sourcemaps for e2e test apps
     rolldownOptions: {

--- a/packages/e2e/react-router/v8/package.json
+++ b/packages/e2e/react-router/v8/package.json
@@ -21,18 +21,22 @@
     "react-router": "catalog:react-router8"
   },
   "devDependencies": {
+    "@babel/core": "catalog:react-compiler",
+    "@babel/preset-typescript": "catalog:react-compiler",
     "@playwright/test": "catalog:e2e",
     "@react-router/dev": "catalog:react-router8",
     "@react-router/express": "catalog:react-router8",
     "@types/node": "^24.13.3",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
+    "babel-plugin-react-compiler": "catalog:react-compiler",
     "compression": "^1.8.1",
     "cross-env": "^10.1.0",
     "e2e-shared": "workspace:*",
     "express": "^4.22.2",
     "typescript": "catalog:typescript",
     "vite": "catalog:vite",
+    "vite-plugin-babel": "catalog:react-compiler",
     "vite-tsconfig-paths": "^6.1.1"
   }
 }

--- a/packages/e2e/react-router/v8/vite.config.ts
+++ b/packages/e2e/react-router/v8/vite.config.ts
@@ -1,9 +1,27 @@
 import { reactRouter } from '@react-router/dev/vite'
 import { defineConfig } from 'vite'
+import babel from 'vite-plugin-babel'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
-  plugins: [reactRouter(), tsconfigPaths()],
+  plugins: [
+    reactRouter(),
+    tsconfigPaths(),
+    ...(process.env.REACT_COMPILER === 'true'
+      ? [
+          babel({
+            include: [
+              /\/app\/.*\.[jt]sx?$/,
+              /\/packages\/e2e\/shared\/specs\/.*\.tsx$/
+            ],
+            babelConfig: {
+              presets: ['@babel/preset-typescript'],
+              plugins: ['babel-plugin-react-compiler']
+            }
+          })
+        ]
+      : [])
+  ],
   build: {
     sourcemap: false, // Disable sourcemaps for e2e test apps
     rolldownOptions: {

--- a/packages/e2e/react/package.json
+++ b/packages/e2e/react/package.json
@@ -21,8 +21,9 @@
     "@types/node": "^24.13.3",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "catalog:react-compiler",
     "e2e-shared": "workspace:*",
+    "oxc-transform-react": "catalog:react-compiler",
     "typescript": "catalog:typescript",
     "vite": "catalog:vite"
   }

--- a/packages/e2e/react/vite.config.ts
+++ b/packages/e2e/react/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, loadEnv } from 'vite'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   return {
-    plugins: [react()],
+    plugins: [react({ compiler: env.REACT_COMPILER === 'true' })],
     build: {
       target: 'es2022',
       sourcemap: true

--- a/packages/e2e/shared/specs/debounce.spec.ts
+++ b/packages/e2e/shared/specs/debounce.spec.ts
@@ -38,22 +38,25 @@ export function testDebounce(config: TestDebounceConfig) {
       page
     }) => {
       const DEBOUNCE_TIME = 400
+      await page.clock.install({ time: 0 })
       await navigateTo(page, getUrl(path, { debounceTime: DEBOUNCE_TIME }))
+      await page.clock.pauseAt(60_000)
       await page.locator('input[type="text"]').fill('pass')
       const incrementButton = page.locator('button#increment-page-index')
-      await incrementButton.click()
-      await incrementButton.click()
-      await incrementButton.click()
+      await incrementButton.click({ force: true })
+      await incrementButton.click({ force: true })
+      await incrementButton.click({ force: true })
       await expect(page.locator('#client-state')).toHaveText(
         '{"search":"pass","pageIndex":3}'
       )
+      await page.clock.runFor(0)
       await expect(page).toHaveURL(
         url => url.search === `?debounceTime=${DEBOUNCE_TIME}&page=3`
       )
       await expect(page.locator('#server-state')).toHaveText(
         '{"search":"","pageIndex":3}'
       )
-      await page.waitForTimeout(DEBOUNCE_TIME)
+      await page.clock.runFor(DEBOUNCE_TIME + 1)
       await expect(page).toHaveURL(
         url => url.search === `?debounceTime=${DEBOUNCE_TIME}&page=3&q=pass`
       )

--- a/packages/e2e/shared/specs/repro-1444.spec.ts
+++ b/packages/e2e/shared/specs/repro-1444.spec.ts
@@ -35,6 +35,12 @@ export const testRepro1444 = defineTest('repro-1444', ({ path }) => {
     logSpy.logs.length = 0
     await toggle.click()
     await expect(page.locator('#client-state')).toHaveText('fresh-value')
+    await expect
+      .poll(
+        () => logSpy.logs.filter(log => log === 'commit: fresh-value').length,
+        'Activity child should commit the fresh value when revealed'
+      )
+      .toBeGreaterThan(0)
     await assertLogCount(
       logSpy,
       'commit: stale-value',

--- a/packages/e2e/tanstack-router/package.json
+++ b/packages/e2e/tanstack-router/package.json
@@ -25,8 +25,9 @@
     "@types/node": "^24.13.3",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "catalog:react-compiler",
     "e2e-shared": "workspace:*",
+    "oxc-transform-react": "catalog:react-compiler",
     "typescript": "catalog:typescript",
     "vite": "catalog:vite"
   }

--- a/packages/e2e/tanstack-router/vite.config.js
+++ b/packages/e2e/tanstack-router/vite.config.js
@@ -7,7 +7,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [
     tanstackRouter({ autoCodeSplitting: true, target: 'react' }),
-    viteReact()
+    viteReact({ compiler: process.env.REACT_COMPILER === 'true' })
   ],
   build: {
     sourcemap: true

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -1,4 +1,10 @@
-import { startTransition, useCallback, useEffect, useState } from 'react'
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useInsertionEffect,
+  useState
+} from 'react'
 import { debug } from '../../lib/debug'
 import { setQueueResetMutex } from '../../lib/queues/reset'
 import { renderQueryString } from '../../lib/url-encoding'
@@ -134,7 +140,9 @@ export function createReactRouterBasedAdapter({
             false // No need for a copy here
           )
     })
-    useEffect(() => {
+    // Activity disconnects passive effects while hidden. Keep the router
+    // subscription attached so a memoized reader has pending work before reveal.
+    useInsertionEffect(() => {
       function onPopState() {
         startTransition(() => {
           setSearchParams(
@@ -149,6 +157,12 @@ export function createReactRouterBasedAdapter({
       }
       emitter.on('update', onEmitterUpdate)
       window.addEventListener('popstate', onPopState)
+      return () => {
+        emitter.off('update', onEmitterUpdate)
+        window.removeEventListener('popstate', onPopState)
+      }
+    }, [JSON.stringify(watchKeys)])
+    useEffect(() => {
       // Catch up with the URL as it stands now that we're subscribed. A hook
       // mounting during a navigation transition subscribes after the emitter
       // has fired (e.g. a sibling route's shallow update), so its state would
@@ -165,11 +179,7 @@ export function createReactRouterBasedAdapter({
       if (caughtUp.toString() !== searchParams.toString()) {
         setSearchParams(caughtUp)
       }
-      return () => {
-        emitter.off('update', onEmitterUpdate)
-        window.removeEventListener('popstate', onPopState)
-      }
-    }, [watchKeys.join('&')])
+    }, [JSON.stringify(watchKeys)])
     return searchParams
   }
   /**

--- a/packages/nuqs/src/adapters/react.ts
+++ b/packages/nuqs/src/adapters/react.ts
@@ -3,8 +3,10 @@ import {
   createElement,
   useContext,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
+  useState,
   useSyncExternalStore,
   type ReactElement,
   type ReactNode
@@ -77,6 +79,7 @@ function useNuqsReactAdapter(watchKeys: string[]): AdapterInterface {
   // and it preserves key isolation (a change to an unwatched key keeps the same ref,
   // so this hook doesn't re-render).
   const cache = useRef<{ key: string; search: URLSearchParams } | null>(null)
+  const [, forceUpdate] = useState(0)
   function snapshot(source: string | URLSearchParams) {
     const filteredSearch = filterSearchParams(
       new URLSearchParams(source),
@@ -90,6 +93,19 @@ function useNuqsReactAdapter(watchKeys: string[]): AdapterInterface {
     cache.current = { key, search: filteredSearch }
     return filteredSearch
   }
+  // Activity disconnects passive effects while hidden. Keep a key-isolated
+  // invalidation attached so a memoized reader has pending work before reveal.
+  useInsertionEffect(
+    () =>
+      subscribe(() => {
+        const previous = cache.current?.search
+        const next = snapshot(location.search)
+        if (next !== previous) {
+          forceUpdate(version => version + 1)
+        }
+      }),
+    [JSON.stringify(watchKeys)]
+  )
   const searchParams = useSyncExternalStore(
     subscribe,
     // Reading location.search live in getSnapshot (rather than from React state

--- a/packages/nuqs/src/adapters/tanstack-router.ts
+++ b/packages/nuqs/src/adapters/tanstack-router.ts
@@ -4,8 +4,10 @@ import {
   startTransition,
   useCallback,
   useEffect,
+  useInsertionEffect,
   useMemo,
-  useRef
+  useRef,
+  useState
 } from 'react'
 import { resetQueues } from '../lib/queues/reset'
 import { renderQueryString } from '../lib/url-encoding'
@@ -17,6 +19,9 @@ import type { AdapterInterface, UpdateUrlFunction } from './lib/defs'
 type SearchRecord = Record<string, string | string[]>
 
 type HistorySubscriberArgs = {
+  location: {
+    search: string
+  }
   action: {
     type: 'PUSH' | 'REPLACE' | 'BACK' | 'FORWARD' | 'GO'
   }
@@ -48,6 +53,39 @@ function useNuqsTanstackRouterAdapter(watchKeys: string[]): AdapterInterface {
   })
   const router = useRouter()
   const { navigate } = router
+  const [, forceUpdate] = useState(0)
+  const getWatchedSearchKey = (search: string) => {
+    const searchParams = new URLSearchParams(search)
+    return JSON.stringify(watchKeys.map(key => searchParams.getAll(key)))
+  }
+  const watchedSearchKeyRef = useRef(
+    getWatchedSearchKey(router.history.location.search)
+  )
+  // useRouterState provides key isolation above, but its external-store
+  // subscription is disconnected by Activity. Track whether it is connected so
+  // this retained history fallback only enqueues hidden updates and does not add
+  // a duplicate visible render.
+  const effectsConnectedRef = useRef(false)
+  useEffect(() => {
+    effectsConnectedRef.current = true
+    return () => {
+      effectsConnectedRef.current = false
+    }
+  }, [])
+  useInsertionEffect(() => {
+    watchedSearchKeyRef.current = getWatchedSearchKey(
+      router.history.location.search
+    )
+    return router.history.subscribe(({ location }: HistorySubscriberArgs) => {
+      const nextKey = getWatchedSearchKey(location.search)
+      if (nextKey !== watchedSearchKeyRef.current) {
+        watchedSearchKeyRef.current = nextKey
+        if (!effectsConnectedRef.current) {
+          forceUpdate(version => version + 1)
+        }
+      }
+    })
+  }, [router.history, JSON.stringify(watchKeys)])
 
   // Track which pathname this hook instance was mounted under to
   // keep its last stable search during cross-page transitions.

--- a/packages/nuqs/src/useQueryStates.browser.test.tsx
+++ b/packages/nuqs/src/useQueryStates.browser.test.tsx
@@ -1,5 +1,7 @@
 import React, {
+  Activity,
   createElement,
+  memo,
   startTransition,
   Suspense,
   useEffect,
@@ -12,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, renderHook } from 'vitest-browser-react'
 import { page, userEvent } from 'vitest/browser'
 import { createReactRouterBasedAdapter } from './adapters/lib/react-router'
+import { NuqsAdapter as NuqsReactAdapter } from './adapters/react'
 import {
   NullDetector,
   useFakeLoadingState
@@ -1811,6 +1814,67 @@ describe('useQueryStates: discarded renders', () => {
     await expect
       .element(page.getByTestId('value'))
       .toHaveTextContent('incoming')
+  })
+})
+
+describe('useQueryStates: detached Activity', () => {
+  const originalUrl = location.href
+
+  afterEach(() => {
+    history.replaceState(null, '', originalUrl)
+  })
+
+  it('reveals a memoized reader with the current external URL state', async () => {
+    const commits: Array<string | null> = []
+
+    const Reader = memo(function Reader() {
+      const [value] = useQueryState('test')
+      useEffect(() => {
+        commits.push(value)
+      })
+      return <div data-testid="activity-value">{String(value)}</div>
+    })
+
+    function App() {
+      const [visible, setVisible] = useState(true)
+      return (
+        <>
+          <button onClick={() => setVisible(value => !value)}>Toggle</button>
+          <button
+            onClick={() => {
+              history.back()
+            }}
+          >
+            Update
+          </button>
+          <Activity mode={visible ? 'visible' : 'hidden'}>
+            <Reader />
+          </Activity>
+        </>
+      )
+    }
+
+    history.replaceState(null, '', '/page?test=fresh')
+    history.pushState(null, '', '/page?test=stale')
+    render(
+      <NuqsReactAdapter>
+        <App />
+      </NuqsReactAdapter>
+    )
+    const user = userEvent.setup()
+    const value = page.getByTestId('activity-value')
+    const toggle = page.getByRole('button', { name: 'Toggle' })
+
+    await expect.element(value).toHaveTextContent('stale')
+    await user.click(toggle)
+    await user.click(page.getByRole('button', { name: 'Update' }))
+    await vi.waitFor(() => expect(location.search).toBe('?test=fresh'))
+
+    commits.length = 0
+    await user.click(toggle)
+    await expect.element(value).toHaveTextContent('fresh')
+    await vi.waitFor(() => expect(commits).toContain('fresh'))
+    expect(commits).not.toContain('stale')
   })
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,25 @@ catalogs:
     next:
       specifier: 16.3.3
       version: 16.3.3
+  react-compiler:
+    '@babel/core':
+      specifier: ^7.29.7
+      version: 7.29.7
+    '@babel/preset-typescript':
+      specifier: ^7.29.7
+      version: 7.29.7
+    '@vitejs/plugin-react':
+      specifier: 6.1.1
+      version: 6.1.1
+    babel-plugin-react-compiler:
+      specifier: 1.0.0
+      version: 1.0.0
+    oxc-transform-react:
+      specifier: 0.145.0
+      version: 0.145.0
+    vite-plugin-babel:
+      specifier: ^1.7.3
+      version: 1.7.3
   react-router7:
     '@react-router/dev':
       specifier: ^7.18.1
@@ -345,7 +364,7 @@ importers:
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: catalog:react-compiler
         version: 1.0.0
       e2e-shared:
         specifier: workspace:*
@@ -379,11 +398,14 @@ importers:
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^6.0.3
-        version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: catalog:react-compiler
+        version: 6.1.1(babel-plugin-react-compiler@1.0.0)(oxc-transform-react@0.145.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       e2e-shared:
         specifier: workspace:*
         version: link:../shared
+      oxc-transform-react:
+        specifier: catalog:react-compiler
+        version: 0.145.0
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -464,11 +486,14 @@ importers:
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^6.0.3
-        version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: catalog:react-compiler
+        version: 6.1.1(babel-plugin-react-compiler@1.0.0)(oxc-transform-react@0.145.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       e2e-shared:
         specifier: workspace:*
         version: link:../../shared
+      oxc-transform-react:
+        specifier: catalog:react-compiler
+        version: 0.145.0
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -500,6 +525,12 @@ importers:
         specifier: catalog:react-router7
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@babel/core':
+        specifier: catalog:react-compiler
+        version: 7.29.7
+      '@babel/preset-typescript':
+        specifier: catalog:react-compiler
+        version: 7.29.7(@babel/core@7.29.7)
       '@playwright/test':
         specifier: catalog:e2e
         version: 1.61.1
@@ -518,6 +549,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
+      babel-plugin-react-compiler:
+        specifier: catalog:react-compiler
+        version: 1.0.0
       compression:
         specifier: ^1.8.1
         version: 1.8.1
@@ -536,6 +570,9 @@ importers:
       vite:
         specifier: catalog:vite
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-babel:
+        specifier: catalog:react-compiler
+        version: 1.7.3(@babel/core@7.29.7)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -564,6 +601,12 @@ importers:
         specifier: catalog:react-router8
         version: 8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
+      '@babel/core':
+        specifier: catalog:react-compiler
+        version: 7.29.7
+      '@babel/preset-typescript':
+        specifier: catalog:react-compiler
+        version: 7.29.7(@babel/core@7.29.7)
       '@playwright/test':
         specifier: catalog:e2e
         version: 1.61.1
@@ -582,6 +625,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
+      babel-plugin-react-compiler:
+        specifier: catalog:react-compiler
+        version: 1.0.0
       compression:
         specifier: ^1.8.1
         version: 1.8.1
@@ -600,6 +646,9 @@ importers:
       vite:
         specifier: catalog:vite
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite-plugin-babel:
+        specifier: catalog:react-compiler
+        version: 1.7.3(@babel/core@7.29.7)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       vite-tsconfig-paths:
         specifier: ^6.1.1
         version: 6.1.1(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -717,11 +766,14 @@ importers:
         specifier: catalog:react19
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^6.0.3
-        version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+        specifier: catalog:react-compiler
+        version: 6.1.1(babel-plugin-react-compiler@1.0.0)(oxc-transform-react@0.145.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       e2e-shared:
         specifier: workspace:*
         version: link:../shared
+      oxc-transform-react:
+        specifier: catalog:react-compiler
+        version: 0.145.0
       typescript:
         specifier: catalog:typescript
         version: 7.0.2
@@ -2719,6 +2771,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
     resolution: {integrity: sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.145.0':
+    resolution: {integrity: sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform-react/binding-android-arm64@0.145.0':
+    resolution: {integrity: sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform-react/binding-darwin-arm64@0.145.0':
+    resolution: {integrity: sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-darwin-x64@0.145.0':
+    resolution: {integrity: sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-freebsd-x64@0.145.0':
+    resolution: {integrity: sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0':
+    resolution: {integrity: sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0':
+    resolution: {integrity: sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.145.0':
+    resolution: {integrity: sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.145.0':
+    resolution: {integrity: sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0':
+    resolution: {integrity: sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0':
+    resolution: {integrity: sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.145.0':
+    resolution: {integrity: sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.145.0':
+    resolution: {integrity: sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.145.0':
+    resolution: {integrity: sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.145.0':
+    resolution: {integrity: sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.145.0':
+    resolution: {integrity: sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.145.0':
+    resolution: {integrity: sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.145.0':
+    resolution: {integrity: sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.145.0':
+    resolution: {integrity: sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -4951,6 +5125,22 @@ packages:
       '@rolldown/plugin-babel':
         optional: true
       babel-plugin-react-compiler:
+        optional: true
+
+  '@vitejs/plugin-react@6.1.1':
+    resolution: {integrity: sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      oxc-transform-react: ^0.145.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      oxc-transform-react:
         optional: true
 
   '@vitest/browser-playwright@4.1.10':
@@ -7672,6 +7862,10 @@ packages:
   oxc-resolver@11.21.3:
     resolution: {integrity: sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==}
 
+  oxc-transform-react@0.145.0:
+    resolution: {integrity: sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -9178,6 +9372,12 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-plugin-babel@1.7.3:
+    resolution: {integrity: sha512-PsomVbH74/XyqMzXSwBDqb/1o5sAqE68gPlHLfx4FiMGbvKDhaZVQNv/gj/7oRQ5BvuIlyTKBtNEA9MnirGwRA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite-tsconfig-paths@6.1.1:
     resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
@@ -10950,6 +11150,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-x64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-freebsd-x64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.145.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -13158,6 +13415,14 @@ snapshots:
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-react@6.1.1(babel-plugin-react-compiler@1.0.0)(oxc-transform-react@0.145.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+      oxc-transform-react: 0.145.0
 
   '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(playwright@1.61.1)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -16437,6 +16702,28 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.21.3
       '@oxc-resolver/binding-win32-x64-msvc': 11.21.3
 
+  oxc-transform-react@0.145.0:
+    optionalDependencies:
+      '@oxc-transform-react/binding-android-arm-eabi': 0.145.0
+      '@oxc-transform-react/binding-android-arm64': 0.145.0
+      '@oxc-transform-react/binding-darwin-arm64': 0.145.0
+      '@oxc-transform-react/binding-darwin-x64': 0.145.0
+      '@oxc-transform-react/binding-freebsd-x64': 0.145.0
+      '@oxc-transform-react/binding-linux-arm-gnueabihf': 0.145.0
+      '@oxc-transform-react/binding-linux-arm-musleabihf': 0.145.0
+      '@oxc-transform-react/binding-linux-arm64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-arm64-musl': 0.145.0
+      '@oxc-transform-react/binding-linux-ppc64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-riscv64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-riscv64-musl': 0.145.0
+      '@oxc-transform-react/binding-linux-s390x-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-x64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-x64-musl': 0.145.0
+      '@oxc-transform-react/binding-openharmony-arm64': 0.145.0
+      '@oxc-transform-react/binding-win32-arm64-msvc': 0.145.0
+      '@oxc-transform-react/binding-win32-ia32-msvc': 0.145.0
+      '@oxc-transform-react/binding-win32-x64-msvc': 0.145.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -18202,6 +18489,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-babel@1.7.3(@babel/core@7.29.7)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      '@babel/core': 7.29.7
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   vite-tsconfig-paths@6.1.1(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,14 @@ catalogs:
     playwright: ^1.61.1
     '@playwright/test': ^1.61.1
 
+  react-compiler:
+    '@babel/core': ^7.29.7
+    '@babel/preset-typescript': ^7.29.7
+    '@vitejs/plugin-react': 6.1.1
+    babel-plugin-react-compiler: 1.0.0
+    oxc-transform-react: 0.145.0
+    vite-plugin-babel: ^1.7.3
+
   knip:
     knip: ^6.27.0
 


### PR DESCRIPTION
## Summary

- keep query-state readers subscribed while React Activity trees are hidden, so compiler memoization cannot reveal stale URL state
- add browser and shared E2E regressions without weakening the original stale-commit assertion
- run React Compiler E2E variants for React, React Router v6-v8, and TanStack Router
- use the Rust/Oxc compiler in direct Vite apps; retain Babel where React Router framework mode does not expose the standalone Rust transform
- make the debounce sequencing test deterministic with Playwright's controlled browser clock

## Validation

- full compiler-on Chromium suites, one worker: React, React Router v6/v7/v8, TanStack Router
- compiler-on and compiler-off focused Activity repro across all five targets
- `pnpm run test --filter nuqs`
- React Router debounce clock regression: RRv8 10/10, RRv6, RRv7
- `pnpm run lint:sherif`
- `actionlint .github/workflows/ci-cd.yml`
- `zizmor .github/workflows/ci-cd.yml`
- Prettier and `git diff --check`
