### PR TITLE
chore: compare mutation test files

### DIFF
--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -146,7 +146,7 @@
     "build:size-json": "size-limit --json > size.json",
     "test": "pnpm run --stream '/^test:/'",
     "test:unit": "vitest run --project unit",
-    "mutation:config-test": "node --test scripts/mutation-projects.node-test.mjs scripts/mutation-report.node-test.mjs",
+    "mutation:config-test": "node --test scripts/mutation-projects.node-test.mjs scripts/mutation-report.node-test.mjs scripts/mutation-scope.node-test.mjs",
     "mutation": "node scripts/mutation.mjs",
     "test:browser": "vitest run --project browser --browser.headless",
     "test:types": "vitest run --project types",

--- a/packages/nuqs/scripts/mutation-scope.mjs
+++ b/packages/nuqs/scripts/mutation-scope.mjs
@@ -3,11 +3,15 @@ import { dirname, extname, relative, resolve } from 'node:path'
 
 const sourceExtensions = new Set([
   '.cjs',
+  '.cjsx',
   '.cts',
+  '.ctsx',
   '.js',
   '.jsx',
   '.mjs',
+  '.mjsx',
   '.mts',
+  '.mtsx',
   '.ts',
   '.tsx'
 ])

--- a/packages/nuqs/scripts/mutation-scope.mjs
+++ b/packages/nuqs/scripts/mutation-scope.mjs
@@ -1,6 +1,17 @@
 import { readFile, readdir, writeFile } from 'node:fs/promises'
 import { dirname, extname, relative, resolve } from 'node:path'
 
+const sourceExtensions = new Set([
+  '.cjs',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx'
+])
+
 const [root, reportPath] = process.argv.slice(2)
 if (!root || !reportPath) {
   throw new Error('usage: mutation-scope.mjs <nuqs-root> <report>')
@@ -78,7 +89,7 @@ async function listSourceFiles(directory) {
     const path = resolve(directory, entry.name)
     if (entry.isDirectory()) {
       files.push(...(await listSourceFiles(path)))
-    } else if (['.ts', '.tsx'].includes(extname(entry.name))) {
+    } else if (sourceExtensions.has(extname(entry.name))) {
       files.push(relative(root, path))
     }
   }

--- a/packages/nuqs/scripts/mutation-scope.node-test.mjs
+++ b/packages/nuqs/scripts/mutation-scope.node-test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { execFile } from 'node:child_process'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execute = promisify(execFile)
+const temporaryDirectories = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(path => rm(path, { recursive: true }))
+  )
+})
+
+it('records JavaScript and TypeScript source files', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'nuqs-mutation-scope-'))
+  temporaryDirectories.push(root)
+  const sourceDirectory = join(root, 'src')
+  const reportDirectory = join(root, 'reports', 'mutation')
+  const cacheDirectory = join(reportDirectory, 'cache')
+  await mkdir(sourceDirectory, { recursive: true })
+  await mkdir(cacheDirectory, { recursive: true })
+
+  const extensions = ['cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'ts', 'tsx']
+  await Promise.all(
+    extensions.map(extension =>
+      writeFile(join(sourceDirectory, `example.${extension}`), '')
+    )
+  )
+  await writeFile(join(sourceDirectory, 'ignored.json'), '')
+  await writeFile(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { mutation: 'node scripts/mutation.mjs' } })
+  )
+
+  const reportPath = join(reportDirectory, 'stryker-incremental.json')
+  await writeFile(
+    reportPath,
+    JSON.stringify({ config: { strategy: 'runtime-ownership-v1' }, files: {} })
+  )
+  const runtimeReport = {
+    files: {},
+    testFiles: {},
+    config: { mutator: { excludedMutations: [] }, ignorePatterns: [] }
+  }
+  await Promise.all(
+    ['node', 'browser'].map(runtime =>
+      writeFile(
+        join(cacheDirectory, `${runtime}.json`),
+        JSON.stringify(runtimeReport)
+      )
+    )
+  )
+
+  await execute(process.execPath, [
+    fileURLToPath(new URL('./mutation-scope.mjs', import.meta.url)),
+    root,
+    reportPath
+  ])
+
+  const report = JSON.parse(await readFile(reportPath, 'utf8'))
+  assert.deepEqual(
+    report.config.scope.sourceFiles,
+    extensions.map(extension => `src/example.${extension}`).sort()
+  )
+})

--- a/packages/nuqs/scripts/mutation-scope.node-test.mjs
+++ b/packages/nuqs/scripts/mutation-scope.node-test.mjs
@@ -25,7 +25,20 @@ it('records JavaScript and TypeScript source files', async () => {
   await mkdir(sourceDirectory, { recursive: true })
   await mkdir(cacheDirectory, { recursive: true })
 
-  const extensions = ['cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'ts', 'tsx']
+  const extensions = [
+    'cjs',
+    'cjsx',
+    'cts',
+    'ctsx',
+    'js',
+    'jsx',
+    'mjs',
+    'mjsx',
+    'mts',
+    'mtsx',
+    'ts',
+    'tsx'
+  ]
   await Promise.all(
     extensions.map(extension =>
       writeFile(join(sourceDirectory, `example.${extension}`), '')

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -47,7 +47,12 @@ const defaultConfig = {
   scope: {
     strategy: 'runtime-ownership-v1',
     command: 'node scripts/mutation.mjs',
-    sourceFiles: ['src/browser.ts', 'src/example.ts'],
+    sourceFiles: [
+      'src/browser.test.ts',
+      'src/browser.ts',
+      'src/example.test.ts',
+      'src/example.ts'
+    ],
     node: {
       mutationFiles: ['src/example.ts'],
       excludedMutations: [],
@@ -216,6 +221,47 @@ describe('mutation gate', () => {
         report(['Survived'], candidateConfig)
       )
     ).toThrow('mutation scope changed')
+  })
+
+  it('allows tests to be renamed within an executed test file', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.node.executedTests = [
+      'src/example.test.ts\0renamed test'
+    ]
+
+    expect(
+      compareMutationReports(
+        report(['Killed']),
+        report(['Killed'], candidateConfig)
+      )
+    ).toMatchObject({ pass: true, delta: 0 })
+  })
+
+  it('allows executed tests to disappear with a deleted test file', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.sourceFiles = candidateConfig.scope.sourceFiles.filter(
+      file => file !== 'src/example.test.ts'
+    )
+    candidateConfig.scope.node.executedTests = []
+
+    expect(
+      compareMutationReports(
+        report(['Killed']),
+        report(['Killed'], candidateConfig)
+      )
+    ).toMatchObject({ pass: true, delta: 0 })
+  })
+
+  it('rejects losing an executed test file that still exists', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.node.executedTests = []
+
+    expect(() =>
+      compareMutationReports(
+        report(['Killed']),
+        report(['Killed'], candidateConfig)
+      )
+    ).toThrow('node mutation scope lost 1 executed test file')
   })
 
   it('compares mutation debt across toolchain changes', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -109,7 +109,7 @@ describe('mutation gate', () => {
         report(['Killed', 'Timeout', 'Survived', 'NoCoverage', 'Ignored'])
       )
     ).toStrictEqual({
-      debt: 4,
+      debt: 3,
       detected: 2,
       errors: 0,
       ignored: 1,
@@ -122,13 +122,19 @@ describe('mutation gate', () => {
     })
   })
 
-  it('does not let timeout variance change mutation debt', () => {
+  it('tolerates a baseline timeout surviving for the same mutant', () => {
     expect(
       compareMutationReports(report(['Timeout']), report(['Survived']))
     ).toMatchObject({ pass: true, delta: 0 })
     expect(
       compareMutationReports(report(['Survived']), report(['Timeout']))
-    ).toMatchObject({ pass: true, delta: 0 })
+    ).toMatchObject({ pass: true, delta: -1 })
+
+    const differentMutant = report(['Survived'])
+    differentMutant.files['src/example.ts']!.mutants[0]!.id = 'other'
+    expect(
+      compareMutationReports(report(['Timeout']), differentMutant)
+    ).toMatchObject({ pass: false, delta: 1 })
   })
 
   it('passes when mutation debt is stable or decreases', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -39,6 +39,21 @@ function report(
   }
 }
 
+function identifyMutants(report: MutationReport): MutationReport {
+  report.files['src/example.ts']!.source = 'true'
+  for (const mutant of report.files['src/example.ts']!.mutants) {
+    Object.assign(mutant, {
+      location: {
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 5 }
+      },
+      mutatorName: 'BooleanLiteral',
+      replacement: 'false'
+    })
+  }
+  return report
+}
+
 const defaultConfig = {
   mutate: ['src/**/*.ts'],
   testRunner: 'vitest',
@@ -124,26 +139,78 @@ describe('mutation gate', () => {
 
   it('tolerates a baseline timeout surviving for the same mutant', () => {
     expect(
-      compareMutationReports(report(['Timeout']), report(['Survived']))
+      compareMutationReports(
+        identifyMutants(report(['Timeout'])),
+        identifyMutants(report(['Survived']))
+      )
     ).toMatchObject({ pass: true, delta: 0 })
     expect(
       compareMutationReports(report(['Survived']), report(['Timeout']))
     ).toMatchObject({ pass: true, delta: -1 })
 
-    const renumberedMutant = report(['Survived'])
+    const renumberedMutant = identifyMutants(report(['Survived']))
     renumberedMutant.files['src/example.ts']!.mutants[0]!.id = 'other'
     expect(
-      compareMutationReports(report(['Timeout']), renumberedMutant)
+      compareMutationReports(
+        identifyMutants(report(['Timeout'])),
+        renumberedMutant
+      )
     ).toMatchObject({ pass: true, delta: 0 })
 
-    const differentMutant = report(['Survived'])
+    const differentMutant = identifyMutants(report(['Survived']))
     differentMutant.files['src/example.ts']!.mutants[0]!.location = {
       start: { line: 2, column: 1 },
       end: { line: 2, column: 5 }
     }
     expect(
-      compareMutationReports(report(['Timeout']), differentMutant)
+      compareMutationReports(
+        identifyMutants(report(['Timeout'])),
+        differentMutant
+      )
     ).toMatchObject({ pass: false, delta: 1 })
+  })
+
+  it('does not reuse timeout credit already covered by baseline debt', () => {
+    const baseline = identifyMutants(report(['Timeout', 'Survived']))
+    expect(
+      compareMutationReports(
+        baseline,
+        identifyMutants(report(['Timeout', 'Survived', 'Survived']))
+      )
+    ).toMatchObject({ pass: false, delta: 1 })
+    expect(
+      compareMutationReports(
+        baseline,
+        identifyMutants(report(['Survived', 'Survived', 'Survived']))
+      )
+    ).toMatchObject({ pass: false, delta: 1 })
+    expect(
+      compareMutationReports(
+        baseline,
+        identifyMutants(report(['Survived', 'Survived']))
+      )
+    ).toMatchObject({ pass: true, delta: 0 })
+  })
+
+  it('does not match timeouts without a complete mutant fingerprint', () => {
+    for (const side of ['baseline', 'candidate'] as const) {
+      for (const field of [
+        'location',
+        'mutatorName',
+        'replacement'
+      ] as const) {
+        const baseline = identifyMutants(report(['Timeout']))
+        const candidate = identifyMutants(report(['Survived']))
+        delete (side === 'baseline'
+          ? baseline.files['src/example.ts']!.mutants[0]!
+          : candidate.files['src/example.ts']!.mutants[0]!)[field]
+
+        expect(
+          compareMutationReports(baseline, candidate),
+          `${side} ${field}`
+        ).toMatchObject({ pass: false, delta: 1 })
+      }
+    }
   })
 
   it('passes when mutation debt is stable or decreases', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -123,9 +123,25 @@ describe('mutation gate', () => {
   })
 
   it('fails when a timed-out mutant starts surviving', () => {
-    expect(
-      compareMutationReports(report(['Timeout']), report(['Survived']))
-    ).toMatchObject({ pass: false, delta: 1 })
+    const baseline = report(['Timeout'])
+    const candidate = report(['Survived'])
+    const identity = {
+      mutatorName: 'ConditionalExpression',
+      replacement: 'false',
+      location: {
+        end: { line: 1, column: 4 },
+        start: { line: 1, column: 0 }
+      }
+    }
+    baseline.files['src/example.ts']!.source = 'true'
+    candidate.files['src/example.ts']!.source = 'true'
+    Object.assign(baseline.files['src/example.ts']!.mutants[0]!, identity)
+    Object.assign(candidate.files['src/example.ts']!.mutants[0]!, identity)
+
+    expect(compareMutationReports(baseline, candidate)).toMatchObject({
+      pass: false,
+      delta: 1
+    })
   })
 
   it('passes when mutation debt is stable or decreases', () => {
@@ -270,6 +286,18 @@ describe('mutation gate', () => {
         report(['Killed'], candidateConfig)
       )
     ).toThrow('node mutation scope lost 1 executed test')
+  })
+
+  it('checks executed test loss for the browser runtime', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.browser.executedTests = []
+
+    expect(() =>
+      compareMutationReports(
+        report(['Killed']),
+        report(['Killed'], candidateConfig)
+      )
+    ).toThrow('browser mutation scope lost 1 executed test')
   })
 
   it('rejects losing one of several tests in an existing file', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -145,6 +145,12 @@ describe('mutation gate', () => {
       )
     ).toMatchObject({ pass: true, delta: 0 })
     expect(
+      compareMutationReports(
+        identifyMutants(report(['Timeout'])),
+        identifyMutants(report(['NoCoverage']))
+      )
+    ).toMatchObject({ pass: false, delta: 1 })
+    expect(
       compareMutationReports(report(['Survived']), report(['Timeout']))
     ).toMatchObject({ pass: true, delta: -1 })
 

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -251,14 +251,20 @@ describe('mutation gate', () => {
     })
   })
 
-  it('does not fingerprint out-of-range source locations', () => {
+  it.each([
+    {
+      start: { line: 2, column: 1 },
+      end: { line: 2, column: 5 }
+    },
+    {
+      start: { line: 1, column: 1.5 },
+      end: { line: 1, column: 5 }
+    }
+  ])('does not fingerprint invalid source location %#', location => {
     const baseline = identifyMutants(report(['Timeout']))
     const candidate = identifyMutants(report(['Survived']))
     for (const current of [baseline, candidate]) {
-      current.files['src/example.ts']!.mutants[0]!.location = {
-        start: { line: 2, column: 1 },
-        end: { line: 2, column: 5 }
-      }
+      current.files['src/example.ts']!.mutants[0]!.location = location
     }
 
     expect(compareMutationReports(baseline, candidate)).toMatchObject({

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -39,21 +39,6 @@ function report(
   }
 }
 
-function identifyMutants(report: MutationReport): MutationReport {
-  report.files['src/example.ts']!.source = 'true'
-  for (const mutant of report.files['src/example.ts']!.mutants) {
-    Object.assign(mutant, {
-      location: {
-        start: { line: 1, column: 1 },
-        end: { line: 1, column: 5 }
-      },
-      mutatorName: 'BooleanLiteral',
-      replacement: 'false'
-    })
-  }
-  return report
-}
-
 const defaultConfig = {
   mutate: ['src/**/*.ts'],
   testRunner: 'vitest',
@@ -137,146 +122,10 @@ describe('mutation gate', () => {
     })
   })
 
-  it('tolerates a baseline timeout surviving for the same mutant', () => {
+  it('fails when a timed-out mutant starts surviving', () => {
     expect(
-      compareMutationReports(
-        identifyMutants(report(['Timeout'])),
-        identifyMutants(report(['Survived']))
-      )
-    ).toMatchObject({ pass: true, delta: 0 })
-    expect(
-      compareMutationReports(
-        identifyMutants(report(['Timeout'])),
-        identifyMutants(report(['NoCoverage']))
-      )
+      compareMutationReports(report(['Timeout']), report(['Survived']))
     ).toMatchObject({ pass: false, delta: 1 })
-    expect(
-      compareMutationReports(report(['Survived']), report(['Timeout']))
-    ).toMatchObject({ pass: true, delta: -1 })
-
-    const renumberedMutant = identifyMutants(report(['Survived']))
-    renumberedMutant.files['src/example.ts']!.mutants[0]!.id = 'other'
-    expect(
-      compareMutationReports(
-        identifyMutants(report(['Timeout'])),
-        renumberedMutant
-      )
-    ).toMatchObject({ pass: true, delta: 0 })
-
-    const differentMutant = identifyMutants(report(['Survived']))
-    differentMutant.files['src/example.ts']!.mutants[0]!.location = {
-      start: { line: 2, column: 1 },
-      end: { line: 2, column: 5 }
-    }
-    expect(
-      compareMutationReports(
-        identifyMutants(report(['Timeout'])),
-        differentMutant
-      )
-    ).toMatchObject({ pass: false, delta: 1 })
-  })
-
-  it('does not reuse timeout credit across duplicate fingerprints', () => {
-    const cases = [
-      {
-        baseline: ['Timeout', 'Survived'],
-        candidate: ['Timeout', 'Survived', 'Survived'],
-        delta: 1
-      },
-      {
-        baseline: ['Timeout', 'Survived'],
-        candidate: ['Survived', 'Survived', 'Survived'],
-        delta: 2
-      },
-      {
-        baseline: ['Timeout', 'Ignored'],
-        candidate: ['Ignored', 'Survived'],
-        delta: 1
-      },
-      {
-        baseline: ['Timeout', 'Killed'],
-        candidate: ['Killed', 'Survived'],
-        delta: 1
-      }
-    ] as const
-    for (const { baseline, candidate, delta } of cases) {
-      expect(
-        compareMutationReports(
-          identifyMutants(report([...baseline])),
-          identifyMutants(report([...candidate]))
-        ),
-        `${baseline.join(',')} -> ${candidate.join(',')}`
-      ).toMatchObject({ pass: false, delta })
-    }
-
-    expect(
-      compareMutationReports(
-        identifyMutants(report(['Timeout', 'Survived'])),
-        identifyMutants(report(['Survived', 'Survived']))
-      )
-    ).toMatchObject({ pass: false, delta: 1 })
-
-    const renumberedDuplicate = identifyMutants(
-      report(['Killed', 'Survived'])
-    )
-    renumberedDuplicate.files['src/example.ts']!.mutants[1]!.id = 'renumbered'
-    expect(
-      compareMutationReports(
-        identifyMutants(report(['Killed', 'Timeout'])),
-        renumberedDuplicate
-      )
-    ).toMatchObject({ pass: false, delta: 1 })
-  })
-
-  it('does not match timeouts without a complete mutant fingerprint', () => {
-    for (const side of ['baseline', 'candidate'] as const) {
-      for (const field of [
-        'location',
-        'mutatorName',
-        'replacement'
-      ] as const) {
-        const baseline = identifyMutants(report(['Timeout']))
-        const candidate = identifyMutants(report(['Survived']))
-        delete (side === 'baseline'
-          ? baseline.files['src/example.ts']!.mutants[0]!
-          : candidate.files['src/example.ts']!.mutants[0]!)[field]
-
-        expect(
-          compareMutationReports(baseline, candidate),
-          `${side} ${field}`
-        ).toMatchObject({ pass: false, delta: 1 })
-      }
-    }
-
-    const baseline = identifyMutants(report(['Timeout']))
-    const candidate = identifyMutants(report(['Timeout', 'Survived']))
-    delete candidate.files['src/example.ts']!.mutants[0]!.location
-    expect(compareMutationReports(baseline, candidate)).toMatchObject({
-      pass: false,
-      delta: 1
-    })
-  })
-
-  it.each([
-    {
-      start: { line: 2, column: 1 },
-      end: { line: 2, column: 5 }
-    },
-    {
-      start: { line: 1, column: 1.5 },
-      end: { line: 1, column: 5 }
-    }
-  ])('does not fingerprint invalid source location %#', location => {
-    const baseline = identifyMutants(report(['Timeout']))
-    const candidate = identifyMutants(report(['Survived']))
-    for (const current of [baseline, candidate]) {
-      current.files['src/example.ts']!.mutants[0]!.location = location
-    }
-
-    expect(compareMutationReports(baseline, candidate)).toMatchObject({
-      pass: false,
-      delta: 1
-    })
   })
 
   it('passes when mutation debt is stable or decreases', () => {
@@ -380,10 +229,11 @@ describe('mutation gate', () => {
     ).toThrow('mutation scope changed')
   })
 
-  it('allows tests to be renamed within an executed test file', () => {
+  it('allows tests to be renamed or added within an executed test file', () => {
     const candidateConfig = structuredClone(defaultConfig)
     candidateConfig.scope.node.executedTests = [
-      'src/example.test.ts\0renamed test'
+      'src/example.test.ts\0renamed test',
+      'src/example.test.ts\0additional test'
     ]
 
     expect(
@@ -396,9 +246,10 @@ describe('mutation gate', () => {
 
   it('allows executed tests to disappear with a deleted test file', () => {
     const candidateConfig = structuredClone(defaultConfig)
-    candidateConfig.scope.sourceFiles = candidateConfig.scope.sourceFiles.filter(
-      file => file !== 'src/example.test.ts'
-    )
+    candidateConfig.scope.sourceFiles =
+      candidateConfig.scope.sourceFiles.filter(
+        file => file !== 'src/example.test.ts'
+      )
     candidateConfig.scope.node.executedTests = []
 
     expect(
@@ -449,20 +300,31 @@ describe('mutation gate', () => {
     ).toThrow('node mutation scope lost 1 executed test')
   })
 
-  it.each([
-    'src/example.test.ts',
-    '\0test',
-    'src/example.test.ts\0'
-  ])('rejects malformed executed test identifier %j', executedTest => {
-    const candidateConfig = structuredClone(defaultConfig)
-    candidateConfig.scope.node.executedTests = [executedTest]
+  it.each(['src/example.test.ts', '\0test'])(
+    'rejects malformed executed test identifier %j',
+    executedTest => {
+      const candidateConfig = structuredClone(defaultConfig)
+      candidateConfig.scope.node.executedTests = [executedTest]
 
-    expect(() =>
+      expect(() =>
+        compareMutationReports(
+          report(['Killed']),
+          report(['Killed'], candidateConfig)
+        )
+      ).toThrow('invalid executed test identifier')
+    }
+  )
+
+  it('allows an empty test name', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.node.executedTests = ['src/example.test.ts\0']
+
+    expect(
       compareMutationReports(
         report(['Killed']),
         report(['Killed'], candidateConfig)
       )
-    ).toThrow('invalid executed test identifier')
+    ).toMatchObject({ pass: true, delta: 0 })
   })
 
   it('compares mutation debt across toolchain changes', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -278,9 +278,27 @@ describe('mutation gate', () => {
     ).toThrow('node mutation scope lost 1 executed test')
   })
 
-  it('rejects malformed executed test identifiers', () => {
+  it('rejects moving a test to another file without reducing the total', () => {
     const candidateConfig = structuredClone(defaultConfig)
-    candidateConfig.scope.node.executedTests = ['src/example.test.ts']
+    candidateConfig.scope.node.executedTests = [
+      'src/browser.test.ts\0moved test'
+    ]
+
+    expect(() =>
+      compareMutationReports(
+        report(['Killed']),
+        report(['Killed'], candidateConfig)
+      )
+    ).toThrow('node mutation scope lost 1 executed test')
+  })
+
+  it.each([
+    'src/example.test.ts',
+    '\0test',
+    'src/example.test.ts\0'
+  ])('rejects malformed executed test identifier %j', executedTest => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.node.executedTests = [executedTest]
 
     expect(() =>
       compareMutationReports(

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -174,29 +174,33 @@ describe('mutation gate', () => {
     const cases = [
       {
         baseline: ['Timeout', 'Survived'],
-        candidate: ['Timeout', 'Survived', 'Survived']
+        candidate: ['Timeout', 'Survived', 'Survived'],
+        delta: 1
       },
       {
         baseline: ['Timeout', 'Survived'],
-        candidate: ['Survived', 'Survived', 'Survived']
+        candidate: ['Survived', 'Survived', 'Survived'],
+        delta: 2
       },
       {
         baseline: ['Timeout', 'Ignored'],
-        candidate: ['Ignored', 'Survived']
+        candidate: ['Ignored', 'Survived'],
+        delta: 1
       },
       {
         baseline: ['Timeout', 'Killed'],
-        candidate: ['Killed', 'Survived']
+        candidate: ['Killed', 'Survived'],
+        delta: 1
       }
     ] as const
-    for (const { baseline, candidate } of cases) {
+    for (const { baseline, candidate, delta } of cases) {
       expect(
         compareMutationReports(
           identifyMutants(report([...baseline])),
           identifyMutants(report([...candidate]))
         ),
         `${baseline.join(',')} -> ${candidate.join(',')}`
-      ).toMatchObject({ pass: false, delta: 1 })
+      ).toMatchObject({ pass: false, delta })
     }
 
     expect(
@@ -204,7 +208,7 @@ describe('mutation gate', () => {
         identifyMutants(report(['Timeout', 'Survived'])),
         identifyMutants(report(['Survived', 'Survived']))
       )
-    ).toMatchObject({ pass: true, delta: 0 })
+    ).toMatchObject({ pass: false, delta: 1 })
   })
 
   it('does not match timeouts without a complete mutant fingerprint', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -209,6 +209,17 @@ describe('mutation gate', () => {
         identifyMutants(report(['Survived', 'Survived']))
       )
     ).toMatchObject({ pass: false, delta: 1 })
+
+    const renumberedDuplicate = identifyMutants(
+      report(['Killed', 'Survived'])
+    )
+    renumberedDuplicate.files['src/example.ts']!.mutants[1]!.id = 'renumbered'
+    expect(
+      compareMutationReports(
+        identifyMutants(report(['Killed', 'Timeout'])),
+        renumberedDuplicate
+      )
+    ).toMatchObject({ pass: false, delta: 1 })
   })
 
   it('does not match timeouts without a complete mutant fingerprint', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -170,23 +170,38 @@ describe('mutation gate', () => {
     ).toMatchObject({ pass: false, delta: 1 })
   })
 
-  it('does not reuse timeout credit already covered by baseline debt', () => {
-    const baseline = identifyMutants(report(['Timeout', 'Survived']))
+  it('does not reuse timeout credit across duplicate fingerprints', () => {
+    const cases = [
+      {
+        baseline: ['Timeout', 'Survived'],
+        candidate: ['Timeout', 'Survived', 'Survived']
+      },
+      {
+        baseline: ['Timeout', 'Survived'],
+        candidate: ['Survived', 'Survived', 'Survived']
+      },
+      {
+        baseline: ['Timeout', 'Ignored'],
+        candidate: ['Ignored', 'Survived']
+      },
+      {
+        baseline: ['Timeout', 'Killed'],
+        candidate: ['Killed', 'Survived']
+      }
+    ] as const
+    for (const { baseline, candidate } of cases) {
+      expect(
+        compareMutationReports(
+          identifyMutants(report([...baseline])),
+          identifyMutants(report([...candidate]))
+        ),
+        `${baseline.join(',')} -> ${candidate.join(',')}`
+      ).toMatchObject({ pass: false, delta: 1 })
+    }
+
     expect(
       compareMutationReports(
-        baseline,
-        identifyMutants(report(['Timeout', 'Survived', 'Survived']))
-      )
-    ).toMatchObject({ pass: false, delta: 1 })
-    expect(
-      compareMutationReports(
-        baseline,
-        identifyMutants(report(['Survived', 'Survived', 'Survived']))
-      )
-    ).toMatchObject({ pass: false, delta: 1 })
-    expect(
-      compareMutationReports(
-        baseline,
+        identifyMutants(report(['Timeout', 'Survived'])),
         identifyMutants(report(['Survived', 'Survived']))
       )
     ).toMatchObject({ pass: true, delta: 0 })
@@ -211,6 +226,30 @@ describe('mutation gate', () => {
         ).toMatchObject({ pass: false, delta: 1 })
       }
     }
+
+    const baseline = identifyMutants(report(['Timeout']))
+    const candidate = identifyMutants(report(['Timeout', 'Survived']))
+    delete candidate.files['src/example.ts']!.mutants[0]!.location
+    expect(compareMutationReports(baseline, candidate)).toMatchObject({
+      pass: false,
+      delta: 1
+    })
+  })
+
+  it('does not fingerprint out-of-range source locations', () => {
+    const baseline = identifyMutants(report(['Timeout']))
+    const candidate = identifyMutants(report(['Survived']))
+    for (const current of [baseline, candidate]) {
+      current.files['src/example.ts']!.mutants[0]!.location = {
+        start: { line: 2, column: 1 },
+        end: { line: 2, column: 5 }
+      }
+    }
+
+    expect(compareMutationReports(baseline, candidate)).toMatchObject({
+      pass: false,
+      delta: 1
+    })
   })
 
   it('passes when mutation debt is stable or decreases', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -261,7 +261,33 @@ describe('mutation gate', () => {
         report(['Killed']),
         report(['Killed'], candidateConfig)
       )
-    ).toThrow('node mutation scope lost 1 executed test file')
+    ).toThrow('node mutation scope lost 1 executed test')
+  })
+
+  it('rejects losing one of several tests in an existing file', () => {
+    const baselineConfig = structuredClone(defaultConfig)
+    baselineConfig.scope.node.executedTests.push(
+      'src/example.test.ts\0second test'
+    )
+
+    expect(() =>
+      compareMutationReports(
+        report(['Killed'], baselineConfig),
+        report(['Killed'])
+      )
+    ).toThrow('node mutation scope lost 1 executed test')
+  })
+
+  it('rejects malformed executed test identifiers', () => {
+    const candidateConfig = structuredClone(defaultConfig)
+    candidateConfig.scope.node.executedTests = ['src/example.test.ts']
+
+    expect(() =>
+      compareMutationReports(
+        report(['Killed']),
+        report(['Killed'], candidateConfig)
+      )
+    ).toThrow('invalid executed test identifier')
   })
 
   it('compares mutation debt across toolchain changes', () => {

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -130,8 +130,17 @@ describe('mutation gate', () => {
       compareMutationReports(report(['Survived']), report(['Timeout']))
     ).toMatchObject({ pass: true, delta: -1 })
 
+    const renumberedMutant = report(['Survived'])
+    renumberedMutant.files['src/example.ts']!.mutants[0]!.id = 'other'
+    expect(
+      compareMutationReports(report(['Timeout']), renumberedMutant)
+    ).toMatchObject({ pass: true, delta: 0 })
+
     const differentMutant = report(['Survived'])
-    differentMutant.files['src/example.ts']!.mutants[0]!.id = 'other'
+    differentMutant.files['src/example.ts']!.mutants[0]!.location = {
+      start: { line: 2, column: 1 },
+      end: { line: 2, column: 5 }
+    }
     expect(
       compareMutationReports(report(['Timeout']), differentMutant)
     ).toMatchObject({ pass: false, delta: 1 })

--- a/packages/scripts/mutation-gate.test.ts
+++ b/packages/scripts/mutation-gate.test.ts
@@ -109,7 +109,7 @@ describe('mutation gate', () => {
         report(['Killed', 'Timeout', 'Survived', 'NoCoverage', 'Ignored'])
       )
     ).toStrictEqual({
-      debt: 3,
+      debt: 4,
       detected: 2,
       errors: 0,
       ignored: 1,
@@ -120,6 +120,15 @@ describe('mutation gate', () => {
       total: 5,
       undetected: 2
     })
+  })
+
+  it('does not let timeout variance change mutation debt', () => {
+    expect(
+      compareMutationReports(report(['Timeout']), report(['Survived']))
+    ).toMatchObject({ pass: true, delta: 0 })
+    expect(
+      compareMutationReports(report(['Survived']), report(['Timeout']))
+    ).toMatchObject({ pass: true, delta: 0 })
   })
 
   it('passes when mutation debt is stable or decreases', () => {

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -291,6 +291,17 @@ function timeoutVarianceCredit(
     return 0
   }
 
+  const groupByFingerprint = (mutants: FingerprintedMutant[]) => {
+    const groups = new Map<string, FingerprintedMutant[]>()
+    for (const mutant of mutants) {
+      const group = groups.get(mutant.fingerprint) ?? []
+      group.push(mutant)
+      groups.set(mutant.fingerprint, group)
+    }
+    return groups
+  }
+  const baselineByFingerprint = groupByFingerprint(baseline)
+  const candidateByFingerprint = groupByFingerprint(candidate)
   const candidateByIdentity = new Map(
     candidate.map(mutant => [mutant.identity, mutant])
   )
@@ -307,7 +318,9 @@ function timeoutVarianceCredit(
       matchedCandidateIdentities.add(candidateMutant.identity)
       if (
         baselineMutant.status === 'Timeout' &&
-        UNDETECTED_STATUSES.has(candidateMutant.status)
+        UNDETECTED_STATUSES.has(candidateMutant.status) &&
+        baselineByFingerprint.get(baselineMutant.fingerprint)?.length === 1 &&
+        candidateByFingerprint.get(candidateMutant.fingerprint)?.length === 1
       ) {
         credit++
       }
@@ -319,15 +332,6 @@ function timeoutVarianceCredit(
   const unmatchedCandidate = candidate.filter(
     mutant => !matchedCandidateIdentities.has(mutant.identity)
   )
-  const groupByFingerprint = (mutants: FingerprintedMutant[]) => {
-    const groups = new Map<string, FingerprintedMutant[]>()
-    for (const mutant of mutants) {
-      const group = groups.get(mutant.fingerprint) ?? []
-      group.push(mutant)
-      groups.set(mutant.fingerprint, group)
-    }
-    return groups
-  }
   const baselineGroups = groupByFingerprint(unmatchedBaseline)
   const candidateGroups = groupByFingerprint(unmatchedCandidate)
   for (const [fingerprint, baselineGroup] of baselineGroups) {

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -186,7 +186,7 @@ export function summarizeMutationReport(
     }
   }
 
-  summary.debt = summary.undetected + summary.ignored + summary.timeout
+  summary.debt = summary.undetected + summary.ignored
 
   return summary
 }
@@ -321,7 +321,6 @@ export function compareMutationReports(
     )
   }
 
-  const delta = candidate.debt - baseline.debt
   const candidateUndetected = Object.entries(candidateReport.files)
     .flatMap(([file, { mutants, source }]) =>
       mutants
@@ -344,6 +343,17 @@ export function compareMutationReports(
           (right.location?.start.column ?? 0) ||
         left.id.localeCompare(right.id)
     )
+  const baselineTimeouts = new Set(
+    Object.entries(baselineReport.files).flatMap(([file, { mutants }]) =>
+      mutants
+        .filter(mutant => mutant.status === 'Timeout')
+        .map(mutant => `${file}\0${mutant.id}`)
+    )
+  )
+  const toleratedTimeoutVariance = candidateUndetected.filter(mutant =>
+    baselineTimeouts.has(`${mutant.file}\0${mutant.id}`)
+  ).length
+  const delta = candidate.debt - baseline.debt - toleratedTimeoutVariance
   return {
     baseline,
     candidate,
@@ -426,7 +436,7 @@ async function main(): Promise<void> {
     process.stderr.write(
       `Mutation debt increased by ${result.delta}: ` +
         `${result.baseline.debt} → ${result.candidate.debt} ` +
-        `survived, uncovered, ignored, or timed-out mutants.\n`
+        `survived, uncovered, or ignored mutants.\n`
     )
     process.stderr.write(
       `Ignored mutants: ${result.baseline.ignored} → ${result.candidate.ignored}.\n`
@@ -449,7 +459,7 @@ async function main(): Promise<void> {
     process.stdout.write(
       `Mutation debt ${outcome}: ` +
         `${result.baseline.debt} → ${result.candidate.debt} ` +
-        `survived, uncovered, ignored, or timed-out mutants.\n`
+        `survived, uncovered, or ignored mutants.\n`
     )
   }
 }

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -225,15 +225,17 @@ function scopeSettings(scope: MutationScope): unknown {
   }
 }
 
-function executedTestFiles(tests: string[]): string[] {
-  return [
-    ...new Set(
-      tests.map(test => {
-        const separator = test.indexOf('\0')
-        return separator === -1 ? test : test.slice(0, separator)
-      })
-    )
-  ].sort()
+function executedTestCounts(tests: string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const test of tests) {
+    const separator = test.indexOf('\0')
+    if (separator <= 0 || separator === test.length - 1) {
+      throw new Error(`invalid executed test identifier: ${JSON.stringify(test)}`)
+    }
+    const file = test.slice(0, separator)
+    counts.set(file, (counts.get(file) ?? 0) + 1)
+  }
+  return counts
 }
 
 function difference(baseline: string[], candidate: string[]): string[] {
@@ -282,13 +284,23 @@ export function compareMutationReports(
         `${runtime} mutation scope lost ${missingMutationFiles.length} existing source file(s)`
       )
     }
-    const missingTestFiles = difference(
-      executedTestFiles(baselineReport.config.scope[runtime].executedTests),
-      executedTestFiles(candidateReport.config.scope[runtime].executedTests)
-    ).filter(file => candidateReport.config.scope.sourceFiles.includes(file))
-    if (missingTestFiles.length > 0) {
+    const baselineTestCounts = executedTestCounts(
+      baselineReport.config.scope[runtime].executedTests
+    )
+    const candidateTestCounts = executedTestCounts(
+      candidateReport.config.scope[runtime].executedTests
+    )
+    const missingTests = [...baselineTestCounts].reduce(
+      (count, [file, baselineCount]) =>
+        candidateReport.config.scope.sourceFiles.includes(file)
+          ? count +
+            Math.max(0, baselineCount - (candidateTestCounts.get(file) ?? 0))
+          : count,
+      0
+    )
+    if (missingTests > 0) {
       throw new Error(
-        `${runtime} mutation scope lost ${missingTestFiles.length} executed test file(s)`
+        `${runtime} mutation scope lost ${missingTests} executed test(s)`
       )
     }
   }

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -212,6 +212,28 @@ function sourceAtLocation(
     .join('\n')
 }
 
+function mutantFingerprint(
+  file: string,
+  source: string,
+  mutant: {
+    location?: UndetectedMutant['location']
+    mutatorName?: string
+    replacement?: string
+  }
+): string {
+  const location = mutant.location
+  return JSON.stringify([
+    file,
+    location?.start.line,
+    location?.start.column,
+    location?.end.line,
+    location?.end.column,
+    mutant.mutatorName,
+    sourceAtLocation(source, location),
+    mutant.replacement
+  ])
+}
+
 function scopeSettings(scope: MutationScope): unknown {
   const withoutExecutedTests = (runtime: RuntimeMutationScope) => {
     const { executedTests: _, mutationFiles: __, ...settings } = runtime
@@ -343,16 +365,22 @@ export function compareMutationReports(
           (right.location?.start.column ?? 0) ||
         left.id.localeCompare(right.id)
     )
-  const baselineTimeouts = new Set(
-    Object.entries(baselineReport.files).flatMap(([file, { mutants }]) =>
+  const baselineTimeouts = Object.entries(baselineReport.files).flatMap(
+    ([file, { mutants, source }]) =>
       mutants
         .filter(mutant => mutant.status === 'Timeout')
-        .map(mutant => `${file}\0${mutant.id}`)
+        .map(mutant => mutantFingerprint(file, source, mutant))
+  )
+  const candidateUndetectedFingerprints = candidateUndetected.map(mutant =>
+    mutantFingerprint(
+      mutant.file,
+      candidateReport.files[mutant.file]!.source,
+      mutant
     )
   )
-  const toleratedTimeoutVariance = candidateUndetected.filter(mutant =>
-    baselineTimeouts.has(`${mutant.file}\0${mutant.id}`)
-  ).length
+  const toleratedTimeoutVariance =
+    candidateUndetectedFingerprints.length -
+    difference(candidateUndetectedFingerprints, baselineTimeouts).length
   const delta = candidate.debt - baseline.debt - toleratedTimeoutVariance
   return {
     baseline,

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -200,15 +200,28 @@ function sourceAtLocation(
   }
   const lines = source.split('\n')
   const { start, end } = location
+  const startLine = lines[start.line - 1]
+  const endLine = lines[end.line - 1]
+  if (
+    startLine === undefined ||
+    endLine === undefined ||
+    start.line > end.line ||
+    start.column < 1 ||
+    end.column < 1 ||
+    start.column > startLine.length + 1 ||
+    end.column > endLine.length + 1 ||
+    (start.line === end.line && start.column > end.column)
+  ) {
+    return undefined
+  }
   if (start.line === end.line) {
-    return lines[start.line - 1]?.slice(start.column - 1, end.column - 1)
+    return startLine.slice(start.column - 1, end.column - 1)
   }
   return [
-    lines[start.line - 1]?.slice(start.column - 1),
+    startLine.slice(start.column - 1),
     ...lines.slice(start.line, end.line - 1),
-    lines[end.line - 1]?.slice(0, end.column - 1)
+    endLine.slice(0, end.column - 1)
   ]
-    .filter((line): line is string => line !== undefined)
     .join('\n')
 }
 
@@ -243,23 +256,92 @@ function mutantFingerprint(
   ])
 }
 
-function mutantFingerprintCounts(
-  report: MutationReport,
-  statuses: ReadonlySet<string>
-): Map<string, number> {
-  const counts = new Map<string, number>()
+type FingerprintedMutant = {
+  fingerprint: string
+  identity: string
+  status: MutantStatus
+}
+
+function fingerprintedMutants(
+  report: MutationReport
+): FingerprintedMutant[] | undefined {
+  const records: FingerprintedMutant[] = []
+  const identities = new Set<string>()
   for (const [file, { mutants, source }] of Object.entries(report.files)) {
     for (const mutant of mutants) {
-      if (!statuses.has(mutant.status)) {
-        continue
-      }
       const fingerprint = mutantFingerprint(file, source, mutant)
-      if (fingerprint !== undefined) {
-        counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1)
+      const identity = `${file}\0${mutant.id}`
+      if (fingerprint === undefined || identities.has(identity)) {
+        return undefined
       }
+      identities.add(identity)
+      records.push({ fingerprint, identity, status: mutant.status })
     }
   }
-  return counts
+  return records
+}
+
+function timeoutVarianceCredit(
+  baselineReport: MutationReport,
+  candidateReport: MutationReport
+): number {
+  const baseline = fingerprintedMutants(baselineReport)
+  const candidate = fingerprintedMutants(candidateReport)
+  if (!baseline || !candidate) {
+    return 0
+  }
+
+  const candidateByIdentity = new Map(
+    candidate.map(mutant => [mutant.identity, mutant])
+  )
+  const matchedCandidateIdentities = new Set<string>()
+  const unmatchedBaseline: FingerprintedMutant[] = []
+  let credit = 0
+
+  for (const baselineMutant of baseline) {
+    const candidateMutant = candidateByIdentity.get(baselineMutant.identity)
+    if (
+      candidateMutant &&
+      candidateMutant.fingerprint === baselineMutant.fingerprint
+    ) {
+      matchedCandidateIdentities.add(candidateMutant.identity)
+      if (
+        baselineMutant.status === 'Timeout' &&
+        UNDETECTED_STATUSES.has(candidateMutant.status)
+      ) {
+        credit++
+      }
+    } else {
+      unmatchedBaseline.push(baselineMutant)
+    }
+  }
+
+  const unmatchedCandidate = candidate.filter(
+    mutant => !matchedCandidateIdentities.has(mutant.identity)
+  )
+  const groupByFingerprint = (mutants: FingerprintedMutant[]) => {
+    const groups = new Map<string, FingerprintedMutant[]>()
+    for (const mutant of mutants) {
+      const group = groups.get(mutant.fingerprint) ?? []
+      group.push(mutant)
+      groups.set(mutant.fingerprint, group)
+    }
+    return groups
+  }
+  const baselineGroups = groupByFingerprint(unmatchedBaseline)
+  const candidateGroups = groupByFingerprint(unmatchedCandidate)
+  for (const [fingerprint, baselineGroup] of baselineGroups) {
+    const candidateGroup = candidateGroups.get(fingerprint)
+    if (
+      baselineGroup.length === 1 &&
+      candidateGroup?.length === 1 &&
+      baselineGroup[0]!.status === 'Timeout' &&
+      UNDETECTED_STATUSES.has(candidateGroup[0]!.status)
+    ) {
+      credit++
+    }
+  }
+  return credit
 }
 
 function scopeSettings(scope: MutationScope): unknown {
@@ -393,37 +475,9 @@ export function compareMutationReports(
           (right.location?.start.column ?? 0) ||
         left.id.localeCompare(right.id)
     )
-  const baselineTimeouts = mutantFingerprintCounts(
+  const toleratedTimeoutVariance = timeoutVarianceCredit(
     baselineReport,
-    new Set(['Timeout'])
-  )
-  const candidateTimeouts = mutantFingerprintCounts(
-    candidateReport,
-    new Set(['Timeout'])
-  )
-  const baselineUndetected = mutantFingerprintCounts(
-    baselineReport,
-    UNDETECTED_STATUSES
-  )
-  const candidateUndetectedCounts = mutantFingerprintCounts(
-    candidateReport,
-    UNDETECTED_STATUSES
-  )
-  const toleratedTimeoutVariance = [...candidateUndetectedCounts].reduce(
-    (credit, [fingerprint, candidateCount]) =>
-      credit +
-      Math.min(
-        Math.max(
-          0,
-          (baselineTimeouts.get(fingerprint) ?? 0) -
-            (candidateTimeouts.get(fingerprint) ?? 0)
-        ),
-        Math.max(
-          0,
-          candidateCount - (baselineUndetected.get(fingerprint) ?? 0)
-        )
-      ),
-    0
+    candidateReport
   )
   const delta = candidate.debt - baseline.debt - toleratedTimeoutVariance
   return {

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -186,7 +186,7 @@ export function summarizeMutationReport(
     }
   }
 
-  summary.debt = summary.undetected + summary.ignored
+  summary.debt = summary.undetected + summary.ignored + summary.timeout
 
   return summary
 }
@@ -426,7 +426,7 @@ async function main(): Promise<void> {
     process.stderr.write(
       `Mutation debt increased by ${result.delta}: ` +
         `${result.baseline.debt} → ${result.candidate.debt} ` +
-        `survived, uncovered, or ignored mutants.\n`
+        `survived, uncovered, ignored, or timed-out mutants.\n`
     )
     process.stderr.write(
       `Ignored mutants: ${result.baseline.ignored} → ${result.candidate.ignored}.\n`
@@ -449,7 +449,7 @@ async function main(): Promise<void> {
     process.stdout.write(
       `Mutation debt ${outcome}: ` +
         `${result.baseline.debt} → ${result.candidate.debt} ` +
-        `survived, uncovered, or ignored mutants.\n`
+        `survived, uncovered, ignored, or timed-out mutants.\n`
     )
   }
 }

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -322,7 +322,7 @@ function timeoutVarianceCredit(
       matchedCandidateIdentities.add(candidateMutant.identity)
       if (
         baselineMutant.status === 'Timeout' &&
-        UNDETECTED_STATUSES.has(candidateMutant.status) &&
+        candidateMutant.status === 'Survived' &&
         baselineByFingerprint.get(baselineMutant.fingerprint)?.length === 1 &&
         candidateByFingerprint.get(candidateMutant.fingerprint)?.length === 1
       ) {
@@ -346,7 +346,7 @@ function timeoutVarianceCredit(
       baselineByFingerprint.get(fingerprint)?.length === 1 &&
       candidateByFingerprint.get(fingerprint)?.length === 1 &&
       baselineGroup[0]!.status === 'Timeout' &&
-      UNDETECTED_STATUSES.has(candidateGroup[0]!.status)
+      candidateGroup[0]!.status === 'Survived'
     ) {
       credit++
     }

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -225,6 +225,17 @@ function scopeSettings(scope: MutationScope): unknown {
   }
 }
 
+function executedTestFiles(tests: string[]): string[] {
+  return [
+    ...new Set(
+      tests.map(test => {
+        const separator = test.indexOf('\0')
+        return separator === -1 ? test : test.slice(0, separator)
+      })
+    )
+  ].sort()
+}
+
 function difference(baseline: string[], candidate: string[]): string[] {
   const remaining = new Map<string, number>()
   for (const value of candidate) {
@@ -271,13 +282,13 @@ export function compareMutationReports(
         `${runtime} mutation scope lost ${missingMutationFiles.length} existing source file(s)`
       )
     }
-    const missingTests = difference(
-      baselineReport.config.scope[runtime].executedTests,
-      candidateReport.config.scope[runtime].executedTests
-    )
-    if (missingTests.length > 0) {
+    const missingTestFiles = difference(
+      executedTestFiles(baselineReport.config.scope[runtime].executedTests),
+      executedTestFiles(candidateReport.config.scope[runtime].executedTests)
+    ).filter(file => candidateReport.config.scope.sourceFiles.includes(file))
+    if (missingTestFiles.length > 0) {
       throw new Error(
-        `${runtime} mutation scope lost ${missingTests.length} executed test(s)`
+        `${runtime} mutation scope lost ${missingTestFiles.length} executed test file(s)`
       )
     }
   }

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -339,6 +339,8 @@ function timeoutVarianceCredit(
     if (
       baselineGroup.length === 1 &&
       candidateGroup?.length === 1 &&
+      baselineByFingerprint.get(fingerprint)?.length === 1 &&
+      candidateByFingerprint.get(fingerprint)?.length === 1 &&
       baselineGroup[0]!.status === 'Timeout' &&
       UNDETECTED_STATUSES.has(candidateGroup[0]!.status)
     ) {

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -205,6 +205,10 @@ function sourceAtLocation(
   if (
     startLine === undefined ||
     endLine === undefined ||
+    !Number.isInteger(start.line) ||
+    !Number.isInteger(start.column) ||
+    !Number.isInteger(end.line) ||
+    !Number.isInteger(end.column) ||
     start.line > end.line ||
     start.column < 1 ||
     end.column < 1 ||

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -200,158 +200,16 @@ function sourceAtLocation(
   }
   const lines = source.split('\n')
   const { start, end } = location
-  const startLine = lines[start.line - 1]
-  const endLine = lines[end.line - 1]
-  if (
-    startLine === undefined ||
-    endLine === undefined ||
-    !Number.isInteger(start.line) ||
-    !Number.isInteger(start.column) ||
-    !Number.isInteger(end.line) ||
-    !Number.isInteger(end.column) ||
-    start.line > end.line ||
-    start.column < 1 ||
-    end.column < 1 ||
-    start.column > startLine.length + 1 ||
-    end.column > endLine.length + 1 ||
-    (start.line === end.line && start.column > end.column)
-  ) {
-    return undefined
-  }
   if (start.line === end.line) {
-    return startLine.slice(start.column - 1, end.column - 1)
+    return lines[start.line - 1]?.slice(start.column - 1, end.column - 1)
   }
   return [
-    startLine.slice(start.column - 1),
+    lines[start.line - 1]?.slice(start.column - 1),
     ...lines.slice(start.line, end.line - 1),
-    endLine.slice(0, end.column - 1)
+    lines[end.line - 1]?.slice(0, end.column - 1)
   ]
+    .filter((line): line is string => line !== undefined)
     .join('\n')
-}
-
-function mutantFingerprint(
-  file: string,
-  source: string,
-  mutant: {
-    location?: UndetectedMutant['location']
-    mutatorName?: string
-    replacement?: string
-  }
-): string | undefined {
-  const location = mutant.location
-  const original = sourceAtLocation(source, location)
-  if (
-    !location ||
-    mutant.mutatorName === undefined ||
-    mutant.replacement === undefined ||
-    original === undefined
-  ) {
-    return undefined
-  }
-  return JSON.stringify([
-    file,
-    location.start.line,
-    location.start.column,
-    location.end.line,
-    location.end.column,
-    mutant.mutatorName,
-    original,
-    mutant.replacement
-  ])
-}
-
-type FingerprintedMutant = {
-  fingerprint: string
-  identity: string
-  status: MutantStatus
-}
-
-function fingerprintedMutants(
-  report: MutationReport
-): FingerprintedMutant[] | undefined {
-  const records: FingerprintedMutant[] = []
-  const identities = new Set<string>()
-  for (const [file, { mutants, source }] of Object.entries(report.files)) {
-    for (const mutant of mutants) {
-      const fingerprint = mutantFingerprint(file, source, mutant)
-      const identity = `${file}\0${mutant.id}`
-      if (fingerprint === undefined || identities.has(identity)) {
-        return undefined
-      }
-      identities.add(identity)
-      records.push({ fingerprint, identity, status: mutant.status })
-    }
-  }
-  return records
-}
-
-function timeoutVarianceCredit(
-  baselineReport: MutationReport,
-  candidateReport: MutationReport
-): number {
-  const baseline = fingerprintedMutants(baselineReport)
-  const candidate = fingerprintedMutants(candidateReport)
-  if (!baseline || !candidate) {
-    return 0
-  }
-
-  const groupByFingerprint = (mutants: FingerprintedMutant[]) => {
-    const groups = new Map<string, FingerprintedMutant[]>()
-    for (const mutant of mutants) {
-      const group = groups.get(mutant.fingerprint) ?? []
-      group.push(mutant)
-      groups.set(mutant.fingerprint, group)
-    }
-    return groups
-  }
-  const baselineByFingerprint = groupByFingerprint(baseline)
-  const candidateByFingerprint = groupByFingerprint(candidate)
-  const candidateByIdentity = new Map(
-    candidate.map(mutant => [mutant.identity, mutant])
-  )
-  const matchedCandidateIdentities = new Set<string>()
-  const unmatchedBaseline: FingerprintedMutant[] = []
-  let credit = 0
-
-  for (const baselineMutant of baseline) {
-    const candidateMutant = candidateByIdentity.get(baselineMutant.identity)
-    if (
-      candidateMutant &&
-      candidateMutant.fingerprint === baselineMutant.fingerprint
-    ) {
-      matchedCandidateIdentities.add(candidateMutant.identity)
-      if (
-        baselineMutant.status === 'Timeout' &&
-        candidateMutant.status === 'Survived' &&
-        baselineByFingerprint.get(baselineMutant.fingerprint)?.length === 1 &&
-        candidateByFingerprint.get(candidateMutant.fingerprint)?.length === 1
-      ) {
-        credit++
-      }
-    } else {
-      unmatchedBaseline.push(baselineMutant)
-    }
-  }
-
-  const unmatchedCandidate = candidate.filter(
-    mutant => !matchedCandidateIdentities.has(mutant.identity)
-  )
-  const baselineGroups = groupByFingerprint(unmatchedBaseline)
-  const candidateGroups = groupByFingerprint(unmatchedCandidate)
-  for (const [fingerprint, baselineGroup] of baselineGroups) {
-    const candidateGroup = candidateGroups.get(fingerprint)
-    if (
-      baselineGroup.length === 1 &&
-      candidateGroup?.length === 1 &&
-      baselineByFingerprint.get(fingerprint)?.length === 1 &&
-      candidateByFingerprint.get(fingerprint)?.length === 1 &&
-      baselineGroup[0]!.status === 'Timeout' &&
-      candidateGroup[0]!.status === 'Survived'
-    ) {
-      credit++
-    }
-  }
-  return credit
 }
 
 function scopeSettings(scope: MutationScope): unknown {
@@ -367,17 +225,16 @@ function scopeSettings(scope: MutationScope): unknown {
   }
 }
 
-function executedTestCounts(tests: string[]): Map<string, number> {
-  const counts = new Map<string, number>()
-  for (const test of tests) {
+function executedTestFiles(tests: string[]): string[] {
+  return tests.map(test => {
     const separator = test.indexOf('\0')
-    if (separator <= 0 || separator === test.length - 1) {
-      throw new Error(`invalid executed test identifier: ${JSON.stringify(test)}`)
+    if (separator <= 0) {
+      throw new Error(
+        `invalid executed test identifier: ${JSON.stringify(test)}`
+      )
     }
-    const file = test.slice(0, separator)
-    counts.set(file, (counts.get(file) ?? 0) + 1)
-  }
-  return counts
+    return test.slice(0, separator)
+  })
 }
 
 function difference(baseline: string[], candidate: string[]): string[] {
@@ -426,23 +283,13 @@ export function compareMutationReports(
         `${runtime} mutation scope lost ${missingMutationFiles.length} existing source file(s)`
       )
     }
-    const baselineTestCounts = executedTestCounts(
-      baselineReport.config.scope[runtime].executedTests
-    )
-    const candidateTestCounts = executedTestCounts(
-      candidateReport.config.scope[runtime].executedTests
-    )
-    const missingTests = [...baselineTestCounts].reduce(
-      (count, [file, baselineCount]) =>
-        candidateReport.config.scope.sourceFiles.includes(file)
-          ? count +
-            Math.max(0, baselineCount - (candidateTestCounts.get(file) ?? 0))
-          : count,
-      0
-    )
-    if (missingTests > 0) {
+    const missingTests = difference(
+      executedTestFiles(baselineReport.config.scope[runtime].executedTests),
+      executedTestFiles(candidateReport.config.scope[runtime].executedTests)
+    ).filter(file => candidateReport.config.scope.sourceFiles.includes(file))
+    if (missingTests.length > 0) {
       throw new Error(
-        `${runtime} mutation scope lost ${missingTests} executed test(s)`
+        `${runtime} mutation scope lost ${missingTests.length} executed test(s)`
       )
     }
   }
@@ -463,6 +310,7 @@ export function compareMutationReports(
     )
   }
 
+  const delta = candidate.debt - baseline.debt
   const candidateUndetected = Object.entries(candidateReport.files)
     .flatMap(([file, { mutants, source }]) =>
       mutants
@@ -485,11 +333,6 @@ export function compareMutationReports(
           (right.location?.start.column ?? 0) ||
         left.id.localeCompare(right.id)
     )
-  const toleratedTimeoutVariance = timeoutVarianceCredit(
-    baselineReport,
-    candidateReport
-  )
-  const delta = candidate.debt - baseline.debt - toleratedTimeoutVariance
   return {
     baseline,
     candidate,

--- a/packages/scripts/mutation-gate.ts
+++ b/packages/scripts/mutation-gate.ts
@@ -220,18 +220,46 @@ function mutantFingerprint(
     mutatorName?: string
     replacement?: string
   }
-): string {
+): string | undefined {
   const location = mutant.location
+  const original = sourceAtLocation(source, location)
+  if (
+    !location ||
+    mutant.mutatorName === undefined ||
+    mutant.replacement === undefined ||
+    original === undefined
+  ) {
+    return undefined
+  }
   return JSON.stringify([
     file,
-    location?.start.line,
-    location?.start.column,
-    location?.end.line,
-    location?.end.column,
+    location.start.line,
+    location.start.column,
+    location.end.line,
+    location.end.column,
     mutant.mutatorName,
-    sourceAtLocation(source, location),
+    original,
     mutant.replacement
   ])
+}
+
+function mutantFingerprintCounts(
+  report: MutationReport,
+  statuses: ReadonlySet<string>
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const [file, { mutants, source }] of Object.entries(report.files)) {
+    for (const mutant of mutants) {
+      if (!statuses.has(mutant.status)) {
+        continue
+      }
+      const fingerprint = mutantFingerprint(file, source, mutant)
+      if (fingerprint !== undefined) {
+        counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1)
+      }
+    }
+  }
+  return counts
 }
 
 function scopeSettings(scope: MutationScope): unknown {
@@ -365,22 +393,38 @@ export function compareMutationReports(
           (right.location?.start.column ?? 0) ||
         left.id.localeCompare(right.id)
     )
-  const baselineTimeouts = Object.entries(baselineReport.files).flatMap(
-    ([file, { mutants, source }]) =>
-      mutants
-        .filter(mutant => mutant.status === 'Timeout')
-        .map(mutant => mutantFingerprint(file, source, mutant))
+  const baselineTimeouts = mutantFingerprintCounts(
+    baselineReport,
+    new Set(['Timeout'])
   )
-  const candidateUndetectedFingerprints = candidateUndetected.map(mutant =>
-    mutantFingerprint(
-      mutant.file,
-      candidateReport.files[mutant.file]!.source,
-      mutant
-    )
+  const candidateTimeouts = mutantFingerprintCounts(
+    candidateReport,
+    new Set(['Timeout'])
   )
-  const toleratedTimeoutVariance =
-    candidateUndetectedFingerprints.length -
-    difference(candidateUndetectedFingerprints, baselineTimeouts).length
+  const baselineUndetected = mutantFingerprintCounts(
+    baselineReport,
+    UNDETECTED_STATUSES
+  )
+  const candidateUndetectedCounts = mutantFingerprintCounts(
+    candidateReport,
+    UNDETECTED_STATUSES
+  )
+  const toleratedTimeoutVariance = [...candidateUndetectedCounts].reduce(
+    (credit, [fingerprint, candidateCount]) =>
+      credit +
+      Math.min(
+        Math.max(
+          0,
+          (baselineTimeouts.get(fingerprint) ?? 0) -
+            (candidateTimeouts.get(fingerprint) ?? 0)
+        ),
+        Math.max(
+          0,
+          candidateCount - (baselineUndetected.get(fingerprint) ?? 0)
+        )
+      ),
+    0
+  )
   const delta = candidate.debt - baseline.debt - toleratedTimeoutVariance
   return {
     baseline,


### PR DESCRIPTION
## Summary

- compare executed-test counts per runtime and file instead of exact test names
- allow deleted test files when they are absent from the candidate source tree
- reject malformed test identifiers and per-file count loss
- record JavaScript-family test files so coverage loss cannot look like deletion
- keep Timeout-to-Survived changes in the aggregate mutation-debt calculation

This fixes false failures found while restacking #1549 after #1575. #1549 deletes `compose.test.ts` and renames or adds tests. The gate now allows those structural changes while still rejecting reduced per-file test counts. The unsafe timeout-variance credit was removed.

## Validation

- `pnpm run test --filter scripts --force` — 12 files, 319 tests
- `pnpm --filter nuqs mutation:config-test` — 9 tests
- paired #1549 baseline and candidate reports pass: debt 720 → 699
- four initial reviews and two adversarial review passes
