### PR TITLE
doc: address Vercel Doctor findings

### DIFF
--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -16,6 +16,7 @@ const config = {
   },
   reactCompiler: true,
   experimental: {
+    turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true
   },
   reactStrictMode: true,

--- a/packages/docs/src/app/api/isr/route.ts
+++ b/packages/docs/src/app/api/isr/route.ts
@@ -25,8 +25,6 @@ export async function GET(req: NextRequest) {
   // Reject a missing/empty configured token outright, so an unset ISR_TOKEN
   // can't be matched by an empty `?token=`.
   if (!expected || !token || !tokensMatch(token, expected)) {
-    // Log the requested token for analysis (sliced to avoid flooding logs)
-    console.log('Invalid token `%s`', token?.slice(0, 256))
     return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
   }
   // Accept one or more `tag` params so a single call can bust several tags

--- a/packages/docs/src/components/link-tree.tsx
+++ b/packages/docs/src/components/link-tree.tsx
@@ -14,7 +14,7 @@ export function LinkTreeItem({ href, icon, label, detail }: LinkTreeItemProps) {
   const isLocalRoute = href.startsWith('/')
   const Component = isLocalRoute ? Link : 'a'
   const props = isLocalRoute
-    ? { href }
+    ? { href, prefetch: false }
     : { href, target: '_blank', rel: 'noopener noreferrer' }
   return (
     <li>

--- a/packages/docs/src/components/link-tree.tsx
+++ b/packages/docs/src/components/link-tree.tsx
@@ -12,6 +12,10 @@ export type LinkTreeItemProps = {
 
 export function LinkTreeItem({ href, icon, label, detail }: LinkTreeItemProps) {
   const isLocalRoute = href.startsWith('/')
+  const Component = isLocalRoute ? Link : 'a'
+  const props = isLocalRoute
+    ? { href }
+    : { href, target: '_blank', rel: 'noopener noreferrer' }
   return (
     <li>
       <Button
@@ -21,11 +25,7 @@ export function LinkTreeItem({ href, icon, label, detail }: LinkTreeItemProps) {
           'flex w-full items-center justify-start gap-3 py-6 text-base transition-all active:scale-[0.99]'
         )}
       >
-        <Link
-          href={href}
-          target={isLocalRoute ? undefined : '_blank'}
-          rel={isLocalRoute ? undefined : 'noopener noreferrer'}
-        >
+        <Component {...props}>
           {icon}
           <span className="justify-self-center">{label}</span>
           {detail && (
@@ -33,7 +33,7 @@ export function LinkTreeItem({ href, icon, label, detail }: LinkTreeItemProps) {
               {detail}
             </span>
           )}
-        </Link>
+        </Component>
       </Button>
     </li>
   )

--- a/packages/docs/src/components/typography.tsx
+++ b/packages/docs/src/components/typography.tsx
@@ -1,6 +1,5 @@
 import { cn } from '@/src/lib/utils'
 import { Link } from 'lucide-react'
-import NextLink from 'next/link'
 import { ComponentProps } from 'react'
 
 export function H1({ children, className, ...props }: ComponentProps<'h1'>) {
@@ -15,12 +14,12 @@ export function H1({ children, className, ...props }: ComponentProps<'h1'>) {
     >
       {props.id ? (
         <>
-          <NextLink
+          <a
             href={`#${props.id}`}
             className="peer font-extrabold no-underline hover:opacity-100"
           >
             {children}
-          </NextLink>
+          </a>
           <Link
             className="text-fd-muted-foreground size-3.5 shrink-0 opacity-0 transition-opacity peer-hover:opacity-100"
             aria-label="Link to section"
@@ -45,12 +44,12 @@ export function H2({ children, className, ...props }: ComponentProps<'h2'>) {
     >
       {props.id ? (
         <>
-          <NextLink
+          <a
             href={`#${props.id}`}
             className="peer font-semibold no-underline hover:opacity-100"
           >
             {children}
-          </NextLink>
+          </a>
           <Link
             className="text-fd-muted-foreground size-3.5 shrink-0 opacity-0 transition-opacity peer-hover:opacity-100"
             aria-label="Link to section"

--- a/packages/docs/src/components/ui/pagination.tsx
+++ b/packages/docs/src/components/ui/pagination.tsx
@@ -74,6 +74,7 @@ const PaginationLink = ({
 }: PaginationLinkProps) => (
   <Link
     aria-current={isActive ? 'page' : undefined}
+    prefetch={false}
     className={cn(
       buttonVariants({
         variant: isActive ? 'outline' : 'ghost',

--- a/packages/docs/vercel-doctor.config.json
+++ b/packages/docs/vercel-doctor.config.json
@@ -1,0 +1,15 @@
+{
+  "ignore": {
+    "rules": ["vercel-doctor/vercel-consider-bun-runtime"],
+    "files": [
+      "src/app/playground/_demos/**",
+      "src/app/(pages)/stats/page.tsx",
+      "src/components/anchored-details.tsx",
+      "src/components/anchored-tabs.tsx",
+      "src/components/release-contribution-graph.tsx",
+      "src/components/vercel-oss-badge.tsx",
+      "src/lib/remark-audience.ts"
+    ]
+  },
+  "diff": false
+}


### PR DESCRIPTION
## Summary

- tighten link semantics and disable prefetch for dynamic pagination links
- enable Turbopack build caching explicitly and add targeted Vercel Doctor exclusions
- stop logging ISR tokens while preserving the existing GitHub Actions response behavior

## Vercel Doctor

The docs scan drops from 38 to 25 warnings. The remaining findings are intentional:

- 20 large static assets that require a separate hosting or asset decision
- 4 useful default-prefetch links for primary/static navigation
- 1 cache-policy warning for the curl-only ISR invalidation endpoint

The project remains on Node.js. The Bun recommendation is explicitly ignored.

## Verification

- `pnpm run test --filter docs` — 139 tests passed
- `pnpm run build --filter docs` — 97 pages generated
- `pnpm exec knip --workspace packages/docs`
- `pnpm --filter docs exec prettier --write next.config.mjs vercel-doctor.config.json src/app/api/isr/route.ts src/components/link-tree.tsx src/components/typography.tsx src/components/ui/pagination.tsx`
- `git diff --check`
- `pnpm dlx vercel-doctor@1.2.0 . --yes --verbose --offline --output json`
