### PR TITLE
chore: avoid redundant beta version bumps

### DIFF
--- a/packages/scripts/compute-version.integration.test.ts
+++ b/packages/scripts/compute-version.integration.test.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { computeVersion } from './compute-version'
+import { readReleaseHistory } from './lib/git'
+
+const temporaryDirectories: string[] = []
+const gitEnvironment = { ...process.env }
+delete gitEnvironment.GIT_DIR
+delete gitEnvironment.GIT_WORK_TREE
+gitEnvironment.GIT_CONFIG_GLOBAL = '/dev/null'
+gitEnvironment.GIT_CONFIG_SYSTEM = '/dev/null'
+
+function git(cwd: string, ...args: string[]): void {
+  try {
+    execFileSync('git', args, {
+      cwd,
+      env: gitEnvironment,
+      stdio: 'pipe'
+    })
+  } catch (error) {
+    const stderr = (error as { stderr?: Buffer }).stderr?.toString().trim()
+    throw new Error(
+      `git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`
+    )
+  }
+}
+
+function commit(cwd: string, message: string): void {
+  git(cwd, 'commit', '--allow-empty', '-m', message)
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('computeVersion with Git history', () => {
+  it('raises the target when a feature lands after a patch beta', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuqs-version-history-'))
+    temporaryDirectories.push(root)
+    const origin = join(root, 'origin.git')
+    const repository = join(root, 'repository')
+
+    git(root, 'init', '--bare', origin)
+    git(root, 'init', '--initial-branch=next', repository)
+    git(repository, 'config', 'user.name', 'Test User')
+    git(repository, 'config', 'user.email', 'test@example.com')
+
+    commit(repository, 'chore: initial release')
+    git(repository, 'tag', 'v1.2.3')
+    commit(repository, 'fix: a bug')
+    git(repository, 'tag', 'v1.2.4-beta.1')
+    commit(repository, 'feat: a feature')
+    git(repository, 'remote', 'add', 'origin', origin)
+    git(repository, 'push', '--tags', '--set-upstream', 'origin', 'next')
+
+    const history = readReleaseHistory(repository)
+    expect(computeVersion({ channel: 'beta', history })).toMatchObject({
+      version: '1.3.0-beta.1',
+      bump: 'minor'
+    })
+  })
+
+  it('includes a branch merged after the latest beta tag', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuqs-version-merge-'))
+    temporaryDirectories.push(root)
+    const origin = join(root, 'origin.git')
+    const repository = join(root, 'repository')
+
+    git(root, 'init', '--bare', origin)
+    git(root, 'init', '--initial-branch=next', repository)
+    git(repository, 'config', 'user.name', 'Test User')
+    git(repository, 'config', 'user.email', 'test@example.com')
+
+    commit(repository, 'chore: initial release')
+    git(repository, 'tag', 'v1.0.0')
+    git(repository, 'checkout', '-b', 'feature')
+    commit(repository, 'feat: a feature')
+    git(repository, 'checkout', 'next')
+    commit(repository, 'fix: a bug')
+    git(repository, 'tag', 'v1.0.1-beta.1')
+    git(repository, 'merge', '--no-ff', 'feature', '-m', 'chore: merge feature')
+    git(repository, 'remote', 'add', 'origin', origin)
+    git(repository, 'push', '--tags', '--set-upstream', 'origin', 'next')
+
+    const history = readReleaseHistory(repository)
+    expect(computeVersion({ channel: 'beta', history })).toMatchObject({
+      version: '1.1.0-beta.1',
+      bump: 'minor'
+    })
+  })
+
+  it('computes from the checked-out snapshot when origin/next advances', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuqs-version-snapshot-'))
+    temporaryDirectories.push(root)
+    const origin = join(root, 'origin.git')
+    const repository = join(root, 'repository')
+
+    git(root, 'init', '--bare', origin)
+    git(root, 'init', '--initial-branch=next', repository)
+    git(repository, 'config', 'user.name', 'Test User')
+    git(repository, 'config', 'user.email', 'test@example.com')
+
+    commit(repository, 'chore: initial release')
+    git(repository, 'tag', 'v1.0.0')
+    commit(repository, 'fix: included in the snapshot')
+    const snapshot = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repository,
+      env: gitEnvironment,
+      encoding: 'utf8'
+    }).trim()
+    git(repository, 'remote', 'add', 'origin', origin)
+    git(repository, 'push', '--tags', '--set-upstream', 'origin', 'next')
+
+    commit(repository, 'feat: merged after the workflow started')
+    git(repository, 'tag', 'v1.1.0-beta.1')
+    git(repository, 'push', '--tags', 'origin', 'next')
+    git(repository, 'checkout', '--detach', snapshot)
+
+    const history = readReleaseHistory(repository)
+    expect(computeVersion({ channel: 'stable', history })).toMatchObject({
+      version: '1.0.1',
+      bump: 'patch'
+    })
+  })
+
+  it('refuses to reuse a matching tag outside the release history', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuqs-version-collision-'))
+    temporaryDirectories.push(root)
+    const repository = join(root, 'repository')
+
+    git(root, 'init', '--initial-branch=next', repository)
+    git(repository, 'config', 'user.name', 'Test User')
+    git(repository, 'config', 'user.email', 'test@example.com')
+    commit(repository, 'chore: initial release')
+    git(repository, 'tag', 'v1.0.0')
+    commit(repository, 'fix: a new bug')
+
+    git(repository, 'checkout', '--orphan', 'unrelated')
+    commit(repository, 'chore: unrelated release')
+    git(repository, 'tag', 'v1.0.1')
+    git(repository, 'checkout', 'next')
+
+    try {
+      execFileSync(
+        process.execPath,
+        [join(import.meta.dirname, 'compute-version.ts')],
+        {
+          cwd: repository,
+          env: { ...gitEnvironment, CHANNEL: 'stable' },
+          encoding: 'utf8',
+          stdio: 'pipe'
+        }
+      )
+      expect.fail('Expected the calculator to reject an existing tag')
+    } catch (error) {
+      const stderr = (error as { stderr?: string }).stderr ?? ''
+      expect(stderr).toContain('Refusing to reuse existing release tag v1.0.1')
+    }
+  })
+})

--- a/packages/scripts/compute-version.test.ts
+++ b/packages/scripts/compute-version.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   computeVersion,
+  formatReleaseTrace,
   selectLastGATag,
   selectLastReleaseTag
 } from './compute-version'
@@ -92,6 +93,24 @@ describe('selectLastReleaseTag', () => {
     expect(selectLastReleaseTag('stable', ['v1.2.3', 'v1.2.4-beta.1'])).toBe(
       'v1.2.3'
     )
+  })
+})
+
+describe('release trace', () => {
+  it('shows the published release checkpoint used by a beta run', () => {
+    const trace = formatReleaseTrace({
+      channel: 'beta',
+      lastGATag: 'v1.2.3',
+      lastReleaseTag: 'v1.2.4-beta.1',
+      plan: {
+        version: '1.2.4-beta.2',
+        tag: 'v1.2.4-beta.2',
+        distTag: 'beta',
+        bump: 'patch'
+      }
+    })
+
+    expect(trace).toContain('Last release: v1.2.4-beta.1')
   })
 })
 

--- a/packages/scripts/compute-version.test.ts
+++ b/packages/scripts/compute-version.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { computeVersion, selectLastGATag } from './compute-version'
+import {
+  computeVersion,
+  selectLastGATag,
+  selectLastReleaseTag
+} from './compute-version'
 
 describe('selectLastGATag', () => {
   it('returns the highest GA tag, ignoring betas', () => {
@@ -25,12 +29,27 @@ describe('selectLastGATag', () => {
   })
 })
 
+describe('selectLastReleaseTag', () => {
+  it('selects the greatest published tag for a beta', () => {
+    expect(
+      selectLastReleaseTag('beta', ['v1.2.3', 'v1.2.4-beta.1', 'v1.2.4-beta.2'])
+    ).toBe('v1.2.4-beta.2')
+  })
+
+  it('selects the greatest GA tag for a stable release', () => {
+    expect(selectLastReleaseTag('stable', ['v1.2.3', 'v1.2.4-beta.1'])).toBe(
+      'v1.2.3'
+    )
+  })
+})
+
 describe('computeVersion', () => {
   it('bumps a patch for a fix commit on the stable channel', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['fix: a bug'],
+      newCommits: ['fix: a bug'],
       tags: ['v1.2.3']
     })
     expect(plan).toEqual({
@@ -46,6 +65,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['feat: a feature'],
+      newCommits: ['feat: a feature'],
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '1.3.0', bump: 'minor' })
@@ -56,6 +76,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['feat(scope)!: a breaking feature'],
+      newCommits: ['feat(scope)!: a breaking feature'],
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '2.0.0', bump: 'major' })
@@ -66,6 +87,7 @@ describe('computeVersion', () => {
       channel: 'beta',
       lastGATag: 'v1.2.3',
       commits: ['feat: a feature'],
+      newCommits: ['feat: a feature'],
       tags: ['v1.2.3']
     })
     expect(plan).toEqual({
@@ -76,14 +98,26 @@ describe('computeVersion', () => {
     })
   })
 
-  it('increments the beta counter past existing betas for the same target', () => {
+  it('increments the beta counter when a lower bump lands after it', () => {
     const plan = computeVersion({
       channel: 'beta',
       lastGATag: 'v1.2.3',
-      commits: ['feat: a feature'],
+      commits: ['feat: a feature', 'fix: a later bug'],
+      newCommits: ['fix: a later bug'],
       tags: ['v1.2.3', 'v1.3.0-beta.1', 'v1.3.0-beta.2']
     })
     expect(plan).toMatchObject({ version: '1.3.0-beta.3' })
+  })
+
+  it('does not increment a beta for non-bumping commits after it', () => {
+    const plan = computeVersion({
+      channel: 'beta',
+      lastGATag: 'v1.2.3',
+      commits: ['fix: a bug', 'chore: housekeeping'],
+      newCommits: ['chore: housekeeping'],
+      tags: ['v1.2.3', 'v1.2.4-beta.1']
+    })
+    expect(plan).toBeNull()
   })
 
   it('resets the beta counter when the target recomputes higher', () => {
@@ -93,6 +127,7 @@ describe('computeVersion', () => {
       channel: 'beta',
       lastGATag: 'v1.2.3',
       commits: ['feat: a feature'],
+      newCommits: ['feat: a feature'],
       tags: ['v1.2.3', 'v1.2.4-beta.1']
     })
     expect(plan).toMatchObject({ version: '1.3.0-beta.1' })
@@ -103,6 +138,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['fix: a fix', 'feat: a feature', 'chore: housekeeping'],
+      newCommits: ['fix: a fix', 'feat: a feature', 'chore: housekeeping'],
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '1.3.0', bump: 'minor' })
@@ -113,6 +149,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['chore: deps', 'doc: typo'],
+      newCommits: ['chore: deps', 'doc: typo'],
       tags: ['v1.2.3']
     })
     expect(plan).toBeNull()
@@ -126,6 +163,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['feat:'],
+      newCommits: ['feat:'],
       tags: ['v1.2.3']
     })
     expect(plan).toBeNull()
@@ -139,6 +177,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: 'v1.2.3',
       commits: ['fix: a fix\n\nBREAKING CHANGE: removed an API'],
+      newCommits: ['fix: a fix\n\nBREAKING CHANGE: removed an API'],
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '2.0.0', bump: 'major' })
@@ -149,6 +188,7 @@ describe('computeVersion', () => {
       channel: 'stable',
       lastGATag: null,
       commits: ['feat: first feature'],
+      newCommits: ['feat: first feature'],
       tags: []
     })
     expect(plan).toMatchObject({ version: '0.1.0', bump: 'minor' })
@@ -159,6 +199,7 @@ describe('computeVersion', () => {
       channel: 'beta',
       lastGATag: null,
       commits: ['feat: first feature'],
+      newCommits: ['feat: first feature'],
       tags: []
     })
     expect(plan).toEqual({

--- a/packages/scripts/compute-version.test.ts
+++ b/packages/scripts/compute-version.test.ts
@@ -4,6 +4,41 @@ import {
   selectLastGATag,
   selectLastReleaseTag
 } from './compute-version'
+import type { ReleaseHistoryEntry } from './lib/git'
+
+type FixtureEntry =
+  { type: 'commit'; message: string } | { type: 'release'; tag: string }
+
+const release = (tag: string): FixtureEntry => ({ type: 'release', tag })
+const commit = (message: string): FixtureEntry => ({ type: 'commit', message })
+
+function history(...entries: FixtureEntry[]): ReleaseHistoryEntry[] {
+  const commits: ReleaseHistoryEntry[] = []
+  for (const entry of entries) {
+    if (entry.type === 'release') {
+      const target = commits.at(-1)
+      if (target) {
+        target.tags.push(entry.tag)
+      } else {
+        commits.push({
+          hash: 'commit-0',
+          parents: [],
+          message: 'chore: initial release',
+          tags: [entry.tag]
+        })
+      }
+      continue
+    }
+
+    commits.push({
+      hash: `commit-${commits.length}`,
+      parents: commits.length > 0 ? [commits.at(-1)!.hash] : [],
+      message: entry.message,
+      tags: []
+    })
+  }
+  return commits
+}
 
 describe('selectLastGATag', () => {
   it('returns the highest GA tag, ignoring betas', () => {
@@ -36,6 +71,23 @@ describe('selectLastReleaseTag', () => {
     ).toBe('v1.2.4-beta.2')
   })
 
+  it('selects a stable release over its own betas', () => {
+    expect(
+      selectLastReleaseTag('beta', ['v1.2.3', 'v1.2.4-beta.1', 'v1.2.4'])
+    ).toBe('v1.2.4')
+  })
+
+  it('selects a beta for a higher target over the latest stable release', () => {
+    expect(selectLastReleaseTag('beta', ['v1.2.4', 'v1.3.0-beta.1'])).toBe(
+      'v1.3.0-beta.1'
+    )
+  })
+
+  it('returns null when no release tags exist', () => {
+    expect(selectLastReleaseTag('beta', [])).toBeNull()
+    expect(selectLastReleaseTag('stable', [])).toBeNull()
+  })
+
   it('selects the greatest GA tag for a stable release', () => {
     expect(selectLastReleaseTag('stable', ['v1.2.3', 'v1.2.4-beta.1'])).toBe(
       'v1.2.3'
@@ -47,12 +99,7 @@ describe('computeVersion', () => {
   it('bumps a patch for a fix commit on the stable channel', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['fix: a bug'],
-        sinceLastRelease: ['fix: a bug']
-      },
-      tags: ['v1.2.3']
+      history: history(release('v1.2.3'), commit('fix: a bug'))
     })
     expect(plan).toEqual({
       version: '1.2.4',
@@ -65,12 +112,7 @@ describe('computeVersion', () => {
   it('bumps a minor for a feat commit', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['feat: a feature'],
-        sinceLastRelease: ['feat: a feature']
-      },
-      tags: ['v1.2.3']
+      history: history(release('v1.2.3'), commit('feat: a feature'))
     })
     expect(plan).toMatchObject({ version: '1.3.0', bump: 'minor' })
   })
@@ -78,12 +120,10 @@ describe('computeVersion', () => {
   it('bumps a major (1.x -> 2.0.0) for a breaking commit', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['feat(scope)!: a breaking feature'],
-        sinceLastRelease: ['feat(scope)!: a breaking feature']
-      },
-      tags: ['v1.2.3']
+      history: history(
+        release('v1.2.3'),
+        commit('feat(scope)!: a breaking feature')
+      )
     })
     expect(plan).toMatchObject({ version: '2.0.0', bump: 'major' })
   })
@@ -91,12 +131,7 @@ describe('computeVersion', () => {
   it('computes the first beta for a target with no existing betas', () => {
     const plan = computeVersion({
       channel: 'beta',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['feat: a feature'],
-        sinceLastRelease: ['feat: a feature']
-      },
-      tags: ['v1.2.3']
+      history: history(release('v1.2.3'), commit('feat: a feature'))
     })
     expect(plan).toEqual({
       version: '1.3.0-beta.1',
@@ -109,12 +144,14 @@ describe('computeVersion', () => {
   it('increments the beta counter when a lower bump lands after it', () => {
     const plan = computeVersion({
       channel: 'beta',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['feat: a feature', 'fix: a later bug'],
-        sinceLastRelease: ['fix: a later bug']
-      },
-      tags: ['v1.2.3', 'v1.3.0-beta.1', 'v1.3.0-beta.2']
+      history: history(
+        release('v1.2.3'),
+        commit('feat: a feature'),
+        release('v1.3.0-beta.1'),
+        commit('fix: another bug'),
+        release('v1.3.0-beta.2'),
+        commit('fix: a later bug')
+      )
     })
     expect(plan).toMatchObject({ version: '1.3.0-beta.3' })
   })
@@ -122,44 +159,111 @@ describe('computeVersion', () => {
   it('does not increment a beta for non-bumping commits after it', () => {
     const plan = computeVersion({
       channel: 'beta',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['fix: a bug', 'chore: housekeeping'],
-        sinceLastRelease: ['chore: housekeeping']
-      },
-      tags: ['v1.2.3', 'v1.2.4-beta.1']
+      history: history(
+        release('v1.2.3'),
+        commit('fix: a bug'),
+        release('v1.2.4-beta.1'),
+        commit('chore: housekeeping')
+      )
     })
     expect(plan).toBeNull()
   })
 
+  it('promotes the cumulative beta target to stable', () => {
+    const plan = computeVersion({
+      channel: 'stable',
+      history: history(
+        release('v1.2.3'),
+        commit('fix: a bug'),
+        release('v1.2.4-beta.1'),
+        commit('chore: housekeeping')
+      )
+    })
+    expect(plan).toMatchObject({ version: '1.2.4', bump: 'patch' })
+  })
+
+  it('excludes every ancestor of the latest GA tag', () => {
+    const plan = computeVersion({
+      channel: 'stable',
+      history: history(
+        commit('feat!: already released'),
+        commit('chore: release prep'),
+        release('v2.0.0'),
+        commit('fix: a new bug')
+      )
+    })
+    expect(plan).toMatchObject({ version: '2.0.1', bump: 'patch' })
+  })
+
+  it('excludes ancestors from both sides of a tagged merge', () => {
+    const plan = computeVersion({
+      channel: 'stable',
+      history: [
+        { hash: 'root', parents: [], message: 'chore: initial', tags: [] },
+        {
+          hash: 'left',
+          parents: ['root'],
+          message: 'fix: released fix',
+          tags: []
+        },
+        {
+          hash: 'right',
+          parents: ['root'],
+          message: 'feat: released feature',
+          tags: []
+        },
+        {
+          hash: 'merge',
+          parents: ['left', 'right'],
+          message: 'chore: stable release',
+          tags: ['v2.0.0']
+        },
+        {
+          hash: 'head',
+          parents: ['merge'],
+          message: 'fix: a new bug',
+          tags: []
+        }
+      ]
+    })
+    expect(plan).toMatchObject({ version: '2.0.1', bump: 'patch' })
+  })
+
   it('resets the beta counter when the target recomputes higher', () => {
-    // A feat lands after a patch-beta (v1.2.4-beta.1): the target is now the
-    // minor v1.3.0, whose betas start fresh at 1.
     const plan = computeVersion({
       channel: 'beta',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['feat: a feature'],
-        sinceLastRelease: ['feat: a feature']
-      },
-      tags: ['v1.2.3', 'v1.2.4-beta.1']
+      history: history(
+        release('v1.2.3'),
+        commit('fix: a bug'),
+        release('v1.2.4-beta.1'),
+        commit('feat: a feature')
+      )
     })
     expect(plan).toMatchObject({ version: '1.3.0-beta.1' })
+  })
+
+  it('increments the beta counter when the same bump lands after it', () => {
+    const plan = computeVersion({
+      channel: 'beta',
+      history: history(
+        release('v1.2.3'),
+        commit('feat: first feature'),
+        release('v1.3.0-beta.1'),
+        commit('feat: second feature')
+      )
+    })
+    expect(plan).toMatchObject({ version: '1.3.0-beta.2' })
   })
 
   it('takes the highest bump across a mix of commits', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['fix: a fix', 'feat: a feature', 'chore: housekeeping'],
-        sinceLastRelease: [
-          'fix: a fix',
-          'feat: a feature',
-          'chore: housekeeping'
-        ]
-      },
-      tags: ['v1.2.3']
+      history: history(
+        release('v1.2.3'),
+        commit('fix: a fix'),
+        commit('feat: a feature'),
+        commit('chore: housekeeping')
+      )
     })
     expect(plan).toMatchObject({ version: '1.3.0', bump: 'minor' })
   })
@@ -167,41 +271,30 @@ describe('computeVersion', () => {
   it('returns null when no commit triggers a bump', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['chore: deps', 'doc: typo'],
-        sinceLastRelease: ['chore: deps', 'doc: typo']
-      },
-      tags: ['v1.2.3']
+      history: history(
+        release('v1.2.3'),
+        commit('chore: deps'),
+        commit('doc: typo')
+      )
     })
     expect(plan).toBeNull()
   })
 
   it('does not bump on a malformed subject with no description', () => {
-    // A conventional subject requires a description; a bare `feat:` (which
-    // commitlint's subject-empty rule rejects at commit time anyway) is not a
-    // valid bump trigger and must not produce a release.
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: { sinceLastGA: ['feat:'], sinceLastRelease: ['feat:'] },
-      tags: ['v1.2.3']
+      history: history(release('v1.2.3'), commit('feat:'))
     })
     expect(plan).toBeNull()
   })
 
-  it('major-bumps on a BREAKING CHANGE body footer even without a subject "!"', () => {
-    // Per Conventional Commits, the footer is an equivalent breaking trigger. A
-    // fix carrying the footer bumps major (1.x -> 2.0.0), so a footer-only break
-    // never silently ships as a patch.
+  it('major-bumps on a BREAKING CHANGE body footer without a subject "!"', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: 'v1.2.3',
-      commits: {
-        sinceLastGA: ['fix: a fix\n\nBREAKING CHANGE: removed an API'],
-        sinceLastRelease: ['fix: a fix\n\nBREAKING CHANGE: removed an API']
-      },
-      tags: ['v1.2.3']
+      history: history(
+        release('v1.2.3'),
+        commit('fix: a fix\n\nBREAKING CHANGE: removed an API')
+      )
     })
     expect(plan).toMatchObject({ version: '2.0.0', bump: 'major' })
   })
@@ -209,25 +302,15 @@ describe('computeVersion', () => {
   it('counts from 0.0.0 when there is no prior GA tag', () => {
     const plan = computeVersion({
       channel: 'stable',
-      lastGATag: null,
-      commits: {
-        sinceLastGA: ['feat: first feature'],
-        sinceLastRelease: ['feat: first feature']
-      },
-      tags: []
+      history: history(commit('feat: first feature'))
     })
     expect(plan).toMatchObject({ version: '0.1.0', bump: 'minor' })
   })
 
-  it('computes the first-ever beta (no GA tag, no betas) from 0.0.0', () => {
+  it('computes the first-ever beta from 0.0.0', () => {
     const plan = computeVersion({
       channel: 'beta',
-      lastGATag: null,
-      commits: {
-        sinceLastGA: ['feat: first feature'],
-        sinceLastRelease: ['feat: first feature']
-      },
-      tags: []
+      history: history(commit('feat: first feature'))
     })
     expect(plan).toEqual({
       version: '0.1.0-beta.1',

--- a/packages/scripts/compute-version.test.ts
+++ b/packages/scripts/compute-version.test.ts
@@ -48,8 +48,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['fix: a bug'],
-      newCommits: ['fix: a bug'],
+      commits: {
+        sinceLastGA: ['fix: a bug'],
+        sinceLastRelease: ['fix: a bug']
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toEqual({
@@ -64,8 +66,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['feat: a feature'],
-      newCommits: ['feat: a feature'],
+      commits: {
+        sinceLastGA: ['feat: a feature'],
+        sinceLastRelease: ['feat: a feature']
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '1.3.0', bump: 'minor' })
@@ -75,8 +79,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['feat(scope)!: a breaking feature'],
-      newCommits: ['feat(scope)!: a breaking feature'],
+      commits: {
+        sinceLastGA: ['feat(scope)!: a breaking feature'],
+        sinceLastRelease: ['feat(scope)!: a breaking feature']
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '2.0.0', bump: 'major' })
@@ -86,8 +92,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'beta',
       lastGATag: 'v1.2.3',
-      commits: ['feat: a feature'],
-      newCommits: ['feat: a feature'],
+      commits: {
+        sinceLastGA: ['feat: a feature'],
+        sinceLastRelease: ['feat: a feature']
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toEqual({
@@ -102,8 +110,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'beta',
       lastGATag: 'v1.2.3',
-      commits: ['feat: a feature', 'fix: a later bug'],
-      newCommits: ['fix: a later bug'],
+      commits: {
+        sinceLastGA: ['feat: a feature', 'fix: a later bug'],
+        sinceLastRelease: ['fix: a later bug']
+      },
       tags: ['v1.2.3', 'v1.3.0-beta.1', 'v1.3.0-beta.2']
     })
     expect(plan).toMatchObject({ version: '1.3.0-beta.3' })
@@ -113,8 +123,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'beta',
       lastGATag: 'v1.2.3',
-      commits: ['fix: a bug', 'chore: housekeeping'],
-      newCommits: ['chore: housekeeping'],
+      commits: {
+        sinceLastGA: ['fix: a bug', 'chore: housekeeping'],
+        sinceLastRelease: ['chore: housekeeping']
+      },
       tags: ['v1.2.3', 'v1.2.4-beta.1']
     })
     expect(plan).toBeNull()
@@ -126,8 +138,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'beta',
       lastGATag: 'v1.2.3',
-      commits: ['feat: a feature'],
-      newCommits: ['feat: a feature'],
+      commits: {
+        sinceLastGA: ['feat: a feature'],
+        sinceLastRelease: ['feat: a feature']
+      },
       tags: ['v1.2.3', 'v1.2.4-beta.1']
     })
     expect(plan).toMatchObject({ version: '1.3.0-beta.1' })
@@ -137,8 +151,14 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['fix: a fix', 'feat: a feature', 'chore: housekeeping'],
-      newCommits: ['fix: a fix', 'feat: a feature', 'chore: housekeeping'],
+      commits: {
+        sinceLastGA: ['fix: a fix', 'feat: a feature', 'chore: housekeeping'],
+        sinceLastRelease: [
+          'fix: a fix',
+          'feat: a feature',
+          'chore: housekeeping'
+        ]
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '1.3.0', bump: 'minor' })
@@ -148,8 +168,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['chore: deps', 'doc: typo'],
-      newCommits: ['chore: deps', 'doc: typo'],
+      commits: {
+        sinceLastGA: ['chore: deps', 'doc: typo'],
+        sinceLastRelease: ['chore: deps', 'doc: typo']
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toBeNull()
@@ -162,8 +184,7 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['feat:'],
-      newCommits: ['feat:'],
+      commits: { sinceLastGA: ['feat:'], sinceLastRelease: ['feat:'] },
       tags: ['v1.2.3']
     })
     expect(plan).toBeNull()
@@ -176,8 +197,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: 'v1.2.3',
-      commits: ['fix: a fix\n\nBREAKING CHANGE: removed an API'],
-      newCommits: ['fix: a fix\n\nBREAKING CHANGE: removed an API'],
+      commits: {
+        sinceLastGA: ['fix: a fix\n\nBREAKING CHANGE: removed an API'],
+        sinceLastRelease: ['fix: a fix\n\nBREAKING CHANGE: removed an API']
+      },
       tags: ['v1.2.3']
     })
     expect(plan).toMatchObject({ version: '2.0.0', bump: 'major' })
@@ -187,8 +210,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'stable',
       lastGATag: null,
-      commits: ['feat: first feature'],
-      newCommits: ['feat: first feature'],
+      commits: {
+        sinceLastGA: ['feat: first feature'],
+        sinceLastRelease: ['feat: first feature']
+      },
       tags: []
     })
     expect(plan).toMatchObject({ version: '0.1.0', bump: 'minor' })
@@ -198,8 +223,10 @@ describe('computeVersion', () => {
     const plan = computeVersion({
       channel: 'beta',
       lastGATag: null,
-      commits: ['feat: first feature'],
-      newCommits: ['feat: first feature'],
+      commits: {
+        sinceLastGA: ['feat: first feature'],
+        sinceLastRelease: ['feat: first feature']
+      },
       tags: []
     })
     expect(plan).toEqual({

--- a/packages/scripts/compute-version.ts
+++ b/packages/scripts/compute-version.ts
@@ -42,6 +42,23 @@ export function selectLastReleaseTag(
   return resolveRange({ channel, currentRef: 'HEAD', tags }).from
 }
 
+export function formatReleaseTrace(args: {
+  channel: Channel
+  lastGATag: string | null
+  lastReleaseTag: string | null
+  plan: ReleasePlan
+}): string {
+  return [
+    `Channel:      ${args.channel}`,
+    `Last GA:      ${args.lastGATag ?? '(none)'}`,
+    `Last release: ${args.lastReleaseTag ?? '(none)'}`,
+    `Bump:         ${args.plan.bump}`,
+    `Version:      ${args.plan.version}`,
+    `Tag:          ${args.plan.tag}`,
+    `Dist-tag:     ${args.plan.distTag}`
+  ].join('\n')
+}
+
 function highestBump(commits: string[]): Bump | null {
   let highest: Bump | null = null
   for (const commit of commits) {
@@ -134,14 +151,12 @@ function main(): void {
   // Human-readable trace on stderr; the caller routes stdout where it wants
   // (the workflow appends it to $GITHUB_OUTPUT).
   console.error(
-    [
-      `Channel:  ${env.CHANNEL}`,
-      `Last GA:  ${lastGATag ?? '(none)'}`,
-      `Bump:     ${plan.bump}`,
-      `Version:  ${plan.version}`,
-      `Tag:      ${plan.tag}`,
-      `Dist-tag: ${plan.distTag}`
-    ].join('\n')
+    formatReleaseTrace({
+      channel: env.CHANNEL,
+      lastGATag,
+      lastReleaseTag,
+      plan
+    })
   )
 
   // Machine-readable `key=value` lines on stdout (only what the workflow

--- a/packages/scripts/compute-version.ts
+++ b/packages/scripts/compute-version.ts
@@ -8,7 +8,12 @@ import {
   parseCommit
 } from './lib/conventional-commits.ts'
 import { git, readAllTags } from './lib/git.ts'
-import { bumpGA, greatestGATag, highestBetaNumber } from './lib/version.ts'
+import {
+  bumpGA,
+  greatestGATag,
+  greatestTag,
+  highestBetaNumber
+} from './lib/version.ts'
 
 export type Channel = 'stable' | 'beta'
 export type ReleasePlan = {
@@ -23,6 +28,15 @@ const RANKS: Record<Bump, number> = { major: 3, minor: 2, patch: 1 }
 // The highest GA tag (e.g. "v2.10.0"), ignoring -beta.* tags, or null when
 // there are none — the previous stable checkpoint.
 export const selectLastGATag = greatestGATag
+
+// Beta releases announce only changes since the latest published version,
+// while stable releases remain cumulative from the latest GA.
+export function selectLastReleaseTag(
+  channel: Channel,
+  tags: string[]
+): string | null {
+  return channel === 'beta' ? greatestTag(tags) : greatestGATag(tags)
+}
 
 function highestBump(commits: string[]): Bump | null {
   let highest: Bump | null = null
@@ -39,11 +53,14 @@ function highestBump(commits: string[]): Bump | null {
 export function computeVersion(args: {
   channel: Channel
   lastGATag: string | null
+  // The cumulative GA range determines the target version. The incremental
+  // release range decides whether there is anything new to publish.
   commits: string[]
+  newCommits: string[]
   tags: string[]
 }): ReleasePlan | null {
   const bump = highestBump(args.commits)
-  if (!bump) return null
+  if (!bump || !highestBump(args.newCommits)) return null
   const lastGA = args.lastGATag?.replace(/^v/, '') ?? '0.0.0'
   const targetGA = bumpGA(lastGA, bump)
 
@@ -79,11 +96,14 @@ function main(): void {
 
   const tags = readAllTags()
   const lastGATag = selectLastGATag(tags)
+  const lastReleaseTag = selectLastReleaseTag(env.CHANNEL, tags)
   const commits = readCommitsSince(lastGATag)
+  const newCommits = readCommitsSince(lastReleaseTag)
   const plan = computeVersion({
     channel: env.CHANNEL,
     lastGATag,
     commits,
+    newCommits,
     tags
   })
 
@@ -91,7 +111,7 @@ function main(): void {
     // Not a failure: signal "no release" so the workflow stops cleanly
     // (the ci/stage jobs gate on release=true) instead of going red.
     console.error(
-      `No version-bumping commits since ${lastGATag ?? 'the beginning'}. Nothing to release.`
+      `No version-bumping commits since ${lastReleaseTag ?? 'the beginning'}. Nothing to release.`
     )
     process.stdout.write('needsReleasing=false\n')
     return

--- a/packages/scripts/compute-version.ts
+++ b/packages/scripts/compute-version.ts
@@ -53,14 +53,16 @@ function highestBump(commits: string[]): Bump | null {
 export function computeVersion(args: {
   channel: Channel
   lastGATag: string | null
-  // The cumulative GA range determines the target version. The incremental
-  // release range decides whether there is anything new to publish.
-  commits: string[]
-  newCommits: string[]
+  commits: {
+    // The cumulative GA range determines the target version. The incremental
+    // release range decides whether there is anything new to publish.
+    sinceLastGA: string[]
+    sinceLastRelease: string[]
+  }
   tags: string[]
 }): ReleasePlan | null {
-  const bump = highestBump(args.commits)
-  if (!bump || !highestBump(args.newCommits)) return null
+  const bump = highestBump(args.commits.sinceLastGA)
+  if (!bump || !highestBump(args.commits.sinceLastRelease)) return null
   const lastGA = args.lastGATag?.replace(/^v/, '') ?? '0.0.0'
   const targetGA = bumpGA(lastGA, bump)
 
@@ -97,13 +99,13 @@ function main(): void {
   const tags = readAllTags()
   const lastGATag = selectLastGATag(tags)
   const lastReleaseTag = selectLastReleaseTag(env.CHANNEL, tags)
-  const commits = readCommitsSince(lastGATag)
-  const newCommits = readCommitsSince(lastReleaseTag)
   const plan = computeVersion({
     channel: env.CHANNEL,
     lastGATag,
-    commits,
-    newCommits,
+    commits: {
+      sinceLastGA: readCommitsSince(lastGATag),
+      sinceLastRelease: readCommitsSince(lastReleaseTag)
+    },
     tags
   })
 

--- a/packages/scripts/compute-version.ts
+++ b/packages/scripts/compute-version.ts
@@ -7,15 +7,19 @@ import {
   bumpForType,
   parseCommit
 } from './lib/conventional-commits.ts'
-import { git, readAllTags } from './lib/git.ts'
+import {
+  readReleaseHistory,
+  tagExists,
+  type ReleaseHistoryEntry
+} from './lib/git.ts'
 import {
   bumpGA,
+  type Channel,
   greatestGATag,
-  greatestTag,
-  highestBetaNumber
+  highestBetaNumber,
+  resolveRange
 } from './lib/version.ts'
 
-export type Channel = 'stable' | 'beta'
 export type ReleasePlan = {
   version: string
   tag: string
@@ -35,7 +39,7 @@ export function selectLastReleaseTag(
   channel: Channel,
   tags: string[]
 ): string | null {
-  return channel === 'beta' ? greatestTag(tags) : greatestGATag(tags)
+  return resolveRange({ channel, currentRef: 'HEAD', tags }).from
 }
 
 function highestBump(commits: string[]): Bump | null {
@@ -52,41 +56,49 @@ function highestBump(commits: string[]): Bump | null {
 
 export function computeVersion(args: {
   channel: Channel
-  lastGATag: string | null
-  commits: {
-    // The cumulative GA range determines the target version. The incremental
-    // release range decides whether there is anything new to publish.
-    sinceLastGA: string[]
-    sinceLastRelease: string[]
-  }
-  tags: string[]
+  history: ReleaseHistoryEntry[]
 }): ReleasePlan | null {
-  const bump = highestBump(args.commits.sinceLastGA)
-  if (!bump || !highestBump(args.commits.sinceLastRelease)) return null
-  const lastGA = args.lastGATag?.replace(/^v/, '') ?? '0.0.0'
+  const tags = args.history.flatMap(commit => commit.tags)
+  const lastGATag = selectLastGATag(tags)
+  const lastReleaseTag = selectLastReleaseTag(args.channel, tags)
+  const commitsSince = (tag: string | null): string[] => {
+    if (tag === null) {
+      return args.history.map(commit => commit.message)
+    }
+
+    const taggedCommit = args.history.find(commit => commit.tags.includes(tag))
+    if (!taggedCommit)
+      throw new Error(`Release tag ${tag} is missing from history`)
+
+    const commitsByHash = new Map(
+      args.history.map(commit => [commit.hash, commit])
+    )
+    const releasedCommits = new Set<string>()
+    const pending = [taggedCommit.hash]
+    while (pending.length > 0) {
+      const hash = pending.pop()
+      if (!hash || releasedCommits.has(hash)) continue
+      releasedCommits.add(hash)
+      pending.push(...(commitsByHash.get(hash)?.parents ?? []))
+    }
+
+    return args.history
+      .filter(commit => !releasedCommits.has(commit.hash))
+      .map(commit => commit.message)
+  }
+
+  const bump = highestBump(commitsSince(lastGATag))
+  if (!bump || !highestBump(commitsSince(lastReleaseTag))) return null
+  const lastGA = lastGATag?.replace(/^v/, '') ?? '0.0.0'
   const targetGA = bumpGA(lastGA, bump)
 
   if (args.channel === 'stable') {
     return { version: targetGA, tag: `v${targetGA}`, distTag: 'latest', bump }
   }
 
-  const next = highestBetaNumber(args.tags, targetGA) + 1
+  const next = highestBetaNumber(tags, targetGA) + 1
   const version = `${targetGA}-beta.${next}`
   return { version, tag: `v${version}`, distTag: 'beta', bump }
-}
-
-// --- IO layer (untested by design: the pure core above is the unit) -------
-
-// Commit messages reach the parser only through git's stdout — never a shell —
-// so a crafted message cannot inject commands. Each record is a full message
-// (subject + body, %B) split on \x1e, which cannot occur in a message: the body
-// is needed so a `BREAKING CHANGE:` footer triggers a major bump per the spec.
-function readCommitsSince(lastGATag: string | null): string[] {
-  const range = lastGATag ? `${lastGATag}..HEAD` : 'HEAD'
-  return git(['log', range, '--format=%B%x1e'])
-    .split('\x1e')
-    .map(record => record.trim())
-    .filter(Boolean)
 }
 
 function main(): void {
@@ -96,27 +108,27 @@ function main(): void {
     runtimeEnv: process.env
   })
 
-  const tags = readAllTags()
+  const history = readReleaseHistory()
+  const tags = history.flatMap(commit => commit.tags)
   const lastGATag = selectLastGATag(tags)
   const lastReleaseTag = selectLastReleaseTag(env.CHANNEL, tags)
   const plan = computeVersion({
     channel: env.CHANNEL,
-    lastGATag,
-    commits: {
-      sinceLastGA: readCommitsSince(lastGATag),
-      sinceLastRelease: readCommitsSince(lastReleaseTag)
-    },
-    tags
+    history
   })
 
   if (plan === null) {
     // Not a failure: signal "no release" so the workflow stops cleanly
-    // (the ci/stage jobs gate on release=true) instead of going red.
+    // (the jobs gate on needsReleasing=true) instead of going red.
     console.error(
       `No version-bumping commits since ${lastReleaseTag ?? 'the beginning'}. Nothing to release.`
     )
     process.stdout.write('needsReleasing=false\n')
     return
+  }
+
+  if (tagExists(plan.tag)) {
+    throw new Error(`Refusing to reuse existing release tag ${plan.tag}`)
   }
 
   // Human-readable trace on stderr; the caller routes stdout where it wants

--- a/packages/scripts/lib/commit-graph.test.ts
+++ b/packages/scripts/lib/commit-graph.test.ts
@@ -31,9 +31,9 @@ import {
   type PRClosingIssues,
   readCommits,
   type ReleaseGraphReader,
-  resolveChannel,
-  resolveRange
+  resolveChannel
 } from './commit-graph'
+import { resolveRange } from './version'
 
 // Build CommitRecord[] from raw messages, with placeholder SHA/author (PR-
 // sourced tests don't read them). For direct-commit assertions, construct
@@ -240,9 +240,9 @@ describe('extractTargetReferences', () => {
   })
 
   it('deduplicates and sorts ascending', () => {
-    expect(
-      extractTargetReferences('Closes #5\nFixes #2\nResolves #5')
-    ).toEqual([2, 5])
+    expect(extractTargetReferences('Closes #5\nFixes #2\nResolves #5')).toEqual(
+      [2, 5]
+    )
   })
 
   it('ignores a cross-repo owner/repo#N reference (this repo only)', () => {

--- a/packages/scripts/lib/commit-graph.ts
+++ b/packages/scripts/lib/commit-graph.ts
@@ -16,13 +16,12 @@
 // issues), so the drafted notes always list exactly what finalize comments on;
 // only the extra notes-only fields differ between them.
 //
-// Pure core (range resolution, PR-number extraction, channel detection,
+// Pure core (PR-number extraction, channel detection,
 // contributor collection) is unit-tested, and both discovery paths are tested
 // through an injected `ReleaseGraphReader`; the production reader (git log,
 // GitHub GraphQL) is thin glue and untested by design.
 
 import { z } from 'zod'
-import type { Channel } from '../compute-version.ts'
 import type {
   DirectCommitChange,
   ReleaseChanges,
@@ -35,11 +34,11 @@ import {
 } from './conventional-commits.ts'
 import { git, readAllTags } from './git.ts'
 import {
-  greatestTag,
+  type Channel,
   isBeta,
   isGA,
-  isValidSemver,
-  precedes
+  type Range,
+  resolveRange
 } from './version.ts'
 
 // --- Pure core: channel detection -----------------------------------------
@@ -56,42 +55,6 @@ export function resolveChannel(ref: string): Channel {
   throw new Error(
     `resolveChannel: "${ref}" is neither a GA (vX.Y.Z) nor a beta (vX.Y.Z-beta.N) tag`
   )
-}
-
-// --- Pure core: range resolution ------------------------------------------
-
-// The git range `(from, to]` to walk for a release. `from` is null for the
-// first-ever release (walk from the beginning of history).
-export type Range = { from: string | null; to: string }
-
-// Resolve the commit range a release covers, asymmetric by channel:
-//   - GA `vX`      → (previous GA tag, this]      cumulative; betas skipped.
-//   - beta `vX-..` → (greatest published tag, this]  incremental delta.
-// The tag graph is the announcement ledger: tags exist only for *published*
-// releases, so a staged-then-rejected beta leaves no checkpoint and its PRs
-// fold into the next published release (self-healing).
-//
-// `currentRef` is either a tag (finalize: the just-published tag, present in
-// `tags`) or the literal `HEAD` (draft: the tag does not exist yet, and HEAD
-// sits above every tag). The checkpoint is the semver-greatest candidate
-// strictly below `currentRef` — for GA, only GA tags are candidates (so
-// intervening betas are skipped); for beta, every published tag qualifies.
-export function resolveRange(args: {
-  channel: Channel
-  currentRef: string
-  tags: string[]
-}): Range {
-  const { channel, currentRef, tags } = args
-  const candidates = tags.filter(tag =>
-    channel === 'stable' ? isGA(tag) : isValidSemver(tag)
-  )
-  // HEAD is above every tag, so every candidate is "below" it; a real tag is
-  // compared by semver precedence (which also excludes the tag itself).
-  const below =
-    currentRef === 'HEAD'
-      ? candidates
-      : candidates.filter(tag => precedes(tag, currentRef))
-  return { from: greatestTag(below), to: currentRef }
 }
 
 // --- Pure core: PR-number extraction --------------------------------------

--- a/packages/scripts/lib/git.test.ts
+++ b/packages/scripts/lib/git.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readAllTags, readReleaseHistory, tagExists } from './git'
+
+vi.mock('node:child_process')
+
+const execFileSyncMock = vi.mocked(execFileSync)
+
+beforeEach(() => {
+  execFileSyncMock.mockReset()
+})
+
+describe('readAllTags', () => {
+  it('only reads version tags merged into origin/next', () => {
+    execFileSyncMock.mockReturnValue('v1.2.3\nv1.2.4-beta.1\n')
+
+    expect(readAllTags()).toEqual(['v1.2.3', 'v1.2.4-beta.1'])
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'git',
+      ['tag', '--list', 'v*', '--merged', 'origin/next'],
+      { encoding: 'utf8' }
+    )
+  })
+})
+
+describe('readReleaseHistory', () => {
+  it('reads one commit graph with tags attached to their commits', () => {
+    execFileSyncMock.mockReturnValue(
+      [
+        'c3',
+        'c2',
+        'feat: a feature',
+        '',
+        'c2',
+        'c1',
+        'fix: a bug',
+        'tag: refs/tags/v1.2.4, tag: refs/tags/v1.2.4-beta.1',
+        'c1',
+        '',
+        'chore: initial',
+        'tag: refs/tags/v1.2.3',
+        ''
+      ].join('\x00')
+    )
+
+    expect(readReleaseHistory()).toEqual([
+      {
+        hash: 'c3',
+        parents: ['c2'],
+        message: 'feat: a feature',
+        tags: []
+      },
+      {
+        hash: 'c2',
+        parents: ['c1'],
+        message: 'fix: a bug',
+        tags: ['v1.2.4', 'v1.2.4-beta.1']
+      },
+      {
+        hash: 'c1',
+        parents: [],
+        message: 'chore: initial',
+        tags: ['v1.2.3']
+      }
+    ])
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'git',
+      [
+        'log',
+        '-z',
+        'HEAD',
+        '--decorate=full',
+        '--decorate-refs=refs/tags/v*',
+        '--format=%H%x00%P%x00%B%x00%D'
+      ],
+      { encoding: 'utf8' }
+    )
+  })
+
+  it('rejects malformed git log output', () => {
+    execFileSyncMock.mockReturnValue('hash\x00parent\x00message')
+    expect(() => readReleaseHistory()).toThrow(
+      'Unexpected git log record shape'
+    )
+  })
+})
+
+describe('tagExists', () => {
+  it('checks every local tag, including tags outside next', () => {
+    execFileSyncMock.mockReturnValue('v1.2.4-beta.1\n')
+    expect(tagExists('v1.2.4-beta.1')).toBe(true)
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'git',
+      ['tag', '--list', 'v1.2.4-beta.1'],
+      { encoding: 'utf8' }
+    )
+  })
+})

--- a/packages/scripts/lib/git.ts
+++ b/packages/scripts/lib/git.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from 'node:child_process'
 
+export type ReleaseHistoryEntry = {
+  hash: string
+  parents: string[]
+  message: string
+  tags: string[]
+}
+
 // Shared, privileged git boundary for the release scripts.
 //
 // execFileSync (no shell): git arguments and commit content are never subject
@@ -10,10 +17,56 @@ export function git(args: string[]): string {
   return execFileSync('git', args, { encoding: 'utf8' })
 }
 
-// All version tags (`vX.Y.Z` and `vX.Y.Z-beta.N`), trimmed, unsorted.
+// Version tags (`vX.Y.Z` and `vX.Y.Z-beta.N`) reachable from the release
+// branch, trimmed and unsorted. Tags from unrelated branches are not release
+// checkpoints for nuqs.
 export function readAllTags(): string[] {
-  return git(['tag', '--list', 'v*'])
+  return git(['tag', '--list', 'v*', '--merged', 'origin/next'])
     .split('\n')
     .map(line => line.trim())
     .filter(Boolean)
+}
+
+export function tagExists(tag: string): boolean {
+  return git(['tag', '--list', tag])
+    .split('\n')
+    .some(candidate => candidate === tag)
+}
+
+// Read the checked-out release snapshot as a commit graph. Tags stay attached to
+// their commits, so consumers derive every range from one source of truth.
+export function readReleaseHistory(repository?: string): ReleaseHistoryEntry[] {
+  const args = [
+    'log',
+    '-z',
+    'HEAD',
+    '--decorate=full',
+    '--decorate-refs=refs/tags/v*',
+    '--format=%H%x00%P%x00%B%x00%D'
+  ]
+  const fields = git(repository ? ['-C', repository, ...args] : args).split(
+    '\x00'
+  )
+  if (fields.at(-1) === '') fields.pop()
+  if (fields.length % 4 !== 0) {
+    throw new Error('Unexpected git log record shape')
+  }
+
+  const history: ReleaseHistoryEntry[] = []
+  for (let index = 0; index < fields.length; index += 4) {
+    const hash = fields[index]!
+    const parents = fields[index + 1]!
+    const message = fields[index + 2]!
+    const decorations = fields[index + 3]!
+    history.push({
+      hash,
+      parents: parents ? parents.split(' ') : [],
+      message: message.trim(),
+      tags: decorations
+        .split(', ')
+        .map(decoration => decoration.replace(/^tag: refs\/tags\//, ''))
+        .filter(tag => tag.startsWith('v'))
+    })
+  }
+  return history
 }

--- a/packages/scripts/lib/version.ts
+++ b/packages/scripts/lib/version.ts
@@ -1,6 +1,9 @@
 import semver from 'semver'
 import type { Bump } from './conventional-commits.ts'
 
+export type Channel = 'stable' | 'beta'
+export type Range = { from: string | null; to: string }
+
 // The single version vocabulary the release tools speak. semver is an
 // implementation detail held behind this boundary: callers reason about tags,
 // GA/beta channels, and precedence — never semver primitives. The lone leak is
@@ -46,6 +49,28 @@ export function greatestTag(tags: string[]): string | null {
 // The greatest GA tag, ignoring betas — i.e. the previous stable checkpoint.
 export function greatestGATag(tags: string[]): string | null {
   return greatestTag(tags.filter(isGA))
+}
+
+// Resolve the commit range a release covers, asymmetric by channel:
+//   - GA `vX`      → (previous GA tag, this]          cumulative; betas skipped.
+//   - beta `vX-..` → (greatest published tag, this]  incremental delta.
+// Tags are publication checkpoints. A staged but rejected beta has no tag and
+// therefore folds into the next published release. `currentRef` is either HEAD
+// during the draft or the new tag during finalization.
+export function resolveRange(args: {
+  channel: Channel
+  currentRef: string
+  tags: string[]
+}): Range {
+  const { channel, currentRef, tags } = args
+  const candidates = tags.filter(tag =>
+    channel === 'stable' ? isGA(tag) : isValidSemver(tag)
+  )
+  const below =
+    currentRef === 'HEAD'
+      ? candidates
+      : candidates.filter(tag => precedes(tag, currentRef))
+  return { from: greatestTag(below), to: currentRef }
 }
 
 // The highest existing -beta.N for an exact GA target (e.g. '1.3.0'), or 0 when

--- a/packages/scripts/release-finalize.ts
+++ b/packages/scripts/release-finalize.ts
@@ -4,7 +4,7 @@ import type { ThrottlingOptions } from '@octokit/plugin-throttling'
 import { createEnv } from '@t3-oss/env-core'
 import { Octokit, RequestError } from 'octokit'
 import { z } from 'zod'
-import type { Channel } from './compute-version.ts'
+import type { Channel } from './lib/version.ts'
 import {
   type Discussion,
   discoverTargets,
@@ -288,13 +288,16 @@ function collectTargets(
   discussions: Discussion[]
 ): Target[] {
   return [
-    ...changes.map(
-      ({ prNumber }): Target => ({ kind: 'PR', number: prNumber })
-    ),
+    ...changes.map(({ prNumber }): Target => ({
+      kind: 'PR',
+      number: prNumber
+    })),
     ...issues.map((number): Target => ({ kind: 'issue', number })),
-    ...discussions.map(
-      ({ number, id }): Target => ({ kind: 'discussion', number, id })
-    )
+    ...discussions.map(({ number, id }): Target => ({
+      kind: 'discussion',
+      number,
+      id
+    }))
   ]
 }
 


### PR DESCRIPTION
## Summary

- decide whether a beta release is needed from commits after the greatest published tag
- keep the target version cumulative from the latest GA tag
- preserve stable promotion and beta target escalation behavior

## Regression

The beta draft at [run 33743390115](https://github.com/47ng/nuqs/actions/runs/33743390115/job/100610253957) proposed `v2.10.2-beta.2` even though every commit after `v2.10.2-beta.1` was non-bumping. The calculator reused the `fix:` commit that had already produced `beta.1` because it used the latest GA for both version targeting and release detection.

With this change, the same repository history returns:

```text
No version-bumping commits since v2.10.2-beta.1. Nothing to release.
needsReleasing=false
```

Stable calculation still returns `v2.10.2` for the same history.

## Testing

- `pnpm exec turbo run test --filter scripts --force --concurrency=1`, 322 tests passed plus type checking
- `pnpm lint`
- exact-history checks for beta skip and stable promotion
- `pnpm test --concurrency=1` reached the unrelated Next.js E2E suite, where 6 of 582 tests timed out; a fresh forced `e2e-next` run reproduced 6 timeouts. This change only touches `packages/scripts`.
