### PR TITLE
chore: allow stale mutation baselines

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -156,7 +156,7 @@ jobs:
             "$RUNNER_TEMP/mutation-inputs-candidate.sha256"
           then
             echo 'comparable=false' >> "$GITHUB_OUTPUT"
-            echo '::notice::Mutation execution inputs changed; running the complete candidate suite for explicit baseline review.'
+            echo '::notice::Mutation execution inputs changed; running the complete candidate suite against the existing baseline.'
           else
             echo 'comparable=true' >> "$GITHUB_OUTPUT"
           fi
@@ -202,7 +202,7 @@ jobs:
             pnpm exec turbo run mutation --filter=nuqs -- --force
           fi
       - name: Enforce the mutation-debt ratchet
-        if: steps.baseline.outputs.supported == 'true' && steps.inputs.outputs.comparable == 'true'
+        if: steps.baseline.outputs.supported == 'true'
         env:
           MUTATION_SOURCE_ROOT: packages/nuqs
           MUTATION_SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}
@@ -219,12 +219,6 @@ jobs:
           if-no-files-found: ignore
           overwrite: true
           retention-days: 14
-      - name: Require explicit approval for a new baseline
-        if: steps.baseline.outputs.supported == 'true' && steps.inputs.outputs.comparable != 'true'
-        run: |
-          echo '::error::Mutation execution inputs changed, so the relative gate is not meaningful. Review the uploaded full report before merging; later PRs will compare against the merged setup.'
-          exit 1
-
   mutation-full:
     name: Mutation suite (full)
     if: github.event_name != 'pull_request'

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -104,6 +104,14 @@ jobs:
       - name: Establish mutation baseline
         if: steps.baseline.outputs.supported == 'true'
         run: |
+          hash_input() {
+            if test -f "$1"
+            then
+              git hash-object "$1"
+            else
+              printf 'missing'
+            fi
+          }
           for file in \
             .github/workflows/mutation.yml \
             packages/nuqs/scripts/mutation.mjs \
@@ -119,7 +127,7 @@ jobs:
             packages/nuqs/vitest.setup.ts \
             packages/scripts/mutation-gate.ts
           do
-            printf '%s  %s\n' "$(git hash-object "$file")" "$file"
+            printf '%s  %s\n' "$(hash_input "$file")" "$file"
           done > "$RUNNER_TEMP/mutation-inputs-baseline.sha256"
           pnpm exec turbo run mutation --filter=nuqs -- --force
           cp -R packages/nuqs/reports/mutation \
@@ -130,10 +138,18 @@ jobs:
         run: git checkout --detach "$HEAD_SHA"
       - name: Clear the baseline mutation report
         run: rm -rf packages/nuqs/reports/mutation
-      - name: Verify comparable mutation inputs
+      - name: Check whether mutation results can be reused
         if: steps.baseline.outputs.supported == 'true'
         id: inputs
         run: |
+          hash_input() {
+            if test -f "$1"
+            then
+              git hash-object "$1"
+            else
+              printf 'missing'
+            fi
+          }
           for file in \
             .github/workflows/mutation.yml \
             packages/nuqs/scripts/mutation.mjs \
@@ -149,28 +165,28 @@ jobs:
             packages/nuqs/vitest.setup.ts \
             packages/scripts/mutation-gate.ts
           do
-            printf '%s  %s\n' "$(git hash-object "$file")" "$file"
+            printf '%s  %s\n' "$(hash_input "$file")" "$file"
           done > "$RUNNER_TEMP/mutation-inputs-candidate.sha256"
           if ! diff -u \
             "$RUNNER_TEMP/mutation-inputs-baseline.sha256" \
             "$RUNNER_TEMP/mutation-inputs-candidate.sha256"
           then
-            echo 'comparable=false' >> "$GITHUB_OUTPUT"
+            echo 'reusable=false' >> "$GITHUB_OUTPUT"
             echo '::notice::Mutation execution inputs changed; running the complete candidate suite against the existing baseline.'
           else
-            echo 'comparable=true' >> "$GITHUB_OUTPUT"
+            echo 'reusable=true' >> "$GITHUB_OUTPUT"
           fi
       - name: Install candidate dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs... --filter scripts
       - name: Install candidate Playwright Chromium
         run: ./node_modules/.bin/playwright install chromium
         working-directory: packages/nuqs
-      - name: Run incremental candidate mutation tests
+      - name: Run candidate mutation tests
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if test '${{ steps.baseline.outputs.supported }}' = 'true' && \
-            test '${{ steps.inputs.outputs.comparable }}' = 'true'
+            test '${{ steps.inputs.outputs.reusable }}' = 'true'
           then
             mkdir -p packages/nuqs/reports/mutation
             cp -R "$RUNNER_TEMP/mutation-baseline/cache" \

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,11 +39,13 @@ jobs:
             '.github/workflows/mutation.yml' \
             'packages/nuqs/src' \
             'packages/nuqs/tests' \
+            'packages/nuqs/package.json' \
             'packages/nuqs/scripts/mutation.mjs' \
             'packages/nuqs/scripts/mutation-projects.mjs' \
             'packages/nuqs/scripts/mutation-projects.node-test.mjs' \
             'packages/nuqs/scripts/mutation-report.mjs' \
             'packages/nuqs/scripts/mutation-report.node-test.mjs' \
+            'packages/nuqs/scripts/mutation-scope.mjs' \
             'packages/nuqs/stryker.browser.config.mjs' \
             'packages/nuqs/stryker.node.config.mjs' \
             'packages/nuqs/stryker.shared.config.mjs' \
@@ -76,13 +78,14 @@ jobs:
         with:
           node-version-file: .node-version
           cache: pnpm
+      - name: Preserve the candidate scope reporter
+        run: cp packages/nuqs/scripts/mutation-scope.mjs "$RUNNER_TEMP/mutation-scope.mjs"
       - name: Check out the exact base commit
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           BASE_SHA="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
-          printf '%s\n' "$BASE_SHA" > "$RUNNER_TEMP/mutation-base-sha"
           git checkout --detach "$BASE_SHA"
       - name: Check whether the base supports mutation testing
         id: baseline
@@ -104,32 +107,10 @@ jobs:
       - name: Establish mutation baseline
         if: steps.baseline.outputs.supported == 'true'
         run: |
-          hash_input() {
-            if test -f "$1"
-            then
-              git hash-object "$1"
-            else
-              printf 'missing'
-            fi
-          }
-          for file in \
-            .github/workflows/mutation.yml \
-            packages/nuqs/scripts/mutation.mjs \
-            packages/nuqs/scripts/mutation-projects.mjs \
-            packages/nuqs/scripts/mutation-report.mjs \
-            packages/nuqs/stryker.browser.config.mjs \
-            packages/nuqs/stryker.node.config.mjs \
-            packages/nuqs/stryker.shared.config.mjs \
-            packages/nuqs/vitest.browser.mutation.config.ts \
-            packages/nuqs/vitest.browser.setup.ts \
-            packages/nuqs/vitest.config.ts \
-            packages/nuqs/vitest.mutation.config.ts \
-            packages/nuqs/vitest.setup.ts \
-            packages/scripts/mutation-gate.ts
-          do
-            printf '%s  %s\n' "$(hash_input "$file")" "$file"
-          done > "$RUNNER_TEMP/mutation-inputs-baseline.sha256"
           pnpm exec turbo run mutation --filter=nuqs -- --force
+          node "$RUNNER_TEMP/mutation-scope.mjs" \
+            packages/nuqs \
+            packages/nuqs/reports/mutation/stryker-incremental.json
           cp -R packages/nuqs/reports/mutation \
             "$RUNNER_TEMP/mutation-baseline"
       - name: Check out the exact candidate commit
@@ -137,86 +118,19 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: git checkout --detach "$HEAD_SHA"
       - name: Clear the baseline mutation report
+        id: candidate_report_reset
         run: rm -rf packages/nuqs/reports/mutation
-      - name: Check whether mutation results can be reused
-        if: steps.baseline.outputs.supported == 'true'
-        id: inputs
-        run: |
-          hash_input() {
-            if test -f "$1"
-            then
-              git hash-object "$1"
-            else
-              printf 'missing'
-            fi
-          }
-          for file in \
-            .github/workflows/mutation.yml \
-            packages/nuqs/scripts/mutation.mjs \
-            packages/nuqs/scripts/mutation-projects.mjs \
-            packages/nuqs/scripts/mutation-report.mjs \
-            packages/nuqs/stryker.browser.config.mjs \
-            packages/nuqs/stryker.node.config.mjs \
-            packages/nuqs/stryker.shared.config.mjs \
-            packages/nuqs/vitest.browser.mutation.config.ts \
-            packages/nuqs/vitest.browser.setup.ts \
-            packages/nuqs/vitest.config.ts \
-            packages/nuqs/vitest.mutation.config.ts \
-            packages/nuqs/vitest.setup.ts \
-            packages/scripts/mutation-gate.ts
-          do
-            printf '%s  %s\n' "$(hash_input "$file")" "$file"
-          done > "$RUNNER_TEMP/mutation-inputs-candidate.sha256"
-          if ! diff -u \
-            "$RUNNER_TEMP/mutation-inputs-baseline.sha256" \
-            "$RUNNER_TEMP/mutation-inputs-candidate.sha256"
-          then
-            echo 'reusable=false' >> "$GITHUB_OUTPUT"
-            echo '::notice::Mutation execution inputs changed; running the complete candidate suite against the existing baseline.'
-          else
-            echo 'reusable=true' >> "$GITHUB_OUTPUT"
-          fi
       - name: Install candidate dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile --filter nuqs... --filter scripts
       - name: Install candidate Playwright Chromium
         run: ./node_modules/.bin/playwright install chromium
         working-directory: packages/nuqs
       - name: Run candidate mutation tests
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if test '${{ steps.baseline.outputs.supported }}' = 'true' && \
-            test '${{ steps.inputs.outputs.reusable }}' = 'true'
-          then
-            mkdir -p packages/nuqs/reports/mutation
-            cp -R "$RUNNER_TEMP/mutation-baseline/cache" \
-              packages/nuqs/reports/mutation/cache
-            BASE_SHA="$(cat "$RUNNER_TEMP/mutation-base-sha")"
-            if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
-              'packages/nuqs/src/adapters' \
-              'packages/nuqs/src/lib/compare.ts' \
-              'packages/nuqs/src/lib/debug.ts' \
-              'packages/nuqs/src/lib/queues/debounce.ts' \
-              'packages/nuqs/src/lib/queues/rate-limiting.ts' \
-              'packages/nuqs/src/lib/queues/throttle.ts' \
-              'packages/nuqs/src/lib/queues/useSyncExternalStores.ts' \
-              'packages/nuqs/src/lib/safe-parse.ts' \
-              'packages/nuqs/src/lib/search-params.ts' \
-              'packages/nuqs/src/lib/sync.ts' \
-              'packages/nuqs/src/lib/url-encoding.ts' \
-              'packages/nuqs/src/lib/url-keys.ts' \
-              'packages/nuqs/tests' \
-              'packages/nuqs/vitest.browser.setup.ts' \
-              'packages/nuqs/vitest.setup.ts'
-            then
-              pnpm mutation
-            else
-              echo '::notice::Mutation test dependencies changed; running the complete candidate suite.'
-              pnpm mutation -- --force
-            fi
-          else
-            pnpm exec turbo run mutation --filter=nuqs -- --force
-          fi
+          pnpm exec turbo run mutation --filter=nuqs -- --force
+          node "$RUNNER_TEMP/mutation-scope.mjs" \
+            packages/nuqs \
+            packages/nuqs/reports/mutation/stryker-incremental.json
       - name: Enforce the mutation-debt ratchet
         if: steps.baseline.outputs.supported == 'true'
         env:
@@ -227,10 +141,10 @@ jobs:
           "$RUNNER_TEMP/mutation-baseline/stryker-incremental.json"
           "packages/nuqs/reports/mutation/stryker-incremental.json"
       - name: Upload candidate mutation report
-        if: always()
+        if: always() && steps.candidate_report_reset.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: mutation-report-${{ github.event.pull_request.number }}
+          name: mutation-report-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: packages/nuqs/reports/mutation/
           if-no-files-found: ignore
           overwrite: true
@@ -260,7 +174,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: mutation-report-${{ github.run_id }}
+          name: mutation-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: packages/nuqs/reports/mutation/
           if-no-files-found: ignore
           overwrite: true

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -102,10 +102,8 @@ jobs:
         working-directory: packages/nuqs
       - name: Establish mutation baseline
         if: steps.baseline.outputs.supported == 'true'
-        run: pnpm exec turbo run mutation --filter=nuqs -- --force
-      - name: Record baseline mutation scope
-        if: steps.baseline.outputs.supported == 'true'
         run: |
+          pnpm exec turbo run mutation --filter=nuqs -- --force
           node "$RUNNER_TEMP/mutation-scope.mjs" \
             packages/nuqs \
             packages/nuqs/reports/mutation/stryker-incremental.json

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -40,12 +40,7 @@ jobs:
             'packages/nuqs/src' \
             'packages/nuqs/tests' \
             'packages/nuqs/package.json' \
-            'packages/nuqs/scripts/mutation.mjs' \
-            'packages/nuqs/scripts/mutation-projects.mjs' \
-            'packages/nuqs/scripts/mutation-projects.node-test.mjs' \
-            'packages/nuqs/scripts/mutation-report.mjs' \
-            'packages/nuqs/scripts/mutation-report.node-test.mjs' \
-            'packages/nuqs/scripts/mutation-scope.mjs' \
+            'packages/nuqs/scripts' \
             'packages/nuqs/stryker.browser.config.mjs' \
             'packages/nuqs/stryker.node.config.mjs' \
             'packages/nuqs/stryker.shared.config.mjs' \
@@ -73,6 +68,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
@@ -106,8 +102,10 @@ jobs:
         working-directory: packages/nuqs
       - name: Establish mutation baseline
         if: steps.baseline.outputs.supported == 'true'
+        run: pnpm exec turbo run mutation --filter=nuqs -- --force
+      - name: Record baseline mutation scope
+        if: steps.baseline.outputs.supported == 'true'
         run: |
-          pnpm exec turbo run mutation --filter=nuqs -- --force
           node "$RUNNER_TEMP/mutation-scope.mjs" \
             packages/nuqs \
             packages/nuqs/reports/mutation/stryker-incremental.json
@@ -126,11 +124,14 @@ jobs:
         run: ./node_modules/.bin/playwright install chromium
         working-directory: packages/nuqs
       - name: Run candidate mutation tests
-        run: |
-          pnpm exec turbo run mutation --filter=nuqs -- --force
-          node "$RUNNER_TEMP/mutation-scope.mjs" \
-            packages/nuqs \
-            packages/nuqs/reports/mutation/stryker-incremental.json
+        run: pnpm exec turbo run mutation --filter=nuqs -- --force
+      - name: Record candidate mutation scope
+        id: candidate_scope
+        if: always() && steps.candidate_report_reset.outcome == 'success'
+        run: >-
+          node "$RUNNER_TEMP/mutation-scope.mjs"
+          packages/nuqs
+          packages/nuqs/reports/mutation/stryker-incremental.json
       - name: Enforce the mutation-debt ratchet
         if: steps.baseline.outputs.supported == 'true'
         env:
@@ -141,7 +142,7 @@ jobs:
           "$RUNNER_TEMP/mutation-baseline/stryker-incremental.json"
           "packages/nuqs/reports/mutation/stryker-incremental.json"
       - name: Upload candidate mutation report
-        if: always() && steps.candidate_report_reset.outcome == 'success'
+        if: always() && steps.candidate_scope.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: mutation-report-${{ github.event.pull_request.number }}-${{ github.run_attempt }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,10 @@ pnpm mutation
 The report is written to `packages/nuqs/reports/mutation/`. The `Mutation debt`
 check fails when a change increases mutation debt relative to its base. CI
 compares complete reports from the pull request's merge base and candidate
-commit. It rejects comparisons that change the mutation command, source
-or test patterns, runtime ownership, ignore settings, or excluded mutations. It
-also rejects candidates that stop executing a baseline test. Ignored mutants
-count as debt, so code changes cannot lower debt by making mutants ignored.
+commit. It rejects comparisons that change the mutation command, source scope,
+runtime ownership, sandbox exclusions, or excluded mutations. It also rejects
+candidates that stop executing a baseline test. Ignored mutants count as debt,
+so code changes cannot lower debt by making mutants ignored.
 
 ## Opening issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,10 @@ pnpm mutation
 
 The report is written to `packages/nuqs/reports/mutation/`. The `Mutation debt`
 check fails when a change increases the number of undetected mutants relative to
-its base. When mutation inputs change, CI runs the complete candidate suite and
-compares its aggregate debt with a fresh report from the exact base commit.
+its base. CI compares complete reports from the pull request's merge base and
+candidate commit. It rejects the comparison when the mutation command, source or
+test selection, runtime ownership, ignored static code, custom ignorers, source
+exclusion directives, or excluded mutations change.
 
 ## Opening issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,8 @@ pnpm mutation
 
 The report is written to `packages/nuqs/reports/mutation/`. The `Mutation debt`
 check fails when a change increases the number of undetected mutants relative to
-its base. Changes to the mutation setup require reviewing a fresh full report
-before merging.
+its base. When mutation inputs change, CI runs the complete candidate suite and
+compares its aggregate debt with a fresh report from the exact base commit.
 
 ## Opening issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,12 +89,9 @@ pnpm mutation
 ```
 
 The report is written to `packages/nuqs/reports/mutation/`. The `Mutation debt`
-check fails when a change increases mutation debt relative to its base. CI
-compares complete reports from the pull request's merge base and candidate
-commit. It rejects comparisons that change the mutation command, source scope,
-runtime ownership, sandbox exclusions, or excluded mutations. It also rejects
-candidates that stop executing a baseline test. Ignored mutants count as debt,
-so code changes cannot lower debt by making mutants ignored.
+check compares fresh, complete reports and fails when a change increases debt
+relative to its base. It also rejects incompatible mutation setups. Ignored
+mutants count as debt.
 
 ## Opening issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,11 +89,12 @@ pnpm mutation
 ```
 
 The report is written to `packages/nuqs/reports/mutation/`. The `Mutation debt`
-check fails when a change increases the number of undetected mutants relative to
-its base. CI compares complete reports from the pull request's merge base and
-candidate commit. It rejects the comparison when the mutation command, source or
-test selection, runtime ownership, ignored static code, custom ignorers, source
-exclusion directives, or excluded mutations change.
+check fails when a change increases mutation debt relative to its base. CI
+compares complete reports from the pull request's merge base and candidate
+commit. It rejects comparisons that change the mutation command, source
+or test patterns, runtime ownership, ignore settings, or excluded mutations. It
+also rejects candidates that stop executing a baseline test. Ignored mutants
+count as debt, so code changes cannot lower debt by making mutants ignored.
 
 ## Opening issues
 

--- a/packages/nuqs/scripts/mutation-projects.mjs
+++ b/packages/nuqs/scripts/mutation-projects.mjs
@@ -1,34 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 
-const operationalConfigKeys = new Set([
-  '$schema',
-  'allowConsoleColors',
-  'clearTextReporter',
-  'dashboard',
-  'eventReporter',
-  'fileLogLevel',
-  'force',
-  'htmlReporter',
-  'incremental',
-  'incrementalFile',
-  'jsonReporter',
-  'logLevel',
-  'mutate',
-  'reporters',
-  'tempDirName',
-  'testFiles',
-  'warnings'
-])
-
-export function comparableMutationConfig(node, browser) {
-  return {
-    strategy: 'runtime-ownership-v1',
-    node: comparableConfig(node),
-    browser: comparableConfig(browser)
-  }
-}
-
 export function createMutationProjects(root, browserProjects) {
   const browserMutate = []
   const browserTestFiles = []
@@ -67,10 +39,4 @@ function assertFileExists(root, path, kind) {
   if (!existsSync(join(root, path))) {
     throw new Error(`${kind} does not exist: ${path}`)
   }
-}
-
-function comparableConfig(config) {
-  return Object.fromEntries(
-    Object.entries(config).filter(([key]) => !operationalConfigKeys.has(key))
-  )
 }

--- a/packages/nuqs/scripts/mutation-projects.node-test.mjs
+++ b/packages/nuqs/scripts/mutation-projects.node-test.mjs
@@ -3,10 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, it } from 'node:test'
-import {
-  comparableMutationConfig,
-  createMutationProjects
-} from './mutation-projects.mjs'
+import { createMutationProjects } from './mutation-projects.mjs'
 
 const temporaryDirectories = []
 
@@ -123,31 +120,6 @@ describe('createMutationProjects', () => {
 
     assert.deepEqual(projects.browserMutate, ['src/first.ts', 'src/second.ts'])
     assert.deepEqual(projects.browserTestFiles, ['src/shared.browser.test.ts'])
-  })
-
-  it('compares strategy and runtime settings, not project file lists', () => {
-    const config = comparableMutationConfig(
-      {
-        mutate: ['src/a.ts'],
-        testFiles: ['src/a.test.ts'],
-        timeoutMS: 1,
-        concurrency: 2,
-        vitest: { related: false }
-      },
-      {
-        mutate: ['src/b.ts'],
-        testFiles: ['src/b.browser.test.ts'],
-        timeoutMS: 2,
-        concurrency: 3,
-        vitest: { related: true }
-      }
-    )
-
-    assert.deepEqual(config, {
-      strategy: 'runtime-ownership-v1',
-      node: { timeoutMS: 1, concurrency: 2, vitest: { related: false } },
-      browser: { timeoutMS: 2, concurrency: 3, vitest: { related: true } }
-    })
   })
 })
 

--- a/packages/nuqs/scripts/mutation-report.mjs
+++ b/packages/nuqs/scripts/mutation-report.mjs
@@ -87,7 +87,7 @@ export function mergeMutationReports(nodeReport, browserReport) {
   )
 
   return {
-    files: Object.assign({}, ...namespacedReports.map(activeFiles)),
+    files: Object.assign({}, ...namespacedReports.map(report => report.files)),
     schemaVersion: nodeReport.schemaVersion,
     thresholds: nodeReport.thresholds,
     testFiles: Object.assign(
@@ -134,15 +134,6 @@ function namespaceReport(report, runtime) {
       ])
     )
   }
-}
-
-function activeFiles(report) {
-  return Object.fromEntries(
-    Object.entries(report.files).flatMap(([path, file]) => {
-      const mutants = file.mutants.filter(mutant => mutant.status !== 'Ignored')
-      return mutants.length === 0 ? [] : [[path, { ...file, mutants }]]
-    })
-  )
 }
 
 function assertEqual(label, left, right) {

--- a/packages/nuqs/scripts/mutation-report.mjs
+++ b/packages/nuqs/scripts/mutation-report.mjs
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises'
 import { z } from 'zod'
-import { comparableMutationConfig } from './mutation-projects.mjs'
 
 const mutantSchema = z
   .object({
@@ -96,7 +95,11 @@ export function mergeMutationReports(nodeReport, browserReport) {
       ...namespacedReports.map(report => report.testFiles)
     ),
     projectRoot: nodeReport.projectRoot,
-    config: comparableMutationConfig(nodeReport.config, browserReport.config),
+    config: {
+      strategy: 'runtime-ownership-v1',
+      node: nodeReport.config,
+      browser: browserReport.config
+    },
     framework: nodeReport.framework
   }
 }

--- a/packages/nuqs/scripts/mutation-report.node-test.mjs
+++ b/packages/nuqs/scripts/mutation-report.node-test.mjs
@@ -34,7 +34,7 @@ describe('mutation report aggregation', () => {
     )
   })
 
-  it('records strategy and distinct runtime settings', () => {
+  it('records strategy and complete runtime settings', () => {
     const node = report('src/node.ts')
     const browser = report('src/browser.ts')
     node.config.timeoutMS = 1

--- a/packages/nuqs/scripts/mutation-scope.mjs
+++ b/packages/nuqs/scripts/mutation-scope.mjs
@@ -1,5 +1,5 @@
-import { readFile, readdir, writeFile } from 'node:fs/promises'
-import { extname, relative, resolve } from 'node:path'
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 const [root, reportPath] = process.argv.slice(2)
@@ -7,14 +7,16 @@ if (!root || !reportPath) {
   throw new Error('usage: mutation-scope.mjs <nuqs-root> <report>')
 }
 
+const loadJson = async path => JSON.parse(await readFile(path, 'utf8'))
 const loadConfig = async name =>
   (await import(pathToFileURL(resolve(root, name)).href)).default
-const node = await loadConfig('stryker.node.config.mjs')
-const browser = await loadConfig('stryker.browser.config.mjs')
-const report = JSON.parse(await readFile(reportPath, 'utf8'))
-const packageJson = JSON.parse(
-  await readFile(resolve(root, 'package.json'), 'utf8')
-)
+const nodeConfig = await loadConfig('stryker.node.config.mjs')
+const browserConfig = await loadConfig('stryker.browser.config.mjs')
+const report = await loadJson(reportPath)
+const cache = resolve(dirname(reportPath), 'cache')
+const nodeReport = await loadJson(resolve(cache, 'node.json'))
+const browserReport = await loadJson(resolve(cache, 'browser.json'))
+const packageJson = await loadJson(resolve(root, 'package.json'))
 
 if (typeof report.config?.strategy !== 'string') {
   throw new Error('mutation report is missing its runtime ownership strategy')
@@ -23,47 +25,56 @@ if (typeof packageJson.scripts?.mutation !== 'string') {
   throw new Error('package is missing its mutation command')
 }
 
+report.files = mergeRuntimeFiles(nodeReport, browserReport)
 report.config.scope = {
   strategy: report.config.strategy,
   command: packageJson.scripts.mutation,
-  sourceDirectives: await findSourceDirectives(resolve(root, 'src')),
-  node: selectScope(node),
-  browser: selectScope(browser)
+  node: selectScope(nodeConfig, nodeReport),
+  browser: selectScope(browserConfig, browserReport)
 }
 
 await writeFile(reportPath, JSON.stringify(report, null, 2) + '\n')
 
-function selectScope(config) {
-  return {
-    mutate: config.mutate,
-    testFiles: [...config.testFiles].sort(),
-    excludedMutations: [...(config.mutator?.excludedMutations ?? [])].sort(),
-    ignoreStatic: config.ignoreStatic,
-    ignorers: [...(config.ignorers ?? [])].sort()
-  }
-}
-
-async function findSourceDirectives(directory) {
-  const directives = []
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const path = resolve(directory, entry.name)
-    if (entry.isDirectory()) {
-      directives.push(...(await findSourceDirectives(path)))
-    } else if (['.ts', '.tsx'].includes(extname(entry.name))) {
-      const lines = (await readFile(path, 'utf8')).split('\n')
-      for (const [index, line] of lines.entries()) {
-        if (/Stryker (disable|restore)/.test(line)) {
-          directives.push({
-            file: relative(resolve(root, 'src'), path),
-            line: index + 1,
-            directive: line.trim()
-          })
-        }
+function mergeRuntimeFiles(nodeReport, browserReport) {
+  const files = {}
+  for (const [runtime, runtimeReport] of [
+    ['node', nodeReport],
+    ['browser', browserReport]
+  ]) {
+    for (const [path, file] of Object.entries(runtimeReport.files)) {
+      if (path in files) {
+        throw new Error(`duplicate mutation source: ${path}`)
+      }
+      const testId = id => `${runtime}:${id}`
+      files[path] = {
+        ...file,
+        mutants: file.mutants.map(mutant => ({
+          ...mutant,
+          id: testId(mutant.id),
+          ...(mutant.coveredBy && {
+            coveredBy: mutant.coveredBy.map(testId)
+          }),
+          ...(mutant.killedBy && { killedBy: mutant.killedBy.map(testId) })
+        }))
       }
     }
   }
-  return directives.sort(
-    (left, right) =>
-      left.file.localeCompare(right.file) || left.line - right.line
-  )
+  return files
+}
+
+function selectScope(declared, effectiveReport) {
+  const effective = effectiveReport.config
+  return {
+    mutate: declared.mutate,
+    testPatterns: [...declared.testFiles].sort(),
+    excludedMutations: [...effective.mutator.excludedMutations].sort(),
+    ignoreStatic: effective.ignoreStatic,
+    ignorers: [...effective.ignorers].sort(),
+    ignorePatterns: effective.ignorePatterns,
+    executedTests: Object.entries(effectiveReport.testFiles)
+      .flatMap(([file, { tests }]) =>
+        tests.map(test => `${file}\0${test.name}`)
+      )
+      .sort()
+  }
 }

--- a/packages/nuqs/scripts/mutation-scope.mjs
+++ b/packages/nuqs/scripts/mutation-scope.mjs
@@ -66,10 +66,7 @@ function selectScope(declared, effectiveReport) {
   const effective = effectiveReport.config
   return {
     mutate: declared.mutate,
-    testPatterns: [...declared.testFiles].sort(),
     excludedMutations: [...effective.mutator.excludedMutations].sort(),
-    ignoreStatic: effective.ignoreStatic,
-    ignorers: [...effective.ignorers].sort(),
     ignorePatterns: effective.ignorePatterns,
     executedTests: Object.entries(effectiveReport.testFiles)
       .flatMap(([file, { tests }]) =>

--- a/packages/nuqs/scripts/mutation-scope.mjs
+++ b/packages/nuqs/scripts/mutation-scope.mjs
@@ -1,0 +1,69 @@
+import { readFile, readdir, writeFile } from 'node:fs/promises'
+import { extname, relative, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const [root, reportPath] = process.argv.slice(2)
+if (!root || !reportPath) {
+  throw new Error('usage: mutation-scope.mjs <nuqs-root> <report>')
+}
+
+const loadConfig = async name =>
+  (await import(pathToFileURL(resolve(root, name)).href)).default
+const node = await loadConfig('stryker.node.config.mjs')
+const browser = await loadConfig('stryker.browser.config.mjs')
+const report = JSON.parse(await readFile(reportPath, 'utf8'))
+const packageJson = JSON.parse(
+  await readFile(resolve(root, 'package.json'), 'utf8')
+)
+
+if (typeof report.config?.strategy !== 'string') {
+  throw new Error('mutation report is missing its runtime ownership strategy')
+}
+if (typeof packageJson.scripts?.mutation !== 'string') {
+  throw new Error('package is missing its mutation command')
+}
+
+report.config.scope = {
+  strategy: report.config.strategy,
+  command: packageJson.scripts.mutation,
+  sourceDirectives: await findSourceDirectives(resolve(root, 'src')),
+  node: selectScope(node),
+  browser: selectScope(browser)
+}
+
+await writeFile(reportPath, JSON.stringify(report, null, 2) + '\n')
+
+function selectScope(config) {
+  return {
+    mutate: config.mutate,
+    testFiles: [...config.testFiles].sort(),
+    excludedMutations: [...(config.mutator?.excludedMutations ?? [])].sort(),
+    ignoreStatic: config.ignoreStatic,
+    ignorers: [...(config.ignorers ?? [])].sort()
+  }
+}
+
+async function findSourceDirectives(directory) {
+  const directives = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) {
+      directives.push(...(await findSourceDirectives(path)))
+    } else if (['.ts', '.tsx'].includes(extname(entry.name))) {
+      const lines = (await readFile(path, 'utf8')).split('\n')
+      for (const [index, line] of lines.entries()) {
+        if (/Stryker (disable|restore)/.test(line)) {
+          directives.push({
+            file: relative(resolve(root, 'src'), path),
+            line: index + 1,
+            directive: line.trim()
+          })
+        }
+      }
+    }
+  }
+  return directives.sort(
+    (left, right) =>
+      left.file.localeCompare(right.file) || left.line - right.line
+  )
+}

--- a/packages/nuqs/scripts/mutation-scope.mjs
+++ b/packages/nuqs/scripts/mutation-scope.mjs
@@ -1,6 +1,5 @@
-import { readFile, writeFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { readFile, readdir, writeFile } from 'node:fs/promises'
+import { dirname, extname, relative, resolve } from 'node:path'
 
 const [root, reportPath] = process.argv.slice(2)
 if (!root || !reportPath) {
@@ -8,10 +7,6 @@ if (!root || !reportPath) {
 }
 
 const loadJson = async path => JSON.parse(await readFile(path, 'utf8'))
-const loadConfig = async name =>
-  (await import(pathToFileURL(resolve(root, name)).href)).default
-const nodeConfig = await loadConfig('stryker.node.config.mjs')
-const browserConfig = await loadConfig('stryker.browser.config.mjs')
 const report = await loadJson(reportPath)
 const cache = resolve(dirname(reportPath), 'cache')
 const nodeReport = await loadJson(resolve(cache, 'node.json'))
@@ -29,8 +24,9 @@ report.files = mergeRuntimeFiles(nodeReport, browserReport)
 report.config.scope = {
   strategy: report.config.strategy,
   command: packageJson.scripts.mutation,
-  node: selectScope(nodeConfig, nodeReport),
-  browser: selectScope(browserConfig, browserReport)
+  sourceFiles: await listSourceFiles(resolve(root, 'src')),
+  node: selectScope(nodeReport),
+  browser: selectScope(browserReport)
 }
 
 await writeFile(reportPath, JSON.stringify(report, null, 2) + '\n')
@@ -62,16 +58,29 @@ function mergeRuntimeFiles(nodeReport, browserReport) {
   return files
 }
 
-function selectScope(declared, effectiveReport) {
-  const effective = effectiveReport.config
+function selectScope(runtimeReport) {
+  const effective = runtimeReport.config
   return {
-    mutate: declared.mutate,
+    mutationFiles: Object.keys(runtimeReport.files).sort(),
     excludedMutations: [...effective.mutator.excludedMutations].sort(),
     ignorePatterns: effective.ignorePatterns,
-    executedTests: Object.entries(effectiveReport.testFiles)
+    executedTests: Object.entries(runtimeReport.testFiles)
       .flatMap(([file, { tests }]) =>
         tests.map(test => `${file}\0${test.name}`)
       )
       .sort()
   }
+}
+
+async function listSourceFiles(directory) {
+  const files = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listSourceFiles(path)))
+    } else if (['.ts', '.tsx'].includes(extname(entry.name))) {
+      files.push(relative(root, path))
+    }
+  }
+  return files.sort()
 }

--- a/packages/nuqs/scripts/mutation.mjs
+++ b/packages/nuqs/scripts/mutation.mjs
@@ -25,8 +25,8 @@ const report = mergeMutationReports(nodeReport, browserReport)
 
 await writeFile(aggregatePath, JSON.stringify(report, null, 2) + '\n')
 await writeFile(htmlPath, await renderHtml(report))
+assertValidMutationReport(report)
 printSummary(report)
-assertNoMutationErrors(report)
 
 function runStryker(configFile) {
   return new Promise((resolve, reject) => {
@@ -96,13 +96,24 @@ function printSummary(report) {
   )
 }
 
-function assertNoMutationErrors(report) {
-  const errors = Object.values(report.files)
-    .flatMap(file => file.mutants)
-    .filter(mutant =>
-      ['CompileError', 'RuntimeError'].includes(mutant.status)
-    ).length
+function assertValidMutationReport(report) {
+  const mutants = Object.values(report.files).flatMap(file => file.mutants)
+  if (mutants.length === 0) {
+    throw new Error('mutation report contains no mutants')
+  }
+  const errors = mutants.filter(mutant =>
+    ['CompileError', 'RuntimeError'].includes(mutant.status)
+  ).length
   if (errors > 0) {
     throw new Error(`mutation report contains ${errors} mutation error(s)`)
+  }
+  const incomplete = mutants.filter(
+    mutant =>
+      !['Killed', 'Timeout', 'Survived', 'NoCoverage'].includes(mutant.status)
+  ).length
+  if (incomplete > 0) {
+    throw new Error(
+      `mutation report contains ${incomplete} incomplete mutant(s)`
+    )
   }
 }

--- a/packages/nuqs/scripts/mutation.mjs
+++ b/packages/nuqs/scripts/mutation.mjs
@@ -86,13 +86,14 @@ function printSummary(report) {
   const timeout = count('Timeout')
   const survived = count('Survived')
   const noCoverage = count('NoCoverage')
-  const total = statuses.length
-  const score = total === 0 ? 100 : ((killed + timeout) / total) * 100
+  const ignored = count('Ignored')
+  const active = statuses.filter(status => status !== 'Ignored').length
+  const score = active === 0 ? 100 : ((killed + timeout) / active) * 100
 
   process.stdout.write(
     `Combined mutation score: ${score.toFixed(2)}% ` +
       `(${killed} killed, ${timeout} timeout, ${survived} survived, ` +
-      `${noCoverage} no coverage, ${total} total)\n`
+      `${noCoverage} no coverage, ${ignored} ignored, ${active} active)\n`
   )
 }
 
@@ -109,7 +110,9 @@ function assertValidMutationReport(report) {
   }
   const incomplete = mutants.filter(
     mutant =>
-      !['Killed', 'Timeout', 'Survived', 'NoCoverage'].includes(mutant.status)
+      !['Killed', 'Timeout', 'Survived', 'NoCoverage', 'Ignored'].includes(
+        mutant.status
+      )
   ).length
   if (incomplete > 0) {
     throw new Error(

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -47,14 +47,15 @@ const defaultConfig = {
   scope: {
     strategy: 'runtime-ownership-v1',
     command: 'node scripts/mutation.mjs',
+    sourceFiles: ['src/browser.ts', 'src/example.ts'],
     node: {
-      mutate: ['src/**/*.ts'],
+      mutationFiles: ['src/example.ts'],
       excludedMutations: [],
       ignorePatterns: [],
       executedTests: ['src/example.test.ts\0test']
     },
     browser: {
-      mutate: ['src/browser.ts'],
+      mutationFiles: ['src/browser.ts'],
       excludedMutations: [],
       ignorePatterns: [],
       executedTests: ['src/browser.test.ts\0test']
@@ -207,7 +208,7 @@ describe('mutation gate', () => {
 
   it('rejects mutation scope changes', () => {
     const candidateConfig = structuredClone(defaultConfig)
-    candidateConfig.scope.node.mutate = ['src/cache.ts']
+    candidateConfig.scope.command = 'node scripts/other-mutation.mjs'
 
     expect(() =>
       compareMutationReports(

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   compareMutationReports,
-  formatNewUndetectedMutants,
+  formatUndetectedMutants,
   summarizeMutationReport,
   type MutationReport
 } from './mutation-gate'
@@ -15,7 +15,7 @@ function report(
   statuses: Array<
     'Killed' | 'Timeout' | 'Survived' | 'NoCoverage' | 'RuntimeError'
   >,
-  config: MutationReport['config'] = structuredClone(comparableConfig)
+  config: MutationReport['config'] = structuredClone(defaultConfig)
 ): MutationReport {
   return {
     files: {
@@ -29,11 +29,12 @@ function report(
       name: 'StrykerJS',
       version: '9.6.1',
       dependencies: { typescript: '7.0.2' }
-    }
+    },
+    schemaVersion: '2'
   }
 }
 
-const comparableConfig = {
+const defaultConfig = {
   mutate: ['src/**/*.ts'],
   testRunner: 'vitest',
   timeoutMS: 5000,
@@ -126,75 +127,36 @@ describe('mutation gate', () => {
 
     const result = compareMutationReports(baseline, candidate)
     expect(result).toMatchObject({ pass: false, delta: 1 })
-    expect(result.newUndetected).toStrictEqual([
-      {
-        file: 'src/example.ts',
-        id: '0',
-        location: {
-          end: { line: 12, column: 14 },
-          start: { line: 12, column: 5 }
-        },
-        mutatorName: 'ConditionalExpression',
-        original: 'value > 0',
-        previousStatus: 'Killed',
-        replacement: 'false',
-        status: 'Survived'
-      }
-    ])
-    const formatted = formatNewUndetectedMutants(
-      result.newUndetected,
+    expect(
+      result.candidateUndetected.find(mutant => mutant.id === '0')
+    ).toStrictEqual({
+      file: 'src/example.ts',
+      id: '0',
+      location: {
+        end: { line: 12, column: 14 },
+        start: { line: 12, column: 5 }
+      },
+      mutatorName: 'ConditionalExpression',
+      original: 'value > 0',
+      replacement: 'false',
+      status: 'Survived'
+    })
+    const formatted = formatUndetectedMutants(
+      result.candidateUndetected,
       'https://github.com/47ng/nuqs/blob/deadbeef',
       'packages/nuqs'
     )
     expect(formatted).toContain(
-      '::error file=packages/nuqs/src/example.ts,line=12,col=5,title=New undetected mutant::ConditionalExpression Survived (was Killed)%0AOriginal: value > 0%0AMutated: false'
+      '::error file=packages/nuqs/src/example.ts,line=12,col=5,title=Undetected mutant::ConditionalExpression Survived%0AOriginal: value > 0%0AMutated: false'
     )
     expect(formatted).toContain(
       'https://github.com/47ng/nuqs/blob/deadbeef/packages/nuqs/src/example.ts#L12'
     )
     expect(formatted).toContain(
-      '- src/example.ts:12:5 [ConditionalExpression] Newly survived; previously killed'
+      '- src/example.ts:12:5 [ConditionalExpression] Undetected mutant (survived)'
     )
     expect(formatted).toContain('Original: value > 0')
     expect(formatted).toContain('Mutated: false')
-  })
-
-  it('does not reconcile renumbered mutants by mutable source metadata', () => {
-    const location = {
-      end: { line: 1, column: 10 },
-      start: { line: 1, column: 1 }
-    }
-    const baseline = report(['Killed'])
-    Object.assign(baseline.files['src/example.ts']!.mutants[0]!, {
-      id: '17',
-      location,
-      mutatorName: 'ConditionalExpression',
-      replacement: 'false'
-    })
-    const candidate = report(['Survived'])
-    Object.assign(candidate.files['src/example.ts']!.mutants[0]!, {
-      id: '42',
-      location,
-      mutatorName: 'ConditionalExpression',
-      replacement: 'false'
-    })
-
-    expect(
-      compareMutationReports(baseline, candidate).newUndetected
-    ).toMatchObject([
-      { id: '42', previousStatus: undefined, status: 'Survived' }
-    ])
-  })
-
-  it('includes the source file in mutant identity', () => {
-    const baseline = report(['Killed'])
-    baseline.files = { 'src/a.ts': baseline.files['src/example.ts']! }
-    const candidate = report(['Survived'])
-    candidate.files = { 'src/b.ts': candidate.files['src/example.ts']! }
-
-    expect(
-      compareMutationReports(baseline, candidate).newUndetected
-    ).toMatchObject([{ file: 'src/b.ts', id: '0', previousStatus: undefined }])
   })
 
   it('fails closed on mutation errors', () => {
@@ -225,7 +187,7 @@ describe('mutation gate', () => {
       compareMutationReports(
         report(['Killed']),
         report(['Survived'], {
-          ...comparableConfig,
+          ...defaultConfig,
           mutate: ['src/cache.ts'],
           timeoutMS: 1
         })

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -49,19 +49,13 @@ const defaultConfig = {
     command: 'node scripts/mutation.mjs',
     node: {
       mutate: ['src/**/*.ts'],
-      testPatterns: ['src/**/*.test.ts'],
       excludedMutations: [],
-      ignoreStatic: true,
-      ignorers: [],
       ignorePatterns: [],
       executedTests: ['src/example.test.ts\0test']
     },
     browser: {
       mutate: ['src/browser.ts'],
-      testPatterns: ['src/browser.test.ts'],
       excludedMutations: [],
-      ignoreStatic: true,
-      ignorers: [],
       ignorePatterns: [],
       executedTests: ['src/browser.test.ts\0test']
     }

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -38,7 +38,26 @@ const defaultConfig = {
   mutate: ['src/**/*.ts'],
   testRunner: 'vitest',
   timeoutMS: 5000,
-  vitest: { related: true }
+  vitest: { related: true },
+  scope: {
+    strategy: 'runtime-ownership-v1',
+    command: 'node scripts/mutation.mjs',
+    sourceDirectives: [],
+    node: {
+      mutate: ['src/**/*.ts'],
+      testFiles: ['src/**/*.test.ts'],
+      excludedMutations: [],
+      ignoreStatic: true,
+      ignorers: []
+    },
+    browser: {
+      mutate: ['src/browser.ts'],
+      testFiles: ['src/browser.test.ts'],
+      excludedMutations: [],
+      ignoreStatic: true,
+      ignorers: []
+    }
+  }
 }
 
 const temporaryDirectories: string[] = []
@@ -182,17 +201,16 @@ describe('mutation gate', () => {
     )
   })
 
-  it('compares aggregate debt across mutation configuration changes', () => {
-    expect(
+  it('rejects mutation scope changes', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.node.mutate = ['src/cache.ts']
+
+    expect(() =>
       compareMutationReports(
         report(['Killed']),
-        report(['Survived'], {
-          ...defaultConfig,
-          mutate: ['src/cache.ts'],
-          timeoutMS: 1
-        })
+        report(['Survived'], candidateConfig)
       )
-    ).toMatchObject({ pass: false, delta: 1 })
+    ).toThrow('mutation scope changed')
   })
 
   it('compares mutation debt across toolchain changes', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -13,7 +13,12 @@ import {
 
 function report(
   statuses: Array<
-    'Killed' | 'Timeout' | 'Survived' | 'NoCoverage' | 'RuntimeError'
+    | 'Killed'
+    | 'Timeout'
+    | 'Survived'
+    | 'NoCoverage'
+    | 'Ignored'
+    | 'RuntimeError'
   >,
   config: MutationReport['config'] = structuredClone(defaultConfig)
 ): MutationReport {
@@ -42,20 +47,23 @@ const defaultConfig = {
   scope: {
     strategy: 'runtime-ownership-v1',
     command: 'node scripts/mutation.mjs',
-    sourceDirectives: [],
     node: {
       mutate: ['src/**/*.ts'],
-      testFiles: ['src/**/*.test.ts'],
+      testPatterns: ['src/**/*.test.ts'],
       excludedMutations: [],
       ignoreStatic: true,
-      ignorers: []
+      ignorers: [],
+      ignorePatterns: [],
+      executedTests: ['src/example.test.ts\0test']
     },
     browser: {
       mutate: ['src/browser.ts'],
-      testFiles: ['src/browser.test.ts'],
+      testPatterns: ['src/browser.test.ts'],
       excludedMutations: [],
       ignoreStatic: true,
-      ignorers: []
+      ignorers: [],
+      ignorePatterns: [],
+      executedTests: ['src/browser.test.ts\0test']
     }
   }
 }
@@ -98,16 +106,18 @@ describe('mutation gate', () => {
   it('classifies killed and timed-out mutants as detected', () => {
     expect(
       summarizeMutationReport(
-        report(['Killed', 'Timeout', 'Survived', 'NoCoverage'])
+        report(['Killed', 'Timeout', 'Survived', 'NoCoverage', 'Ignored'])
       )
     ).toStrictEqual({
+      debt: 3,
       detected: 2,
       errors: 0,
+      ignored: 1,
       killed: 1,
       noCoverage: 1,
       survived: 1,
       timeout: 1,
-      total: 4,
+      total: 5,
       undetected: 2
     })
   })

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -220,43 +220,17 @@ describe('mutation gate', () => {
     )
   })
 
-  it('refuses to compare reports from different mutation configurations', () => {
-    expect(() =>
+  it('compares aggregate debt across mutation configuration changes', () => {
+    expect(
       compareMutationReports(
         report(['Killed']),
-        report(['Killed'], { ...comparableConfig, mutate: ['src/cache.ts'] })
+        report(['Survived'], {
+          ...comparableConfig,
+          mutate: ['src/cache.ts'],
+          timeoutMS: 1
+        })
       )
-    ).toThrow('mutation configuration changed')
-  })
-
-  it('accepts equivalent configurations and ignores operational settings', () => {
-    const baseline = report(['Killed'], {
-      ...structuredClone(comparableConfig),
-      force: true,
-      reporters: ['json']
-    })
-    const candidate = report(['Killed'], {
-      vitest: { related: true },
-      timeoutMS: 5000,
-      testRunner: 'vitest',
-      mutate: ['src/**/*.ts'],
-      force: false,
-      reporters: ['progress']
-    })
-
-    expect(compareMutationReports(baseline, candidate)).toMatchObject({
-      pass: true,
-      delta: 0
-    })
-  })
-
-  it('treats timeout configuration as result-affecting', () => {
-    expect(() =>
-      compareMutationReports(
-        report(['Killed']),
-        report(['Killed'], { ...comparableConfig, timeoutMS: 1 })
-      )
-    ).toThrow('mutation configuration changed')
+    ).toMatchObject({ pass: false, delta: 1 })
   })
 
   it('compares mutation debt across toolchain changes', () => {

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -19,20 +19,17 @@ export type MutantStatus =
 
 type RuntimeMutationScope = {
   mutate: string[]
-  testFiles: string[]
+  testPatterns: string[]
   excludedMutations: string[]
   ignoreStatic: boolean
   ignorers: string[]
+  ignorePatterns: string[]
+  executedTests: string[]
 }
 
 type MutationScope = {
   strategy: string
   command: string
-  sourceDirectives: Array<{
-    file: string
-    line: number
-    directive: string
-  }>
   node: RuntimeMutationScope
   browser: RuntimeMutationScope
 }
@@ -65,22 +62,17 @@ export type MutationReport = {
 
 const runtimeMutationScopeSchema = z.object({
   mutate: z.array(z.string()),
-  testFiles: z.array(z.string()),
+  testPatterns: z.array(z.string()),
   excludedMutations: z.array(z.string()),
   ignoreStatic: z.boolean(),
-  ignorers: z.array(z.string())
+  ignorers: z.array(z.string()),
+  ignorePatterns: z.array(z.string()),
+  executedTests: z.array(z.string())
 })
 
 const mutationScopeSchema = z.object({
   strategy: z.string(),
   command: z.string(),
-  sourceDirectives: z.array(
-    z.object({
-      file: z.string(),
-      line: z.number(),
-      directive: z.string()
-    })
-  ),
   node: runtimeMutationScopeSchema,
   browser: runtimeMutationScopeSchema
 })
@@ -118,8 +110,10 @@ const mutationReportSchema: z.ZodType<MutationReport> = z.object({
 })
 
 type MutationSummary = {
+  debt: number
   detected: number
   errors: number
+  ignored: number
   killed: number
   noCoverage: number
   survived: number
@@ -145,8 +139,10 @@ export function summarizeMutationReport(
   report: MutationReport
 ): MutationSummary {
   const summary: MutationSummary = {
+    debt: 0,
     detected: 0,
     errors: 0,
+    ignored: 0,
     killed: 0,
     noCoverage: 0,
     survived: 0,
@@ -171,6 +167,8 @@ export function summarizeMutationReport(
         summary.undetected++
       } else if (ERROR_STATUSES.has(mutant.status)) {
         summary.errors++
+      } else if (mutant.status === 'Ignored') {
+        summary.ignored++
       } else {
         throw new Error(`unknown mutant status: ${mutant.status}`)
       }
@@ -191,6 +189,8 @@ export function summarizeMutationReport(
       }
     }
   }
+
+  summary.debt = summary.undetected + summary.ignored
 
   return summary
 }
@@ -216,6 +216,34 @@ function sourceAtLocation(
     .join('\n')
 }
 
+function scopeSettings(scope: MutationScope): unknown {
+  const withoutExecutedTests = (runtime: RuntimeMutationScope) => {
+    const { executedTests: _, ...settings } = runtime
+    return settings
+  }
+  return {
+    strategy: scope.strategy,
+    command: scope.command,
+    node: withoutExecutedTests(scope.node),
+    browser: withoutExecutedTests(scope.browser)
+  }
+}
+
+function difference(baseline: string[], candidate: string[]): string[] {
+  const remaining = new Map<string, number>()
+  for (const value of candidate) {
+    remaining.set(value, (remaining.get(value) ?? 0) + 1)
+  }
+  return baseline.filter(value => {
+    const count = remaining.get(value) ?? 0
+    if (count === 0) {
+      return true
+    }
+    remaining.set(value, count - 1)
+    return false
+  })
+}
+
 export function compareMutationReports(
   baselineReport: MutationReport,
   candidateReport: MutationReport
@@ -232,10 +260,21 @@ export function compareMutationReports(
     throw new Error('mutation report schema changed')
   }
   if (
-    JSON.stringify(baselineReport.config.scope) !==
-    JSON.stringify(candidateReport.config.scope)
+    JSON.stringify(scopeSettings(baselineReport.config.scope)) !==
+    JSON.stringify(scopeSettings(candidateReport.config.scope))
   ) {
     throw new Error('mutation scope changed')
+  }
+  for (const runtime of ['node', 'browser'] as const) {
+    const missingTests = difference(
+      baselineReport.config.scope[runtime].executedTests,
+      candidateReport.config.scope[runtime].executedTests
+    )
+    if (missingTests.length > 0) {
+      throw new Error(
+        `${runtime} mutation scope lost ${missingTests.length} executed test(s)`
+      )
+    }
   }
   if (baseline.total === 0) {
     throw new Error('baseline report contains no mutants')
@@ -254,7 +293,7 @@ export function compareMutationReports(
     )
   }
 
-  const delta = candidate.undetected - baseline.undetected
+  const delta = candidate.debt - baseline.debt
   const candidateUndetected = Object.entries(candidateReport.files)
     .flatMap(([file, { mutants, source }]) =>
       mutants
@@ -358,8 +397,8 @@ async function main(): Promise<void> {
   if (!result.pass) {
     process.stderr.write(
       `Mutation debt increased by ${result.delta}: ` +
-        `${result.baseline.undetected} → ${result.candidate.undetected} ` +
-        `survived or uncovered mutants.\n`
+        `${result.baseline.debt} → ${result.candidate.debt} ` +
+        `survived, uncovered, or ignored mutants.\n`
     )
     process.stderr.write(
       formatUndetectedMutants(
@@ -376,8 +415,8 @@ async function main(): Promise<void> {
         : `decreased by ${Math.abs(result.delta)}`
     process.stdout.write(
       `Mutation debt ${outcome}: ` +
-        `${result.baseline.undetected} → ${result.candidate.undetected} ` +
-        `survived or uncovered mutants.\n`
+        `${result.baseline.debt} → ${result.candidate.debt} ` +
+        `survived, uncovered, or ignored mutants.\n`
     )
   }
 }

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -19,10 +19,7 @@ export type MutantStatus =
 
 type RuntimeMutationScope = {
   mutate: string[]
-  testPatterns: string[]
   excludedMutations: string[]
-  ignoreStatic: boolean
-  ignorers: string[]
   ignorePatterns: string[]
   executedTests: string[]
 }
@@ -62,10 +59,7 @@ export type MutationReport = {
 
 const runtimeMutationScopeSchema = z.object({
   mutate: z.array(z.string()),
-  testPatterns: z.array(z.string()),
   excludedMutations: z.array(z.string()),
-  ignoreStatic: z.boolean(),
-  ignorers: z.array(z.string()),
   ignorePatterns: z.array(z.string()),
   executedTests: z.array(z.string())
 })
@@ -401,12 +395,17 @@ async function main(): Promise<void> {
         `survived, uncovered, or ignored mutants.\n`
     )
     process.stderr.write(
-      formatUndetectedMutants(
-        result.candidateUndetected,
-        process.env.MUTATION_SOURCE_URL,
-        process.env.MUTATION_SOURCE_ROOT
-      )
+      `Ignored mutants: ${result.baseline.ignored} → ${result.candidate.ignored}.\n`
     )
+    if (result.candidateUndetected.length > 0) {
+      process.stderr.write(
+        formatUndetectedMutants(
+          result.candidateUndetected,
+          process.env.MUTATION_SOURCE_URL,
+          process.env.MUTATION_SOURCE_ROOT
+        )
+      )
+    }
     process.exitCode = 1
   } else {
     const outcome =

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -7,23 +7,6 @@ import { z } from 'zod'
 const DETECTED_STATUSES = new Set(['Killed', 'Timeout'])
 const UNDETECTED_STATUSES = new Set(['Survived', 'NoCoverage'])
 const ERROR_STATUSES = new Set(['CompileError', 'RuntimeError'])
-const NON_RESULT_CONFIG_KEYS = new Set([
-  '$schema',
-  'allowConsoleColors',
-  'clearTextReporter',
-  'dashboard',
-  'eventReporter',
-  'fileLogLevel',
-  'force',
-  'htmlReporter',
-  'incremental',
-  'incrementalFile',
-  'jsonReporter',
-  'logLevel',
-  'reporters',
-  'tempDirName',
-  'warnings'
-])
 
 export type MutantStatus =
   | 'Killed'
@@ -173,29 +156,6 @@ export function summarizeMutationReport(
   return summary
 }
 
-function comparableConfig(config: Record<string, unknown>): string {
-  return stableStringify(
-    Object.fromEntries(
-      Object.entries(config).filter(([key]) => !NON_RESULT_CONFIG_KEYS.has(key))
-    )
-  )
-}
-
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`
-  }
-  if (value && typeof value === 'object') {
-    const entries = Object.entries(value as Record<string, unknown>).sort(
-      ([left], [right]) => left.localeCompare(right)
-    )
-    return `{${entries
-      .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`)
-      .join(',')}}`
-  }
-  return JSON.stringify(value)
-}
-
 function sourceAtLocation(
   source: string,
   location?: NewUndetectedMutant['location']
@@ -227,14 +187,6 @@ export function compareMutationReports(
   newUndetected: NewUndetectedMutant[]
   pass: boolean
 } {
-  if (
-    comparableConfig(baselineReport.config) !==
-    comparableConfig(candidateReport.config)
-  ) {
-    throw new Error(
-      'mutation configuration changed; establish and review a new baseline explicitly'
-    )
-  }
   const baseline = summarizeMutationReport(baselineReport)
   const candidate = summarizeMutationReport(candidateReport)
   if (baseline.total > 0 && candidate.total === 0) {

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -18,7 +18,7 @@ export type MutantStatus =
   | string
 
 type RuntimeMutationScope = {
-  mutate: string[]
+  mutationFiles: string[]
   excludedMutations: string[]
   ignorePatterns: string[]
   executedTests: string[]
@@ -27,6 +27,7 @@ type RuntimeMutationScope = {
 type MutationScope = {
   strategy: string
   command: string
+  sourceFiles: string[]
   node: RuntimeMutationScope
   browser: RuntimeMutationScope
 }
@@ -58,7 +59,7 @@ export type MutationReport = {
 }
 
 const runtimeMutationScopeSchema = z.object({
-  mutate: z.array(z.string()),
+  mutationFiles: z.array(z.string()),
   excludedMutations: z.array(z.string()),
   ignorePatterns: z.array(z.string()),
   executedTests: z.array(z.string())
@@ -67,6 +68,7 @@ const runtimeMutationScopeSchema = z.object({
 const mutationScopeSchema = z.object({
   strategy: z.string(),
   command: z.string(),
+  sourceFiles: z.array(z.string()),
   node: runtimeMutationScopeSchema,
   browser: runtimeMutationScopeSchema
 })
@@ -212,7 +214,7 @@ function sourceAtLocation(
 
 function scopeSettings(scope: MutationScope): unknown {
   const withoutExecutedTests = (runtime: RuntimeMutationScope) => {
-    const { executedTests: _, ...settings } = runtime
+    const { executedTests: _, mutationFiles: __, ...settings } = runtime
     return settings
   }
   return {
@@ -260,6 +262,15 @@ export function compareMutationReports(
     throw new Error('mutation scope changed')
   }
   for (const runtime of ['node', 'browser'] as const) {
+    const missingMutationFiles = difference(
+      baselineReport.config.scope[runtime].mutationFiles,
+      candidateReport.config.scope[runtime].mutationFiles
+    ).filter(file => candidateReport.config.scope.sourceFiles.includes(file))
+    if (missingMutationFiles.length > 0) {
+      throw new Error(
+        `${runtime} mutation scope lost ${missingMutationFiles.length} existing source file(s)`
+      )
+    }
     const missingTests = difference(
       baselineReport.config.scope[runtime].executedTests,
       candidateReport.config.scope[runtime].executedTests

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -17,6 +17,26 @@ export type MutantStatus =
   | 'RuntimeError'
   | string
 
+type RuntimeMutationScope = {
+  mutate: string[]
+  testFiles: string[]
+  excludedMutations: string[]
+  ignoreStatic: boolean
+  ignorers: string[]
+}
+
+type MutationScope = {
+  strategy: string
+  command: string
+  sourceDirectives: Array<{
+    file: string
+    line: number
+    directive: string
+  }>
+  node: RuntimeMutationScope
+  browser: RuntimeMutationScope
+}
+
 export type MutationReport = {
   files: Record<
     string,
@@ -34,7 +54,7 @@ export type MutationReport = {
       }>
     }
   >
-  config: Record<string, unknown>
+  config: Record<string, unknown> & { scope: MutationScope }
   framework: {
     name: string
     version: string
@@ -42,6 +62,28 @@ export type MutationReport = {
   }
   schemaVersion: string
 }
+
+const runtimeMutationScopeSchema = z.object({
+  mutate: z.array(z.string()),
+  testFiles: z.array(z.string()),
+  excludedMutations: z.array(z.string()),
+  ignoreStatic: z.boolean(),
+  ignorers: z.array(z.string())
+})
+
+const mutationScopeSchema = z.object({
+  strategy: z.string(),
+  command: z.string(),
+  sourceDirectives: z.array(
+    z.object({
+      file: z.string(),
+      line: z.number(),
+      directive: z.string()
+    })
+  ),
+  node: runtimeMutationScopeSchema,
+  browser: runtimeMutationScopeSchema
+})
 
 const mutationReportSchema: z.ZodType<MutationReport> = z.object({
   files: z.record(
@@ -64,7 +106,9 @@ const mutationReportSchema: z.ZodType<MutationReport> = z.object({
       )
     })
   ),
-  config: z.record(z.string(), z.unknown()),
+  config: z
+    .record(z.string(), z.unknown())
+    .and(z.object({ scope: mutationScopeSchema })),
   framework: z.object({
     name: z.string(),
     version: z.string(),
@@ -186,6 +230,12 @@ export function compareMutationReports(
   const candidate = summarizeMutationReport(candidateReport)
   if (baselineReport.schemaVersion !== candidateReport.schemaVersion) {
     throw new Error('mutation report schema changed')
+  }
+  if (
+    JSON.stringify(baselineReport.config.scope) !==
+    JSON.stringify(candidateReport.config.scope)
+  ) {
+    throw new Error('mutation scope changed')
   }
   if (baseline.total === 0) {
     throw new Error('baseline report contains no mutants')

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -40,6 +40,7 @@ export type MutationReport = {
     version: string
     dependencies?: Record<string, string>
   }
+  schemaVersion: string
 }
 
 const mutationReportSchema: z.ZodType<MutationReport> = z.object({
@@ -68,7 +69,8 @@ const mutationReportSchema: z.ZodType<MutationReport> = z.object({
     name: z.string(),
     version: z.string(),
     dependencies: z.record(z.string(), z.string()).optional()
-  })
+  }),
+  schemaVersion: z.string()
 })
 
 type MutationSummary = {
@@ -82,7 +84,7 @@ type MutationSummary = {
   undetected: number
 }
 
-export type NewUndetectedMutant = {
+export type UndetectedMutant = {
   file: string
   id: string
   location?: {
@@ -91,15 +93,8 @@ export type NewUndetectedMutant = {
   }
   mutatorName?: string
   original?: string
-  previousStatus?: MutantStatus
   replacement?: string
   status: MutantStatus
-}
-
-type Mutant = MutationReport['files'][string]['mutants'][number]
-
-function mutantId(file: string, mutant: Mutant): string {
-  return `${file}\0${mutant.id}`
 }
 
 export function summarizeMutationReport(
@@ -158,7 +153,7 @@ export function summarizeMutationReport(
 
 function sourceAtLocation(
   source: string,
-  location?: NewUndetectedMutant['location']
+  location?: UndetectedMutant['location']
 ): string | undefined {
   if (!location) {
     return undefined
@@ -184,12 +179,18 @@ export function compareMutationReports(
   baseline: MutationSummary
   candidate: MutationSummary
   delta: number
-  newUndetected: NewUndetectedMutant[]
+  candidateUndetected: UndetectedMutant[]
   pass: boolean
 } {
   const baseline = summarizeMutationReport(baselineReport)
   const candidate = summarizeMutationReport(candidateReport)
-  if (baseline.total > 0 && candidate.total === 0) {
+  if (baselineReport.schemaVersion !== candidateReport.schemaVersion) {
+    throw new Error('mutation report schema changed')
+  }
+  if (baseline.total === 0) {
+    throw new Error('baseline report contains no mutants')
+  }
+  if (candidate.total === 0) {
     throw new Error('candidate report contains no mutants')
   }
   if (baseline.errors > 0) {
@@ -204,35 +205,19 @@ export function compareMutationReports(
   }
 
   const delta = candidate.undetected - baseline.undetected
-  const baselineStatuses = new Map<string, MutantStatus>()
-  for (const [file, { mutants }] of Object.entries(baselineReport.files)) {
-    for (const mutant of mutants) {
-      baselineStatuses.set(mutantId(file, mutant), mutant.status)
-    }
-  }
-  const newUndetected = Object.entries(candidateReport.files)
+  const candidateUndetected = Object.entries(candidateReport.files)
     .flatMap(([file, { mutants, source }]) =>
-      mutants.flatMap(mutant => {
-        const previousStatus = baselineStatuses.get(mutantId(file, mutant))
-        if (
-          !UNDETECTED_STATUSES.has(mutant.status) ||
-          (previousStatus && UNDETECTED_STATUSES.has(previousStatus))
-        ) {
-          return []
-        }
-        return [
-          {
-            file,
-            id: mutant.id,
-            location: mutant.location,
-            mutatorName: mutant.mutatorName,
-            original: sourceAtLocation(source, mutant.location),
-            previousStatus,
-            replacement: mutant.replacement,
-            status: mutant.status
-          }
-        ]
-      })
+      mutants
+        .filter(mutant => UNDETECTED_STATUSES.has(mutant.status))
+        .map(mutant => ({
+          file,
+          id: mutant.id,
+          location: mutant.location,
+          mutatorName: mutant.mutatorName,
+          original: sourceAtLocation(source, mutant.location),
+          replacement: mutant.replacement,
+          status: mutant.status
+        }))
     )
     .sort(
       (left, right) =>
@@ -245,14 +230,14 @@ export function compareMutationReports(
   return {
     baseline,
     candidate,
+    candidateUndetected,
     delta,
-    newUndetected,
     pass: delta <= 0
   }
 }
 
-export function formatNewUndetectedMutants(
-  mutants: NewUndetectedMutant[],
+export function formatUndetectedMutants(
+  mutants: UndetectedMutant[],
   sourceBaseUrl?: string,
   sourceRoot?: string
 ): string {
@@ -263,12 +248,7 @@ export function formatNewUndetectedMutants(
     const mutator = mutant.mutatorName ?? 'Unknown mutation'
     const original = oneLine(mutant.original) || '(source unavailable)'
     const replacement = oneLine(mutant.replacement) || '(empty)'
-    const transition = mutant.previousStatus
-      ? `${mutant.status} (was ${mutant.previousStatus})`
-      : `${mutant.status} (new mutant)`
-    const explanation = mutant.previousStatus
-      ? `Newly ${mutant.status.toLowerCase()}; previously ${mutant.previousStatus.toLowerCase()}`
-      : `New undetected mutant (${mutant.status.toLowerCase()})`
+    const explanation = `Undetected mutant (${mutant.status.toLowerCase()})`
     const repositoryPath = [sourceRoot, mutant.file].filter(Boolean).join('/')
     const source =
       sourceBaseUrl && line
@@ -278,14 +258,14 @@ export function formatNewUndetectedMutants(
             .join('/')}#L${line}`
         : undefined
     const annotation = line
-      ? `::error file=${escapeCommandProperty(repositoryPath)},line=${line},col=${column},title=New undetected mutant::${escapeCommandData(`${mutator} ${transition}\nOriginal: ${original}\nMutated: ${replacement}`)}`
+      ? `::error file=${escapeCommandProperty(repositoryPath)},line=${line},col=${column},title=Undetected mutant::${escapeCommandData(`${mutator} ${mutant.status}\nOriginal: ${original}\nMutated: ${replacement}`)}`
       : undefined
     return [
       annotation,
       `- ${location} [${mutator}] ${explanation}${source ? `\n  Source: ${source}` : ''}\n  Original: ${original}\n  Mutated: ${replacement}`
     ].filter((value): value is string => value !== undefined)
   })
-  return `New undetected mutants:\n${lines.join('\n')}\n`
+  return `Candidate undetected mutants:\n${lines.join('\n')}\n`
 }
 
 function oneLine(value?: string): string {
@@ -332,8 +312,8 @@ async function main(): Promise<void> {
         `survived or uncovered mutants.\n`
     )
     process.stderr.write(
-      formatNewUndetectedMutants(
-        result.newUndetected,
+      formatUndetectedMutants(
+        result.candidateUndetected,
         process.env.MUTATION_SOURCE_URL,
         process.env.MUTATION_SOURCE_ROOT
       )


### PR DESCRIPTION
## Summary

- run a complete candidate mutation suite when execution inputs change
- compare the complete candidate report against the existing baseline
- remove the hard failure that required explicit baseline approval
- let the gate compare aggregate mutation debt across config changes

## Test plan

- `pnpm run test --filter scripts --force`
- pre-push type generation and lint hooks
