### PR TITLE
test(next): cover cached page reveal on Back

### DIFF
--- a/packages/e2e/next/specs/activity-reveal.spec.ts
+++ b/packages/e2e/next/specs/activity-reveal.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test'
+import { expectUrl } from 'e2e-shared/playwright/expect-url.ts'
+import { assertLogCount, setupLogSpy } from 'e2e-shared/playwright/log-spy.ts'
+import { navigateTo } from 'e2e-shared/playwright/navigate.ts'
+
+test('a cached memoized page reads its Back destination before committing', async ({
+  page
+}) => {
+  test.skip(
+    process.env.CACHE_COMPONENTS !== 'true',
+    'requires Next.js Cache Components'
+  )
+  using logSpy = setupLogSpy(page)
+  const path = '/app/key-isolation/activity-reveal/a'
+  const value = page.locator('#activity-value')
+  const retained = page.locator('#client-activity-retained')
+
+  await navigateTo(page, path, '?name=fresh-value')
+  await expect(value).toHaveText('fresh-value')
+  await page.getByRole('button', { name: 'Mark retained' }).click()
+  await expect(retained).toHaveText('true')
+
+  await page.getByRole('button', { name: 'Set stale' }).click()
+  await expectUrl(page, url => url.searchParams.get('name') === 'stale-value')
+  await expect(value).toHaveText('stale-value')
+
+  await page.getByRole('link', { name: 'Go to B' }).click()
+  await expectUrl(
+    page,
+    url =>
+      url.pathname.endsWith('/activity-reveal/b') &&
+      url.searchParams.get('name') === 'stale-value'
+  )
+  await expect(value).toHaveCount(1)
+  await expect(value).toBeHidden()
+  await expect(value).toHaveText('stale-value')
+  await expect(retained).toBeHidden()
+  await expect(retained).toHaveText('true')
+
+  logSpy.logs.length = 0
+  await page.goBack()
+  await expectUrl(
+    page,
+    url =>
+      url.pathname.endsWith('/activity-reveal/a') &&
+      url.searchParams.get('name') === 'fresh-value'
+  )
+  await expect
+    .poll(
+      () =>
+        logSpy.logs.filter(line => line === 'activity commit: fresh-value')
+          .length
+    )
+    .toBeGreaterThan(0)
+  await expect(value).toBeVisible()
+  await expect(value).toHaveText('fresh-value')
+  await expect(retained).toBeVisible()
+  await expect(retained).toHaveText('true')
+  await assertLogCount(
+    logSpy,
+    'activity commit: stale-value',
+    0,
+    'retained page must not commit its stale snapshot when revealed'
+  )
+})

--- a/packages/e2e/next/src/app/app/key-isolation/activity-reveal/a/page.tsx
+++ b/packages/e2e/next/src/app/app/key-isolation/activity-reveal/a/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Display } from 'e2e-shared/components/display'
+import Link from 'next/link'
+import { useQueryState } from 'nuqs'
+import { memo, Suspense, useEffect, useState } from 'react'
+
+const Page = memo(function Page() {
+  const [name, setName] = useQueryState('name', { history: 'push' })
+  const [retained, setRetained] = useState(false)
+
+  useEffect(() => {
+    console.log(`activity commit: ${name ?? '<null>'}`)
+  })
+
+  return (
+    <>
+      <code id="activity-value">{name}</code>
+      <Display
+        environment="client"
+        target="activity-retained"
+        state={String(retained)}
+      />
+      <button onClick={() => setRetained(true)}>Mark retained</button>
+      <button onClick={() => setName('stale-value')}>Set stale</button>
+      <Link
+        href="/app/key-isolation/activity-reveal/b?name=stale-value"
+        replace
+        prefetch={false}
+      >
+        Go to B
+      </Link>
+    </>
+  )
+})
+
+export default function Root() {
+  return (
+    <Suspense>
+      <Page />
+    </Suspense>
+  )
+}

--- a/packages/e2e/next/src/app/app/key-isolation/activity-reveal/b/page.tsx
+++ b/packages/e2e/next/src/app/app/key-isolation/activity-reveal/b/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Other page</p>
+}


### PR DESCRIPTION
## Summary

Adds a deterministic Next.js App Router E2E regression test for a memoized page retained by Cache Components while another route is visible.

On browser Back, the destination pathname and search params arrive with the reveal. The retained page must read those destination params before its first visible commit.

Related to #1485 and #1573.

## Changes

- Add retained memoized A/B routes under the key-isolation layout.
- Disable link prefetching so the hidden page cannot learn the destination early.
- Preserve local state to prove that Back reveals the retained page rather than remounting it.
- Capture every effect commit and reject any stale commit during reveal.

## Verification

- `CACHE_COMPONENTS=true REACT_COMPILER=true`: passes on #1485 head.
- Reverse-applying `ea3c9160` and `de7ca531`: fails with one `activity commit: stale-value`.
- Normal Next.js build without Cache Components passes with React Compiler enabled.
- Prettier and `git diff --check` pass.

This is a test-only draft. It targets #1485's branch so the diff stays isolated to the reproduction.
