### PR TITLE
fix: preserve history through React Router blockers

### DIFF
--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -315,24 +315,6 @@ export default function App() {
 
 </Callout>
 
-### Navigation blockers (v6, v7, v8) [#react-router-blockers]
-
-If your app asks for confirmation before navigation, note that nuqs updates the
-URL and query state before React Router checks `useBlocker`.
-In data routers, [`shallow: false{:ts}`](/docs/options#shallow) updates can trigger
-that blocker. Calling `blocker.reset(){:ts}` cancels the router navigation, but
-keeps the query state and URL update, including any new history entry.
-Calling `blocker.proceed(){:ts}` lets the router run its loaders.
-
-Shallow updates do not call the router or trigger its blockers.
-
-<Callout type="warn" title="History limits">
-  Do not rely on `useBlocker` to protect unsaved work across all nuqs history
-  updates. After a shallow push with no pending deep navigation, the first
-  blocked Back can reload the page. This can also happen if the router commits
-  a pending deep push as a replace.
-</Callout>
-
 ## <HumanContent><TanStackRouter className='inline mr-2 -mt-1 not-prose' aria-hidden /></HumanContent>TanStack Router [#tanstack-router]
 
 ```tsx title="src/routes/__root.tsx"

--- a/packages/docs/content/docs/adapters.mdx
+++ b/packages/docs/content/docs/adapters.mdx
@@ -315,6 +315,24 @@ export default function App() {
 
 </Callout>
 
+### Navigation blockers (v6, v7, v8) [#react-router-blockers]
+
+If your app asks for confirmation before navigation, note that nuqs updates the
+URL and query state before React Router checks `useBlocker`.
+In data routers, [`shallow: false{:ts}`](/docs/options#shallow) updates can trigger
+that blocker. Calling `blocker.reset(){:ts}` cancels the router navigation, but
+keeps the query state and URL update, including any new history entry.
+Calling `blocker.proceed(){:ts}` lets the router run its loaders.
+
+Shallow updates do not call the router or trigger its blockers.
+
+<Callout type="warn" title="History limits">
+  Do not rely on `useBlocker` to protect unsaved work across all nuqs history
+  updates. After a shallow push with no pending deep navigation, the first
+  blocked Back can reload the page. This can also happen if the router commits
+  a pending deep push as a replace.
+</Callout>
+
 ## <HumanContent><TanStackRouter className='inline mr-2 -mt-1 not-prose' aria-hidden /></HumanContent>TanStack Router [#tanstack-router]
 
 ```tsx title="src/routes/__root.tsx"

--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -273,6 +273,14 @@ function Search() {
 }
 ```
 
+<Callout title="React Router and Remix redirects">
+  If a loader redirects a `shallow: false{:ts}` query update to a different URL
+  with the same history mode (`push` or `replace`), nuqs cancels queued debounced
+  edits. They will not write onto the redirect URL after their delay.
+  If the loader completes at its requested URL, queued edits keep their delay
+  and can still write to the URL.
+</Callout>
+
 ### Resetting
 
 You can use the `defaultRateLimit{:ts}` import to reset debouncing or throttling to

--- a/packages/e2e/react-router/v6/specs/blocker.spec.ts
+++ b/packages/e2e/react-router/v6/specs/blocker.spec.ts
@@ -1,0 +1,7 @@
+import {
+  testBlocker,
+  testBlockerWithoutLoader
+} from 'e2e-shared/specs/react-router/blocker.spec.ts'
+
+testBlocker({ path: '/blocker' })
+testBlockerWithoutLoader({ path: '/blocker-no-loader' })

--- a/packages/e2e/react-router/v6/specs/pending-loader.spec.ts
+++ b/packages/e2e/react-router/v6/specs/pending-loader.spec.ts
@@ -1,0 +1,3 @@
+import { testPendingLoader } from 'e2e-shared/specs/react-router/pending-loader.spec.ts'
+
+testPendingLoader({ path: '/pending-loader' })

--- a/packages/e2e/react-router/v6/specs/pending-push.spec.ts
+++ b/packages/e2e/react-router/v6/specs/pending-push.spec.ts
@@ -1,0 +1,3 @@
+import { testPendingPush } from 'e2e-shared/specs/react-router/pending-push.spec.ts'
+
+testPendingPush({ path: '/pending-loader' })

--- a/packages/e2e/react-router/v6/specs/repro-1563.spec.ts
+++ b/packages/e2e/react-router/v6/specs/repro-1563.spec.ts
@@ -1,5 +1,12 @@
-import { testRepro1563 } from 'e2e-shared/specs/react-router/repro-1563.spec.ts'
+import {
+  testRepro1563,
+  testRepro1563Link
+} from 'e2e-shared/specs/react-router/repro-1563.spec.ts'
 
 testRepro1563({
+  path: '/repro-1563'
+})
+
+testRepro1563Link({
   path: '/repro-1563'
 })

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -48,6 +48,7 @@ const router = createBrowserRouter(
       <Route path="scroll"                                    lazy={load(import('./routes/scroll'))} />
 
       {/* Local tests */}
+      <Route path="pending-loader"                           lazy={load(import('./routes/pending-loader'))} />
       <Route path="blocker"                                  lazy={load(import('./routes/blocker'))} />
       <Route path="blocker-no-loader"                        lazy={load(import('./routes/blocker.no-loader'))} />
       <Route path="debounce"                                  lazy={load(import('./routes/debounce'))} />

--- a/packages/e2e/react-router/v6/src/react-router.tsx
+++ b/packages/e2e/react-router/v6/src/react-router.tsx
@@ -48,6 +48,8 @@ const router = createBrowserRouter(
       <Route path="scroll"                                    lazy={load(import('./routes/scroll'))} />
 
       {/* Local tests */}
+      <Route path="blocker"                                  lazy={load(import('./routes/blocker'))} />
+      <Route path="blocker-no-loader"                        lazy={load(import('./routes/blocker.no-loader'))} />
       <Route path="debounce"                                  lazy={load(import('./routes/debounce'))} />
       <Route path="debounce/other"                            lazy={load(import('./routes/debounce.other'))} />
       <Route path="dynamic-segments/catch-all?*"              lazy={load(import('./routes/dynamic-segments.catch-all.$'))} />

--- a/packages/e2e/react-router/v6/src/routes/blocker.no-loader.tsx
+++ b/packages/e2e/react-router/v6/src/routes/blocker.no-loader.tsx
@@ -1,0 +1,1 @@
+export { default } from './blocker'

--- a/packages/e2e/react-router/v6/src/routes/blocker.tsx
+++ b/packages/e2e/react-router/v6/src/routes/blocker.tsx
@@ -1,0 +1,22 @@
+import { Blocker } from 'e2e-shared/specs/react-router/blocker'
+import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
+import {
+  useBlocker,
+  useNavigate,
+  useNavigation,
+  type LoaderFunctionArgs
+} from 'react-router-dom'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return delayedLoader(request)
+}
+
+export default function Page() {
+  return (
+    <Blocker
+      useBlocker={useBlocker}
+      useNavigation={useNavigation}
+      useNavigate={useNavigate}
+    />
+  )
+}

--- a/packages/e2e/react-router/v6/src/routes/blocker.tsx
+++ b/packages/e2e/react-router/v6/src/routes/blocker.tsx
@@ -1,6 +1,8 @@
 import { Blocker } from 'e2e-shared/specs/react-router/blocker'
 import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
 import {
+  Form,
+  Link,
   useBlocker,
   useNavigate,
   useNavigation,
@@ -11,12 +13,24 @@ export function loader({ request }: LoaderFunctionArgs) {
   return delayedLoader(request)
 }
 
+export { loader as action }
+
 export default function Page() {
   return (
-    <Blocker
-      useBlocker={useBlocker}
-      useNavigation={useNavigation}
-      useNavigate={useNavigate}
-    />
+    <>
+      <Link id="router-slow-link" to="?count=3&delay=1000">
+        Slow router Link
+      </Link>
+      <Form method="post" action="?count=3&delay=1000">
+        <button id="router-slow-submit" type="submit">
+          Slow router submission
+        </button>
+      </Form>
+      <Blocker
+        useBlocker={useBlocker}
+        useNavigation={useNavigation}
+        useNavigate={useNavigate}
+      />
+    </>
   )
 }

--- a/packages/e2e/react-router/v6/src/routes/pending-loader.tsx
+++ b/packages/e2e/react-router/v6/src/routes/pending-loader.tsx
@@ -1,0 +1,17 @@
+import { PendingLoader } from 'e2e-shared/specs/react-router/pending-loader'
+import { controlledLoader } from 'e2e-shared/specs/react-router/pending-loader.defs'
+import { useBlocker, useLoaderData, useNavigation } from 'react-router-dom'
+
+export const loader = controlledLoader
+
+export default function Page() {
+  const data = useLoaderData() as Awaited<ReturnType<typeof loader>>
+  const navigation = useNavigation()
+  return (
+    <PendingLoader
+      data={data}
+      navigationState={navigation.state}
+      useBlocker={useBlocker}
+    />
+  )
+}

--- a/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v6/src/routes/repro-1563.tsx
@@ -2,6 +2,9 @@ import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { countLoaderCall } from 'e2e-shared/specs/react-router/repro-1563.defs'
 import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
 import {
+  Link,
+  redirect,
+  useBlocker,
   type LoaderFunctionArgs,
   useLoaderData,
   useNavigate,
@@ -12,17 +15,36 @@ import {
 export async function loader({ request }: LoaderFunctionArgs) {
   const call = countLoaderCall(request)
   await delayedLoader(request)
-  return call
+  const url = new URL(request.url)
+  if (
+    url.searchParams.has('redirect') &&
+    url.searchParams.get('test') === 'pass'
+  ) {
+    url.searchParams.set('test', 'redirected')
+    url.searchParams.delete('delay')
+    throw redirect('/repro-1563' + url.search)
+  }
+  return { call, state: url.searchParams.get('test') }
 }
 
 export default function Page() {
-  const loaderCall = useLoaderData() as Awaited<ReturnType<typeof loader>>
+  const { call, state } = useLoaderData() as Awaited<ReturnType<typeof loader>>
   return (
-    <Repro1563
-      loaderCall={loaderCall}
-      useNavigate={useNavigate}
-      useNavigation={useNavigation}
-      useNavigationType={useNavigationType}
-    />
+    <>
+      <Repro1563
+        loaderCall={call}
+        loaderState={state}
+        useBlocker={useBlocker}
+        useNavigate={useNavigate}
+        useNavigation={useNavigation}
+        useNavigationType={useNavigationType}
+      />
+      <Link id="router-redirect-link" to="?test=pass&redirect=true">
+        Router redirect
+      </Link>
+      <Link id="router-link" to="/">
+        Router link
+      </Link>
+    </>
   )
 }

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -31,6 +31,8 @@ export default [
     route('/scroll',                                    './routes/scroll.tsx'),
 
     // Local tests
+    route('/pending-loader',                           './routes/pending-loader.tsx'),
+    route('/redirect-queue',                           './routes/redirect-queue.tsx'),
     route('/blocker',                                   './routes/blocker.tsx'),
     route('/blocker-no-loader',                         './routes/blocker.no-loader.tsx'),
     route('/debounce',                                  './routes/debounce.tsx'),

--- a/packages/e2e/react-router/v7/app/routes.ts
+++ b/packages/e2e/react-router/v7/app/routes.ts
@@ -31,6 +31,8 @@ export default [
     route('/scroll',                                    './routes/scroll.tsx'),
 
     // Local tests
+    route('/blocker',                                   './routes/blocker.tsx'),
+    route('/blocker-no-loader',                         './routes/blocker.no-loader.tsx'),
     route('/debounce',                                  './routes/debounce.tsx'),
     route('/debounce/other',                            './routes/debounce.other.tsx'),
     route('/dynamic-segments/catch-all?/*',             './routes/dynamic-segments.catch-all.$.tsx'),

--- a/packages/e2e/react-router/v7/app/routes/blocker.no-loader.tsx
+++ b/packages/e2e/react-router/v7/app/routes/blocker.no-loader.tsx
@@ -1,0 +1,1 @@
+export { default } from './blocker'

--- a/packages/e2e/react-router/v7/app/routes/blocker.tsx
+++ b/packages/e2e/react-router/v7/app/routes/blocker.tsx
@@ -1,6 +1,8 @@
 import { Blocker } from 'e2e-shared/specs/react-router/blocker'
 import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
 import {
+  Form,
+  Link,
   useBlocker,
   useNavigate,
   useNavigation,
@@ -11,12 +13,24 @@ export function loader({ request }: LoaderFunctionArgs) {
   return delayedLoader(request)
 }
 
+export { loader as action }
+
 export default function Page() {
   return (
-    <Blocker
-      useBlocker={useBlocker}
-      useNavigation={useNavigation}
-      useNavigate={useNavigate}
-    />
+    <>
+      <Link id="router-slow-link" to="?count=3&delay=1000">
+        Slow router Link
+      </Link>
+      <Form method="post" action="?count=3&delay=1000">
+        <button id="router-slow-submit" type="submit">
+          Slow router submission
+        </button>
+      </Form>
+      <Blocker
+        useBlocker={useBlocker}
+        useNavigation={useNavigation}
+        useNavigate={useNavigate}
+      />
+    </>
   )
 }

--- a/packages/e2e/react-router/v7/app/routes/blocker.tsx
+++ b/packages/e2e/react-router/v7/app/routes/blocker.tsx
@@ -1,0 +1,22 @@
+import { Blocker } from 'e2e-shared/specs/react-router/blocker'
+import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
+import {
+  useBlocker,
+  useNavigate,
+  useNavigation,
+  type LoaderFunctionArgs
+} from 'react-router'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return delayedLoader(request)
+}
+
+export default function Page() {
+  return (
+    <Blocker
+      useBlocker={useBlocker}
+      useNavigation={useNavigation}
+      useNavigate={useNavigate}
+    />
+  )
+}

--- a/packages/e2e/react-router/v7/app/routes/pending-loader.tsx
+++ b/packages/e2e/react-router/v7/app/routes/pending-loader.tsx
@@ -1,0 +1,22 @@
+import { PendingLoader } from 'e2e-shared/specs/react-router/pending-loader'
+import {
+  controlledLoader,
+  readLoaderRequest
+} from 'e2e-shared/specs/react-router/pending-loader.defs'
+import {
+  useLoaderData,
+  useNavigation,
+  type LoaderFunctionArgs
+} from 'react-router'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return readLoaderRequest(request)
+}
+
+export const clientLoader = controlledLoader
+
+export default function Page() {
+  const data = useLoaderData<typeof loader>()
+  const navigation = useNavigation()
+  return <PendingLoader data={data} navigationState={navigation.state} />
+}

--- a/packages/e2e/react-router/v7/app/routes/redirect-queue.tsx
+++ b/packages/e2e/react-router/v7/app/routes/redirect-queue.tsx
@@ -1,0 +1,22 @@
+import { RedirectQueue } from 'e2e-shared/specs/react-router/redirect-queue'
+import {
+  readRedirectQueueRequest,
+  redirectQueueLoader
+} from 'e2e-shared/specs/react-router/redirect-queue.defs'
+import {
+  useLoaderData,
+  useNavigation,
+  type LoaderFunctionArgs
+} from 'react-router'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return readRedirectQueueRequest(request)
+}
+
+export const clientLoader = redirectQueueLoader
+
+export default function Page() {
+  const data = useLoaderData<typeof loader>()
+  const navigation = useNavigation()
+  return <RedirectQueue data={data} navigationState={navigation.state} />
+}

--- a/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v7/app/routes/repro-1563.tsx
@@ -2,6 +2,9 @@ import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { countLoaderCall } from 'e2e-shared/specs/react-router/repro-1563.defs'
 import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
 import {
+  Link,
+  redirect,
+  useBlocker,
   useNavigate,
   useNavigation,
   useNavigationType,
@@ -12,17 +15,36 @@ import {
 export async function loader({ request }: LoaderFunctionArgs) {
   const call = countLoaderCall(request)
   await delayedLoader(request)
-  return call
+  const url = new URL(request.url)
+  if (
+    url.searchParams.has('redirect') &&
+    url.searchParams.get('test') === 'pass'
+  ) {
+    url.searchParams.set('test', 'redirected')
+    url.searchParams.delete('delay')
+    throw redirect('/repro-1563' + url.search)
+  }
+  return { call, state: url.searchParams.get('test') }
 }
 
 export default function Page() {
-  const loaderCall = useLoaderData<typeof loader>()
+  const { call, state } = useLoaderData<typeof loader>()
   return (
-    <Repro1563
-      loaderCall={loaderCall}
-      useNavigate={useNavigate}
-      useNavigation={useNavigation}
-      useNavigationType={useNavigationType}
-    />
+    <>
+      <Repro1563
+        loaderCall={call}
+        loaderState={state}
+        useBlocker={useBlocker}
+        useNavigate={useNavigate}
+        useNavigation={useNavigation}
+        useNavigationType={useNavigationType}
+      />
+      <Link id="router-redirect-link" to="?test=pass&redirect=true">
+        Router redirect
+      </Link>
+      <Link id="router-link" to="/">
+        Router link
+      </Link>
+    </>
   )
 }

--- a/packages/e2e/react-router/v7/specs/blocker.spec.ts
+++ b/packages/e2e/react-router/v7/specs/blocker.spec.ts
@@ -1,0 +1,7 @@
+import {
+  testBlocker,
+  testBlockerWithoutLoader
+} from 'e2e-shared/specs/react-router/blocker.spec.ts'
+
+testBlocker({ path: '/blocker' })
+testBlockerWithoutLoader({ path: '/blocker-no-loader' })

--- a/packages/e2e/react-router/v7/specs/pending-loader.spec.ts
+++ b/packages/e2e/react-router/v7/specs/pending-loader.spec.ts
@@ -1,0 +1,3 @@
+import { testPendingLoader } from 'e2e-shared/specs/react-router/pending-loader.spec.ts'
+
+testPendingLoader({ path: '/pending-loader' })

--- a/packages/e2e/react-router/v7/specs/redirect-queue.spec.ts
+++ b/packages/e2e/react-router/v7/specs/redirect-queue.spec.ts
@@ -1,0 +1,3 @@
+import { testRedirectQueue } from 'e2e-shared/specs/react-router/redirect-queue.spec.ts'
+
+testRedirectQueue({ path: '/redirect-queue' })

--- a/packages/e2e/react-router/v7/specs/repro-1563.spec.ts
+++ b/packages/e2e/react-router/v7/specs/repro-1563.spec.ts
@@ -1,5 +1,12 @@
-import { testRepro1563 } from 'e2e-shared/specs/react-router/repro-1563.spec.ts'
+import {
+  testRepro1563,
+  testRepro1563Link
+} from 'e2e-shared/specs/react-router/repro-1563.spec.ts'
 
 testRepro1563({
+  path: '/repro-1563'
+})
+
+testRepro1563Link({
   path: '/repro-1563'
 })

--- a/packages/e2e/react-router/v8/app/routes.ts
+++ b/packages/e2e/react-router/v8/app/routes.ts
@@ -31,6 +31,7 @@ export default [
     route('/scroll',                                    './routes/scroll.tsx'),
 
     // Local tests
+    route('/pending-loader',                           './routes/pending-loader.tsx'),
     route('/blocker',                                   './routes/blocker.tsx'),
     route('/blocker-no-loader',                         './routes/blocker.no-loader.tsx'),
     route('/debounce',                                  './routes/debounce.tsx'),

--- a/packages/e2e/react-router/v8/app/routes.ts
+++ b/packages/e2e/react-router/v8/app/routes.ts
@@ -31,6 +31,8 @@ export default [
     route('/scroll',                                    './routes/scroll.tsx'),
 
     // Local tests
+    route('/blocker',                                   './routes/blocker.tsx'),
+    route('/blocker-no-loader',                         './routes/blocker.no-loader.tsx'),
     route('/debounce',                                  './routes/debounce.tsx'),
     route('/debounce/other',                            './routes/debounce.other.tsx'),
     route('/dynamic-segments/catch-all?/*',             './routes/dynamic-segments.catch-all.$.tsx'),

--- a/packages/e2e/react-router/v8/app/routes/blocker.no-loader.tsx
+++ b/packages/e2e/react-router/v8/app/routes/blocker.no-loader.tsx
@@ -1,0 +1,1 @@
+export { default } from './blocker'

--- a/packages/e2e/react-router/v8/app/routes/blocker.tsx
+++ b/packages/e2e/react-router/v8/app/routes/blocker.tsx
@@ -1,6 +1,8 @@
 import { Blocker } from 'e2e-shared/specs/react-router/blocker'
 import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
 import {
+  Form,
+  Link,
   useBlocker,
   useNavigate,
   useNavigation,
@@ -11,12 +13,24 @@ export function loader({ request }: LoaderFunctionArgs) {
   return delayedLoader(request)
 }
 
+export { loader as action }
+
 export default function Page() {
   return (
-    <Blocker
-      useBlocker={useBlocker}
-      useNavigation={useNavigation}
-      useNavigate={useNavigate}
-    />
+    <>
+      <Link id="router-slow-link" to="?count=3&delay=1000">
+        Slow router Link
+      </Link>
+      <Form method="post" action="?count=3&delay=1000">
+        <button id="router-slow-submit" type="submit">
+          Slow router submission
+        </button>
+      </Form>
+      <Blocker
+        useBlocker={useBlocker}
+        useNavigation={useNavigation}
+        useNavigate={useNavigate}
+      />
+    </>
   )
 }

--- a/packages/e2e/react-router/v8/app/routes/blocker.tsx
+++ b/packages/e2e/react-router/v8/app/routes/blocker.tsx
@@ -1,0 +1,22 @@
+import { Blocker } from 'e2e-shared/specs/react-router/blocker'
+import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
+import {
+  useBlocker,
+  useNavigate,
+  useNavigation,
+  type LoaderFunctionArgs
+} from 'react-router'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return delayedLoader(request)
+}
+
+export default function Page() {
+  return (
+    <Blocker
+      useBlocker={useBlocker}
+      useNavigation={useNavigation}
+      useNavigate={useNavigate}
+    />
+  )
+}

--- a/packages/e2e/react-router/v8/app/routes/pending-loader.tsx
+++ b/packages/e2e/react-router/v8/app/routes/pending-loader.tsx
@@ -1,0 +1,29 @@
+import { PendingLoader } from 'e2e-shared/specs/react-router/pending-loader'
+import {
+  controlledLoader,
+  readLoaderRequest
+} from 'e2e-shared/specs/react-router/pending-loader.defs'
+import {
+  useBlocker,
+  useLoaderData,
+  useNavigation,
+  type LoaderFunctionArgs
+} from 'react-router'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return readLoaderRequest(request)
+}
+
+export const clientLoader = controlledLoader
+
+export default function Page() {
+  const data = useLoaderData<typeof loader>()
+  const navigation = useNavigation()
+  return (
+    <PendingLoader
+      data={data}
+      navigationState={navigation.state}
+      useBlocker={useBlocker}
+    />
+  )
+}

--- a/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
+++ b/packages/e2e/react-router/v8/app/routes/repro-1563.tsx
@@ -2,6 +2,9 @@ import { Repro1563 } from 'e2e-shared/specs/react-router/repro-1563'
 import { countLoaderCall } from 'e2e-shared/specs/react-router/repro-1563.defs'
 import { delayedLoader } from 'e2e-shared/specs/delay-loader.defs'
 import {
+  Link,
+  redirect,
+  useBlocker,
   useNavigate,
   useNavigation,
   useNavigationType,
@@ -12,17 +15,36 @@ import {
 export async function loader({ request }: LoaderFunctionArgs) {
   const call = countLoaderCall(request)
   await delayedLoader(request)
-  return call
+  const url = new URL(request.url)
+  if (
+    url.searchParams.has('redirect') &&
+    url.searchParams.get('test') === 'pass'
+  ) {
+    url.searchParams.set('test', 'redirected')
+    url.searchParams.delete('delay')
+    throw redirect('/repro-1563' + url.search)
+  }
+  return { call, state: url.searchParams.get('test') }
 }
 
 export default function Page() {
-  const loaderCall = useLoaderData<typeof loader>()
+  const { call, state } = useLoaderData<typeof loader>()
   return (
-    <Repro1563
-      loaderCall={loaderCall}
-      useNavigate={useNavigate}
-      useNavigation={useNavigation}
-      useNavigationType={useNavigationType}
-    />
+    <>
+      <Repro1563
+        loaderCall={call}
+        loaderState={state}
+        useBlocker={useBlocker}
+        useNavigate={useNavigate}
+        useNavigation={useNavigation}
+        useNavigationType={useNavigationType}
+      />
+      <Link id="router-redirect-link" to="?test=pass&redirect=true">
+        Router redirect
+      </Link>
+      <Link id="router-link" to="/">
+        Router link
+      </Link>
+    </>
   )
 }

--- a/packages/e2e/react-router/v8/specs/blocker.spec.ts
+++ b/packages/e2e/react-router/v8/specs/blocker.spec.ts
@@ -1,0 +1,7 @@
+import {
+  testBlocker,
+  testBlockerWithoutLoader
+} from 'e2e-shared/specs/react-router/blocker.spec.ts'
+
+testBlocker({ path: '/blocker' })
+testBlockerWithoutLoader({ path: '/blocker-no-loader' })

--- a/packages/e2e/react-router/v8/specs/pending-loader.spec.ts
+++ b/packages/e2e/react-router/v8/specs/pending-loader.spec.ts
@@ -1,0 +1,3 @@
+import { testPendingLoader } from 'e2e-shared/specs/react-router/pending-loader.spec.ts'
+
+testPendingLoader({ path: '/pending-loader' })

--- a/packages/e2e/react-router/v8/specs/pending-push.spec.ts
+++ b/packages/e2e/react-router/v8/specs/pending-push.spec.ts
@@ -1,0 +1,3 @@
+import { testPendingPush } from 'e2e-shared/specs/react-router/pending-push.spec.ts'
+
+testPendingPush({ path: '/pending-loader' })

--- a/packages/e2e/react-router/v8/specs/repro-1563.spec.ts
+++ b/packages/e2e/react-router/v8/specs/repro-1563.spec.ts
@@ -1,5 +1,12 @@
-import { testRepro1563 } from 'e2e-shared/specs/react-router/repro-1563.spec.ts'
+import {
+  testRepro1563,
+  testRepro1563Link
+} from 'e2e-shared/specs/react-router/repro-1563.spec.ts'
 
 testRepro1563({
+  path: '/repro-1563'
+})
+
+testRepro1563Link({
   path: '/repro-1563'
 })

--- a/packages/e2e/react/specs/shared/push.spec.ts
+++ b/packages/e2e/react/specs/shared/push.spec.ts
@@ -1,3 +1,5 @@
+import { expect, test as it } from '@playwright/test'
+import { navigateTo } from 'e2e-shared/playwright/navigate.ts'
 import { testPush } from 'e2e-shared/specs/push.spec.ts'
 
 testPush({
@@ -9,3 +11,27 @@ testPush({
   path: '/push/useQueryStates',
   hook: 'useQueryStates'
 })
+
+for (const hook of ['useQueryState', 'useQueryStates'] as const) {
+  it(`preserves application history state through push and traversal (${hook})`, async ({
+    page
+  }) => {
+    await navigateTo(page, `/push/${hook}`, '?test=init')
+    const applicationState = { idx: 42, custom: 'app' }
+    await page.evaluate(state => {
+      history.replaceState(state, '', location.href)
+    }, applicationState)
+
+    await page.getByRole('button', { name: 'Test', exact: true }).click()
+    await expect(page).toHaveURL(url => url.search === '?test=pass')
+    expect(await page.evaluate(() => history.state)).toEqual(applicationState)
+
+    await page.goBack()
+    await expect(page.locator('#state')).toHaveText('init')
+    expect(await page.evaluate(() => history.state)).toEqual(applicationState)
+
+    await page.goForward()
+    await expect(page.locator('#state')).toHaveText('pass')
+    expect(await page.evaluate(() => history.state)).toEqual(applicationState)
+  })
+}

--- a/packages/e2e/react/tsconfig.node.json
+++ b/packages/e2e/react/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "types": ["node"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/packages/e2e/remix/app/routes/pending-loader.tsx
+++ b/packages/e2e/remix/app/routes/pending-loader.tsx
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useNavigation } from '@remix-run/react'
+import { PendingLoader } from 'e2e-shared/specs/react-router/pending-loader'
+import {
+  controlledLoader,
+  readLoaderRequest
+} from 'e2e-shared/specs/react-router/pending-loader.defs'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return readLoaderRequest(request)
+}
+
+export const clientLoader = controlledLoader
+
+export default function Page() {
+  const data = useLoaderData<typeof loader>()
+  const navigation = useNavigation()
+  return <PendingLoader data={data} navigationState={navigation.state} />
+}

--- a/packages/e2e/remix/app/routes/redirect-queue.tsx
+++ b/packages/e2e/remix/app/routes/redirect-queue.tsx
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useNavigation } from '@remix-run/react'
+import { RedirectQueue } from 'e2e-shared/specs/react-router/redirect-queue'
+import {
+  readRedirectQueueRequest,
+  redirectQueueLoader
+} from 'e2e-shared/specs/react-router/redirect-queue.defs'
+
+export function loader({ request }: LoaderFunctionArgs) {
+  return readRedirectQueueRequest(request)
+}
+
+export const clientLoader = redirectQueueLoader
+
+export default function Page() {
+  const data = useLoaderData<typeof loader>()
+  const navigation = useNavigation()
+  return <RedirectQueue data={data} navigationState={navigation.state} />
+}

--- a/packages/e2e/remix/app/routes/repro-1563.tsx
+++ b/packages/e2e/remix/app/routes/repro-1563.tsx
@@ -12,14 +12,16 @@ import {
 export async function loader({ request }: LoaderFunctionArgs) {
   const call = countLoaderCall(request)
   await delayedLoader(request)
-  return call
+  const url = new URL(request.url)
+  return { call, state: url.searchParams.get('test') }
 }
 
 export default function Page() {
-  const loaderCall = useLoaderData<typeof loader>()
+  const { call, state } = useLoaderData<typeof loader>()
   return (
     <Repro1563
-      loaderCall={loaderCall}
+      loaderCall={call}
+      loaderState={state}
       useNavigate={useNavigate}
       useNavigation={useNavigation}
       useNavigationType={useNavigationType}

--- a/packages/e2e/remix/specs/pending-loader.spec.ts
+++ b/packages/e2e/remix/specs/pending-loader.spec.ts
@@ -1,0 +1,3 @@
+import { testPendingLoader } from 'e2e-shared/specs/react-router/pending-loader.spec.ts'
+
+testPendingLoader({ path: '/pending-loader' })

--- a/packages/e2e/remix/specs/redirect-queue.spec.ts
+++ b/packages/e2e/remix/specs/redirect-queue.spec.ts
@@ -1,0 +1,3 @@
+import { testRedirectQueue } from 'e2e-shared/specs/react-router/redirect-queue.spec.ts'
+
+testRedirectQueue({ path: '/redirect-queue' })

--- a/packages/e2e/shared/playwright/expect-url.ts
+++ b/packages/e2e/shared/playwright/expect-url.ts
@@ -22,7 +22,10 @@ export function expectUrl(
     .toBe(true)
 }
 
-export function expectSearch(page: Page, expected: Record<string, string>) {
+export function expectSearch(
+  page: Page,
+  expected: Record<string, string | null>
+) {
   return expectUrl(
     page,
     url =>

--- a/packages/e2e/shared/specs/react-router/blocker.spec.ts
+++ b/packages/e2e/shared/specs/react-router/blocker.spec.ts
@@ -1,0 +1,616 @@
+import { expect, test as it, type Page } from '@playwright/test'
+import { defineTest } from '../../define-test'
+import { navigateTo } from '../../playwright/navigate'
+
+async function expectCount(page: Page, count: number) {
+  await expect(page).toHaveURL(
+    url => url.searchParams.get('count') === String(count)
+  )
+  await expect(page.locator('#count')).toHaveText(String(count))
+}
+
+async function shallowPush(page: Page, count: number) {
+  await page.locator('#shallow').click()
+  await expectCount(page, count)
+}
+
+async function expectTwoShallowPushes(page: Page, initialCount: number) {
+  const before = await page.evaluate(() => history.length)
+  await shallowPush(page, initialCount + 1)
+  await shallowPush(page, initialCount + 2)
+  expect(await page.evaluate(() => history.length)).toBe(before + 2)
+}
+
+export const testBlockerWithoutLoader = defineTest(
+  'React Router blockers without loaders',
+  ({ path }) => {
+    it('blocks Back after an open blocker unmounts before a router push', async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#toggle-blocker').click()
+      await expect(page.locator('#blocker')).toHaveCount(0)
+      await page.locator('#router-push').click()
+      await expectCount(page, 3)
+      await page.locator('#toggle-blocker').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await page.locator('#enabled').uncheck()
+      await page.locator('#enabled').check()
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.back()
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, 1)
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+)
+
+export const testBlocker = defineTest('React Router blockers', ({ path }) => {
+  for (const cancelFirst of [false, true]) {
+    it(
+      cancelFirst
+        ? 'adds two shallow entries after cancelling a blocked deep push'
+        : 'adds two idle shallow entries',
+      async ({ page }) => {
+        await navigateTo(page, path, '?count=0')
+        if (cancelFirst) {
+          await page.locator('#deep').click()
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await expectCount(page, 1)
+          await page.locator('#cancel').click()
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+        }
+        await expectTwoShallowPushes(page, cancelFirst ? 1 : 0)
+        if (cancelFirst) {
+          await page.evaluate(() => history.back())
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await expectCount(page, 3)
+          await page.locator('#cancel').click()
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+          await expectCount(page, 3)
+        }
+      }
+    )
+  }
+
+  it('blocks Back after cancelling a blocked deep push without reloading', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 0)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('blocks Back after cancelling repeated deep pushes', async ({ page }) => {
+    await navigateTo(page, path, '?count=0')
+    const before = await page.evaluate(() => history.length)
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#deep').click()
+    await expectCount(page, 2)
+    expect(await page.evaluate(() => history.length)).toBe(before + 1)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 2)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 0)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  for (const shallow of [false, true]) {
+    it(`blocks Back after cancelling a deep push and replace (shallow write: ${shallow})`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await page.locator('#deep-replace').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 2)
+      if (shallow) {
+        await shallowPush(page, 3)
+      }
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.back()
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, shallow ? 3 : 2)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, shallow ? 2 : 0)
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
+  for (const shallow of [false, true]) {
+    it(`blocks each Back after separate cancelled deep pushes (shallow write: ${shallow})`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+      })
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      if (shallow) {
+        await shallowPush(page, 2)
+      }
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      for (let count = shallow ? 3 : 2; count > 0; count--) {
+        await page.evaluate(() => history.back())
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectCount(page, count)
+        await page.locator('#proceed').click()
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        await expectCount(page, count - 1)
+      }
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
+  it('blocks Back while the deep push confirmation is open', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 0)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('blocks Back after a cancelled push followed by an accepted push', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expect(page.locator('#navigation')).toHaveText('idle')
+    await expectCount(page, 2)
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 2)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('keeps the Back destination when a shallow push occurs during confirmation', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await shallowPush(page, 2)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 0)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('blocks Back after removing an open blocker and remounting it', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#toggle-blocker').click()
+    await expect(page.locator('#blocker')).toHaveCount(0)
+    await page.locator('#toggle-blocker').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 0)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  for (const shallow of [false, true]) {
+    it(`blocks Back after a cancelled push followed by a router push (shallow write: ${shallow})`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      if (shallow) {
+        await shallowPush(page, 2)
+      }
+      await page.locator('#router-push').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, 3)
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.back()
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, shallow ? 2 : 1)
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
+  it('restores the right entry when shallow updates repeat a URL', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await shallowPush(page, 2)
+    await page.locator('#shallow-decrement').click()
+    await expectCount(page, 1)
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.go(-2)
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 2)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('keeps tracking cancellation after index repair', async ({ page }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await shallowPush(page, 2)
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 2)
+  })
+
+  it('restores and proceeds across multiple shallow entries', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await expectTwoShallowPushes(page, 1)
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.go(-2)
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 3)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('restores across shallow entries created before a cancelled deep push', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await expectTwoShallowPushes(page, 0)
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await page.evaluate(() => history.go(-2))
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 3)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+  })
+
+  it('restores repeated URLs by entry identity', async ({ page }) => {
+    await navigateTo(page, path)
+    const initialUrl = page.url()
+    const before = await page.evaluate(() => history.length)
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#shallow-decrement').click()
+    await expect(page).toHaveURL(initialUrl)
+    await expect(page.locator('#count')).toHaveText('0')
+    expect(await page.evaluate(() => history.length)).toBe(before + 2)
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.go(-2)
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expect(page).toHaveURL(initialUrl)
+    await expect(page.locator('#count')).toHaveText('0')
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expect(page).toHaveURL(initialUrl)
+    await expect(page.locator('#count')).toHaveText('0')
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+    await page.locator('#enabled').uncheck()
+    await page.goForward()
+    await expectCount(page, 1)
+    await page.goForward()
+    await expect(page).toHaveURL(initialUrl)
+    await expect(page.locator('#count')).toHaveText('0')
+    expect(await page.evaluate(() => history.length)).toBe(before + 2)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('blocks Forward after an allowed Back from a cancelled deep push', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#cancel').click()
+    await page.locator('#enabled').uncheck()
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expectCount(page, 0)
+    await page.locator('#enabled').check()
+    await page.evaluate(() => history.forward())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 0)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('proceeds Back after remounting the blocker', async ({ page }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#toggle-blocker').click()
+    await expect(page.locator('#blocker')).toHaveCount(0)
+    await page.locator('#toggle-blocker').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 0)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('handles Cancel while the query controls are unmounted', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#deep').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
+    await page.locator('#toggle-controls').click()
+    await expect(page.locator('#count')).toHaveCount(0)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#toggle-controls').click()
+    await expectCount(page, 1)
+    await expectTwoShallowPushes(page, 1)
+  })
+
+  for (const remove of ['cancel', 'toggle-blocker']) {
+    it(`does not attach an old blocker to an allowed navigation (${remove})`, async ({
+      page
+    }) => {
+      it.setTimeout(10_000)
+      await navigateTo(page, path, '?count=0&delay=1000')
+      const before = await page.evaluate(() => history.length)
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#enabled').uncheck()
+      await page.locator('#deep').click()
+      await expect(page.locator('#navigation')).toHaveText('loading')
+      await expectCount(page, 2)
+      await page.locator(`#${remove}`).click()
+      await shallowPush(page, 3)
+      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      await expect(page.locator('#navigation')).toHaveText('idle')
+      await expectCount(page, 3)
+      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      await expectTwoShallowPushes(page, 3)
+    })
+  }
+
+  for (const shallow of [false, true]) {
+    it(`keeps a proceeding navigation after removing its blocker (shallow write: ${shallow})`, async ({
+      page
+    }) => {
+      it.setTimeout(10_000)
+      await navigateTo(page, path, '?count=0&delay=1000')
+      const before = await page.evaluate(() => history.length)
+      await page.locator('#deep').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await page.locator('#proceed').click()
+      await expect(page.locator('#navigation')).toHaveText('loading')
+      await page.locator('#toggle-blocker').click()
+      await expect(page.locator('#blocker')).toHaveCount(0)
+      if (shallow) {
+        await shallowPush(page, 2)
+      }
+      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      await expect(page.locator('#navigation')).toHaveText('idle')
+      await expectCount(page, shallow ? 2 : 1)
+      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      await expectTwoShallowPushes(page, shallow ? 2 : 1)
+    })
+  }
+
+  for (const blocked of [false, true]) {
+    it(
+      blocked
+        ? 'keeps shallow pushes in the pending entry through Proceed'
+        : 'keeps shallow pushes in a pending loader navigation',
+      async ({ page }) => {
+        it.setTimeout(10_000)
+        await navigateTo(page, path, '?count=0&delay=1000')
+        const before = await page.evaluate(() => history.length)
+        if (!blocked) {
+          await page.locator('#enabled').uncheck()
+        }
+        await page.locator('#deep').click()
+        await expectCount(page, 1)
+        if (blocked) {
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await shallowPush(page, 2)
+          expect(await page.evaluate(() => history.length)).toBe(before + 1)
+          await page.locator('#proceed').click()
+          await expect(page.locator('#blocker')).toHaveText('proceeding')
+        }
+        await expect(page.locator('#navigation')).toHaveText('loading')
+        const count = blocked ? 3 : 2
+        await shallowPush(page, count)
+        expect(await page.evaluate(() => history.length)).toBe(before + 1)
+        await expect(page.locator('#navigation')).toHaveText('idle')
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        await expectCount(page, count)
+        expect(await page.evaluate(() => history.length)).toBe(before + 1)
+        await page.locator('#enabled').uncheck()
+        await page.goBack()
+        await expectCount(page, 0)
+        await page.goForward()
+        await expectCount(page, count)
+        await expect(page.locator('#navigation')).toHaveText('idle')
+        await expectTwoShallowPushes(page, count)
+      }
+    )
+  }
+})

--- a/packages/e2e/shared/specs/react-router/blocker.spec.ts
+++ b/packages/e2e/shared/specs/react-router/blocker.spec.ts
@@ -21,9 +21,236 @@ async function expectTwoShallowPushes(page: Page, initialCount: number) {
   expect(await page.evaluate(() => history.length)).toBe(before + 2)
 }
 
+function testRouterHistory(path: string) {
+  for (const mode of ['push', 'replace'] as const) {
+    it(`blocks Back after idle shallow pushes and an ordinary router ${mode}`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await page.locator('#enabled').uncheck()
+      const before = await page.evaluate(() => history.length)
+      await expectTwoShallowPushes(page, 0)
+      await page.locator(`#router-${mode}`).click()
+      await expectCount(page, 3)
+      await expect(page.locator('#navigation')).toHaveText('idle')
+      expect(await page.evaluate(() => history.length)).toBe(
+        before + (mode === 'push' ? 3 : 2)
+      )
+      await page.locator('#enabled').check()
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.back()
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, 3)
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      const previousCount = mode === 'push' ? 2 : 1
+      await expectCount(page, previousCount)
+      for (const direction of ['forward', 'back'] as const) {
+        const from = direction === 'forward' ? previousCount : 3
+        const to = direction === 'forward' ? 3 : previousCount
+        await page.evaluate(direction => history[direction](), direction)
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectCount(page, from)
+        await page.locator('#cancel').click()
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        await expectCount(page, from)
+        await page.evaluate(direction => history[direction](), direction)
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectCount(page, from)
+        await page.locator('#proceed').click()
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        await expectCount(page, to)
+      }
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
+  it('keeps a separate router entry after a shallow push during confirmation', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    const before = await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      return history.length
+    })
+    await expectTwoShallowPushes(page, 0)
+    await page.locator('#router-push').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 2)
+    await shallowPush(page, 3)
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    const shallowUrl = page.url()
+    expect(await page.evaluate(() => history.length)).toBe(before + 3)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expect(page.locator('#navigation')).toHaveText('idle')
+    await expectCount(page, 3)
+    await expect(page).toHaveURL(shallowUrl)
+    expect(await page.evaluate(() => history.length)).toBe(before + 4)
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 3)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expect(page.locator('#navigation')).toHaveText('idle')
+    await expectCount(page, 3)
+    await expect(page).toHaveURL(shallowUrl)
+    await page.locator('#enabled').uncheck()
+    await page.evaluate(() => history.back())
+    await expectCount(page, 2)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  for (const action of ['deep', 'deep-replace'] as const) {
+    it(`blocks Back after idle shallow pushes and an accepted ${action}`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await expectTwoShallowPushes(page, 0)
+      await page.locator(`#${action}`).click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expect(page.locator('#navigation')).toHaveText('idle')
+      await expectCount(page, 3)
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.back()
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, 3)
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, action === 'deep' ? 2 : 1)
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
+  for (const repeatUrl of [false, true]) {
+    it(`restores multi-entry Back after a router push (repeat URL: ${repeatUrl})`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, '?count=0')
+      await page.locator('#enabled').uncheck()
+      await expectTwoShallowPushes(page, 0)
+      if (repeatUrl) {
+        await page.locator('#shallow-decrement').click()
+        await expectCount(page, 1)
+      }
+      await page.locator('#router-push').click()
+      await expectCount(page, 3)
+      await expect(page.locator('#navigation')).toHaveText('idle')
+      await page.locator('#enabled').check()
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.go(-2)
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, repeatUrl ? 2 : 1)
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
+  it('blocks multi-entry Back after Cancel and blocker remount', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#enabled').uncheck()
+    await expectTwoShallowPushes(page, 0)
+    await page.locator('#router-push').click()
+    await expectCount(page, 3)
+    await expect(page.locator('#navigation')).toHaveText('idle')
+    await page.locator('#enabled').check()
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 3)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 3)
+    await page.locator('#toggle-blocker').click()
+    await expect(page.locator('#blocker')).toHaveCount(0)
+    await page.locator('#toggle-blocker').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#enabled').uncheck()
+    await page.locator('#enabled').check()
+    await page.evaluate(() => history.go(-2))
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 3)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+
+  it('blocks Forward after an allowed Back across shallow pushes and a router push', async ({
+    page
+  }) => {
+    await navigateTo(page, path, '?count=0')
+    await page.locator('#enabled').uncheck()
+    await expectTwoShallowPushes(page, 0)
+    await page.locator('#router-push').click()
+    await expectCount(page, 3)
+    await expect(page.locator('#navigation')).toHaveText('idle')
+    await page.evaluate(() => {
+      document.body.dataset.blockerTest = 'mounted'
+      history.back()
+    })
+    await expectCount(page, 2)
+    await page.locator('#enabled').check()
+    await page.evaluate(() => history.forward())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 2)
+    await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 2)
+    await page.evaluate(() => history.forward())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 2)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 3)
+    expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+      'mounted'
+    )
+  })
+}
+
 export const testBlockerWithoutLoader = defineTest(
   'React Router blockers without loaders',
   ({ path }) => {
+    testRouterHistory(path)
+
     it('blocks Back after an open blocker unmounts before a router push', async ({
       page
     }) => {
@@ -55,6 +282,50 @@ export const testBlockerWithoutLoader = defineTest(
 )
 
 export const testBlocker = defineTest('React Router blockers', ({ path }) => {
+  testRouterHistory(path)
+
+  for (const { name, control, state } of [
+    { name: 'Link loader', control: 'link', state: 'loading' },
+    { name: 'POST action', control: 'submit', state: 'submitting' }
+  ] as const) {
+    it(`adds a router entry after shallow pushes while a ${name} waits`, async ({
+      page
+    }) => {
+      it.setTimeout(10_000)
+      await navigateTo(page, path, '?count=0')
+      await page.locator('#enabled').uncheck()
+      const before = await page.evaluate(() => history.length)
+      await expectTwoShallowPushes(page, 0)
+      await page.locator(`#router-slow-${control}`).click()
+      await expect(page.locator('#navigation')).toHaveText(state)
+      await shallowPush(page, 3)
+      await shallowPush(page, 4)
+      await expect(page.locator('#navigation')).toHaveText(state)
+      await expect(page.locator('#navigation')).toHaveText('idle')
+      await expectCount(page, 3)
+      expect(await page.evaluate(() => history.length)).toBe(before + 5)
+      await page.locator('#enabled').check()
+      await page.evaluate(() => {
+        document.body.dataset.blockerTest = 'mounted'
+        history.back()
+      })
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, 3)
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectCount(page, 3)
+      await page.locator('#proceed').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectCount(page, 4)
+      expect(await page.evaluate(() => document.body.dataset.blockerTest)).toBe(
+        'mounted'
+      )
+    })
+  }
+
   for (const cancelFirst of [false, true]) {
     it(
       cancelFirst
@@ -291,6 +562,8 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     await expect(page.locator('#blocker')).toHaveCount(0)
     await page.locator('#toggle-blocker').click()
     await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#enabled').uncheck()
+    await page.locator('#enabled').check()
     await page.evaluate(() => {
       document.body.dataset.blockerTest = 'mounted'
       history.back()
@@ -367,14 +640,18 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     )
   })
 
-  it('keeps tracking cancellation after index repair', async ({ page }) => {
+  it('blocks Back after repeated cancellation and a shallow push', async ({
+    page
+  }) => {
     await navigateTo(page, path, '?count=0')
     await page.locator('#deep').click()
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
     await page.evaluate(() => history.back())
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
     await shallowPush(page, 2)
     await page.evaluate(() => history.back())
     await expect(page.locator('#blocker')).toHaveText('blocked')
@@ -388,6 +665,7 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     await page.locator('#deep').click()
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
     await expectTwoShallowPushes(page, 1)
     await page.evaluate(() => {
       document.body.dataset.blockerTest = 'mounted'
@@ -411,6 +689,7 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     await page.locator('#deep').click()
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
     await page.evaluate(() => history.go(-2))
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await expectCount(page, 3)
@@ -469,6 +748,7 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await expectCount(page, 1)
     await page.locator('#cancel').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
     await page.locator('#enabled').uncheck()
     await page.evaluate(() => {
       document.body.dataset.blockerTest = 'mounted'
@@ -497,6 +777,8 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     await expect(page.locator('#blocker')).toHaveCount(0)
     await page.locator('#toggle-blocker').click()
     await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.locator('#enabled').uncheck()
+    await page.locator('#enabled').check()
     await page.evaluate(() => {
       document.body.dataset.blockerTest = 'mounted'
       history.back()
@@ -541,6 +823,9 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
       await expect(page.locator('#navigation')).toHaveText('loading')
       await expectCount(page, 2)
       await page.locator(`#${remove}`).click()
+      if (remove === 'cancel') {
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+      }
       await shallowPush(page, 3)
       expect(await page.evaluate(() => history.length)).toBe(before + 1)
       await expect(page.locator('#navigation')).toHaveText('idle')

--- a/packages/e2e/shared/specs/react-router/blocker.tsx
+++ b/packages/e2e/shared/specs/react-router/blocker.tsx
@@ -10,7 +10,10 @@ type BlockerProps = {
     proceed?: () => void
   }
   useNavigation: () => { state: string }
-  useNavigate: () => (to: string) => void | Promise<void>
+  useNavigate: () => (
+    to: string,
+    options?: { replace?: boolean }
+  ) => void | Promise<void>
 }
 
 export function Blocker({
@@ -28,6 +31,12 @@ export function Blocker({
       <output id="navigation">{navigation.state}</output>
       <button id="router-push" onClick={() => navigate('?count=3')}>
         Router push
+      </button>
+      <button
+        id="router-replace"
+        onClick={() => navigate('?count=3', { replace: true })}
+      >
+        Router replace
       </button>
       <button
         id="toggle-controls"

--- a/packages/e2e/shared/specs/react-router/blocker.tsx
+++ b/packages/e2e/shared/specs/react-router/blocker.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { parseAsInteger, useQueryState } from 'nuqs'
+import { useState } from 'react'
+
+type BlockerProps = {
+  useBlocker: (enabled: boolean) => {
+    state: string
+    reset?: () => void
+    proceed?: () => void
+  }
+  useNavigation: () => { state: string }
+  useNavigate: () => (to: string) => void | Promise<void>
+}
+
+export function Blocker({
+  useBlocker,
+  useNavigation,
+  useNavigate
+}: BlockerProps) {
+  const navigation = useNavigation()
+  const navigate = useNavigate()
+  const [showControls, setShowControls] = useState(true)
+  const [showBlocker, setShowBlocker] = useState(true)
+
+  return (
+    <>
+      <output id="navigation">{navigation.state}</output>
+      <button id="router-push" onClick={() => navigate('?count=3')}>
+        Router push
+      </button>
+      <button
+        id="toggle-controls"
+        onClick={() => setShowControls(show => !show)}
+      >
+        Toggle query controls
+      </button>
+      <button id="toggle-blocker" onClick={() => setShowBlocker(show => !show)}>
+        Toggle blocker
+      </button>
+      {showBlocker && <BlockerControls useBlocker={useBlocker} />}
+      {showControls && <QueryControls />}
+    </>
+  )
+}
+
+function BlockerControls({ useBlocker }: Pick<BlockerProps, 'useBlocker'>) {
+  const [enabled, setEnabled] = useState(true)
+  const blocker = useBlocker(enabled)
+  return (
+    <>
+      <output id="blocker">{blocker.state}</output>
+      <label>
+        <input
+          id="enabled"
+          type="checkbox"
+          checked={enabled}
+          onChange={event => setEnabled(event.target.checked)}
+        />
+        Block navigation
+      </label>
+      {blocker.state === 'blocked' && (
+        <>
+          <button id="cancel" onClick={() => blocker.reset?.()}>
+            Cancel
+          </button>
+          <button id="proceed" onClick={() => blocker.proceed?.()}>
+            Proceed
+          </button>
+        </>
+      )}
+    </>
+  )
+}
+
+function QueryControls() {
+  const [count, setCount] = useQueryState(
+    'count',
+    parseAsInteger.withDefault(0)
+  )
+  return (
+    <>
+      <output id="count">{count}</output>
+      <button
+        id="deep"
+        onClick={() =>
+          setCount(n => n + 1, { history: 'push', shallow: false })
+        }
+      >
+        Deep push
+      </button>
+      <button
+        id="deep-replace"
+        onClick={() =>
+          setCount(n => n + 1, { history: 'replace', shallow: false })
+        }
+      >
+        Deep replace
+      </button>
+      <button
+        id="shallow"
+        onClick={() => setCount(n => n + 1, { history: 'push', shallow: true })}
+      >
+        Shallow push
+      </button>
+      <button
+        id="shallow-decrement"
+        onClick={() => setCount(n => n - 1, { history: 'push', shallow: true })}
+      >
+        Shallow decrement
+      </button>
+    </>
+  )
+}

--- a/packages/e2e/shared/specs/react-router/pending-loader.defs.ts
+++ b/packages/e2e/shared/specs/react-router/pending-loader.defs.ts
@@ -1,0 +1,64 @@
+import { parseAsStringLiteral } from 'nuqs/server'
+
+const history = parseAsStringLiteral(['push', 'replace'])
+
+export const pendingLoaderOptions = {
+  qHistory: history.withDefault('replace'),
+  pageHistory: history.withDefault('replace'),
+  panelHistory: history.withDefault('replace')
+}
+
+export function readLoaderRequest(request: Request) {
+  const search = new URL(request.url).searchParams
+  return {
+    q: search.get('q'),
+    page: search.get('page'),
+    panel: search.get('panel')
+  }
+}
+
+export type LoaderRequestData = ReturnType<typeof readLoaderRequest>
+
+type ControlledRequest = {
+  data: LoaderRequestData
+  aborted: boolean
+  release: () => void
+}
+
+declare global {
+  interface Window {
+    pendingLoaderControl?: {
+      requests: ControlledRequest[]
+      completed: number[]
+    }
+  }
+}
+
+export async function controlledLoader({ request }: { request: Request }) {
+  const data = readLoaderRequest(request)
+  if (data.q === 'init' && data.page === '1') {
+    return data
+  }
+  const control = (window.pendingLoaderControl ??= {
+    requests: [],
+    completed: []
+  })
+  let release!: () => void
+  const gate = new Promise<void>(resolve => {
+    release = resolve
+  })
+  const entry = { data, aborted: request.signal.aborted, release }
+  const id = control.requests.push(entry)
+  const onAbort = () => {
+    entry.aborted = true
+  }
+  request.signal.addEventListener('abort', onAbort, { once: true })
+  try {
+    // Keep running after abort so the router must discard the late result.
+    await gate
+    control.completed.push(id)
+    return data
+  } finally {
+    request.signal.removeEventListener('abort', onAbort)
+  }
+}

--- a/packages/e2e/shared/specs/react-router/pending-loader.spec.ts
+++ b/packages/e2e/shared/specs/react-router/pending-loader.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test as it, type Page } from '@playwright/test'
+import { defineTest } from '../../define-test'
+import { expectSearch } from '../../playwright/expect-url'
+import { readHistoryIndex } from '../../playwright/history'
+import { navigateTo } from '../../playwright/navigate'
+import type { LoaderRequestData } from './pending-loader.defs'
+
+async function readLoaderControl(page: Page) {
+  return page.evaluate(() => ({
+    requests:
+      window.pendingLoaderControl?.requests.map(({ data, aborted }) => ({
+        data,
+        aborted
+      })) ?? [],
+    completed: window.pendingLoaderControl?.completed ?? []
+  }))
+}
+
+async function releaseLoader(page: Page, id: number) {
+  await page.evaluate(async id => {
+    const request = window.pendingLoaderControl?.requests[id - 1]
+    if (!request) {
+      throw new Error(`Loader ${id} has not started`)
+    }
+    request.release()
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+  }, id)
+}
+
+async function expectLoaderData(page: Page, data: LoaderRequestData) {
+  await expect(page.locator('#loader-data')).toHaveText(JSON.stringify(data))
+}
+
+async function expectLatestState(page: Page) {
+  await expectSearch(page, { q: 'tea', page: '2', panel: 'open' })
+  await expect(page.locator('#q-state')).toHaveText('tea')
+  await expect(page.locator('#page-state')).toHaveText('2')
+  await expect(page.locator('#panel-state')).toHaveText('open')
+  await expectLoaderData(page, { q: 'tea', page: '2', panel: 'before' })
+  await expect(page.locator('#navigation-state')).toHaveText('idle')
+}
+
+export const testPendingLoader = defineTest(
+  'Out-of-order loaders',
+  ({ path }) => {
+    for (const qHistory of ['replace', 'push'] as const) {
+      for (const pageHistory of ['replace', 'push'] as const) {
+        for (const firstKey of ['q', 'page'] as const) {
+          const secondKey = firstKey === 'q' ? 'page' : 'q'
+          it(`keeps the latest state when ${firstKey} finishes last (q: ${qHistory}, page: ${pageHistory})`, async ({
+            page
+          }) => {
+            await navigateTo(
+              page,
+              path,
+              `?q=init&page=1&qHistory=${qHistory}&pageHistory=${pageHistory}`
+            )
+            await expectLoaderData(page, { q: 'init', page: '1', panel: null })
+            await expect(page.locator('#navigation-state')).toHaveText('idle')
+
+            await page.locator(`#set-${firstKey}`).click()
+            const firstData =
+              firstKey === 'q'
+                ? { q: 'tea', page: '1', panel: null }
+                : { q: 'init', page: '2', panel: null }
+            await expect
+              .poll(() => readLoaderControl(page))
+              .toEqual({
+                requests: [{ data: firstData, aborted: false }],
+                completed: []
+              })
+            await expect(page.locator('#navigation-state')).toHaveText(
+              'loading'
+            )
+
+            await page.locator('#panel-before').click()
+            await expectSearch(page, { ...firstData, panel: 'before' })
+            await expect(page.locator('#panel-state')).toHaveText('before')
+            await page.locator(`#set-${secondKey}`).click()
+            const pending = {
+              requests: [
+                { data: firstData, aborted: true },
+                {
+                  data: { q: 'tea', page: '2', panel: 'before' },
+                  aborted: false
+                }
+              ],
+              completed: []
+            }
+            await expect.poll(() => readLoaderControl(page)).toEqual(pending)
+
+            await page.locator('#panel-open').click()
+            await expectSearch(page, { q: 'tea', page: '2', panel: 'open' })
+            await expect(page.locator('#q-state')).toHaveText('tea')
+            await expect(page.locator('#page-state')).toHaveText('2')
+            await expect(page.locator('#panel-state')).toHaveText('open')
+            await expectLoaderData(page, { q: 'init', page: '1', panel: null })
+            await expect(page.locator('#navigation-state')).toHaveText(
+              'loading'
+            )
+            expect(await readLoaderControl(page)).toEqual(pending)
+
+            await releaseLoader(page, 2)
+            await expectLatestState(page)
+            expect(await readLoaderControl(page)).toEqual({
+              ...pending,
+              completed: [2]
+            })
+            const latestUrl = page.url()
+            const latestIndex = await readHistoryIndex(page)
+            const latestLength = await page.evaluate(() => history.length)
+
+            await releaseLoader(page, 1)
+            expect(await readLoaderControl(page)).toEqual({
+              ...pending,
+              completed: [2, 1]
+            })
+            await expectLatestState(page)
+            expect(page.url()).toBe(latestUrl)
+            expect(await readHistoryIndex(page)).toBe(latestIndex)
+            expect(await page.evaluate(() => history.length)).toBe(latestLength)
+          })
+        }
+      }
+    }
+  }
+)

--- a/packages/e2e/shared/specs/react-router/pending-loader.tsx
+++ b/packages/e2e/shared/specs/react-router/pending-loader.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useQueryState, useQueryStates } from 'nuqs'
+import { useState, type ComponentProps } from 'react'
+import {
+  pendingLoaderOptions,
+  type LoaderRequestData
+} from './pending-loader.defs'
+
+export function PendingLoader({
+  data,
+  navigationState,
+  useBlocker
+}: {
+  data: LoaderRequestData
+  navigationState: string
+  useBlocker?: (enabled: boolean) => {
+    state: string
+    reset?: () => void
+    proceed?: () => void
+  }
+}) {
+  const [{ qHistory, pageHistory, panelHistory }] =
+    useQueryStates(pendingLoaderOptions)
+  const [q, setQ] = useQueryState('q', {
+    shallow: false,
+    history: qHistory
+  })
+  const [page, setPage] = useQueryState('page', {
+    shallow: false,
+    history: pageHistory
+  })
+  const [panel, setPanel] = useQueryState('panel', {
+    shallow: true,
+    history: panelHistory
+  })
+
+  return (
+    <>
+      <button id="set-q" onClick={() => setQ('tea')}>
+        Search for tea
+      </button>
+      <button id="set-page" onClick={() => setPage('2')}>
+        Next page
+      </button>
+      <button
+        id="set-both"
+        onClick={() => {
+          setQ('tea')
+          setPage('2')
+        }}
+      >
+        Search and change page
+      </button>
+      <button id="panel-before" onClick={() => setPanel('before')}>
+        Show panel
+      </button>
+      <button id="panel-open" onClick={() => setPanel('open')}>
+        Expand panel
+      </button>
+      {useBlocker && <PendingBlocker useBlocker={useBlocker} />}
+      <output id="q-state">{q}</output>
+      <output id="page-state">{page}</output>
+      <output id="panel-state">{panel}</output>
+      <output id="loader-data">{JSON.stringify(data)}</output>
+      <output id="navigation-state">{navigationState}</output>
+    </>
+  )
+}
+
+function PendingBlocker({
+  useBlocker
+}: {
+  useBlocker: NonNullable<ComponentProps<typeof PendingLoader>['useBlocker']>
+}) {
+  const [enabled, setEnabled] = useState(false)
+  const blocker = useBlocker(enabled)
+  return (
+    <>
+      <label>
+        <input
+          id="block-navigation"
+          type="checkbox"
+          checked={enabled}
+          onChange={event => setEnabled(event.target.checked)}
+        />
+        Block navigation
+      </label>
+      <output id="blocker">{blocker.state}</output>
+      {blocker.state === 'blocked' && (
+        <>
+          <button id="cancel" onClick={() => blocker.reset?.()}>
+            Cancel
+          </button>
+          <button id="proceed" onClick={() => blocker.proceed?.()}>
+            Proceed
+          </button>
+        </>
+      )}
+    </>
+  )
+}

--- a/packages/e2e/shared/specs/react-router/pending-push.spec.ts
+++ b/packages/e2e/shared/specs/react-router/pending-push.spec.ts
@@ -1,0 +1,482 @@
+import { expect, test as it, type Page } from '@playwright/test'
+import { defineTest } from '../../define-test'
+import { expectSearch } from '../../playwright/expect-url'
+import { navigateTo } from '../../playwright/navigate'
+import type { LoaderRequestData } from './pending-loader.defs'
+
+async function expectRequests(page: Page, count: number) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => window.pendingLoaderControl?.requests.length ?? 0)
+    )
+    .toBe(count)
+}
+
+async function releaseLoader(page: Page, id: number) {
+  await expectRequests(page, id)
+  await releaseRequests(page, [id])
+}
+
+async function releaseRequests(page: Page, ids: number[]) {
+  await page.evaluate(async ids => {
+    for (const id of ids) {
+      window.pendingLoaderControl!.requests[id - 1]!.release()
+    }
+    await new Promise<void>(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+  }, ids)
+}
+
+async function blockedBack(page: Page) {
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        let remaining = 2
+        const onPop = () => {
+          if (--remaining === 0) {
+            window.removeEventListener('popstate', onPop)
+            resolve()
+          }
+        }
+        window.addEventListener('popstate', onPop)
+        history.back()
+      })
+  )
+  await expect(page.locator('#blocker')).toHaveText('blocked')
+}
+
+async function expectState(page: Page, data: LoaderRequestData) {
+  await expectSearch(page, data)
+  await expect(page.locator('#q-state')).toHaveText(data.q ?? '')
+  await expect(page.locator('#page-state')).toHaveText(data.page ?? '')
+  await expect(page.locator('#panel-state')).toHaveText(data.panel ?? '')
+}
+
+async function expectData(page: Page, data: LoaderRequestData) {
+  await expect(page.locator('#loader-data')).toHaveText(JSON.stringify(data))
+  await expect(page.locator('#navigation-state')).toHaveText('idle')
+}
+
+const initial = { q: 'init', page: '1', panel: null }
+const qOnly = { q: 'tea', page: '1', panel: null }
+const bothDeep = { q: 'tea', page: '2', panel: null }
+
+export const testPendingPush = defineTest(
+  'Pending navigation blockers',
+  ({ path }) => {
+    for (const qHistory of ['replace'] as const) {
+      for (const decision of ['cancel', 'proceed'] as const) {
+        it(`keeps repeated Back blocked through accepted completion (${qHistory}, ${decision})`, async ({
+          page
+        }) => {
+          await navigateTo(
+            page,
+            path,
+            `?q=init&page=1&qHistory=${qHistory}&panelHistory=push`
+          )
+          await expectData(page, initial)
+          const length = await page.evaluate(() => {
+            document.body.dataset.pendingPush = 'mounted'
+            return history.length
+          })
+          const expectedLength = length + 1
+          await page.locator('#set-q').click()
+          await expectRequests(page, 1)
+          await expectState(page, qOnly)
+          await page.locator('#panel-open').click()
+          const latest = { ...qOnly, panel: 'open' }
+          await expectState(page, latest)
+          await page.locator('#block-navigation').check()
+          await blockedBack(page)
+          await expectState(page, latest)
+          await blockedBack(page)
+          await expectState(page, latest)
+          await expectRequests(page, 1)
+          expect(
+            await page.evaluate(() => ({
+              aborted: window.pendingLoaderControl!.requests[0]!.aborted,
+              completed: window.pendingLoaderControl!.completed
+            }))
+          ).toEqual({ aborted: false, completed: [] })
+          await releaseLoader(page, 1)
+          await expectData(page, qOnly)
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await expectState(page, latest)
+          await expectRequests(page, 1)
+          expect(await page.evaluate(() => history.length)).toBe(expectedLength)
+          await page.locator(`#${decision}`).click()
+          if (decision === 'cancel') {
+            await expect(page.locator('#blocker')).toHaveText('unblocked')
+            await expectState(page, latest)
+            await expectRequests(page, 1)
+            await blockedBack(page)
+            await page.locator('#proceed').click()
+          }
+          await releaseLoader(page, 2)
+          await expectState(page, qOnly)
+          await expectData(page, qOnly)
+          await page.locator('#block-navigation').uncheck()
+          await page.goForward()
+          await releaseLoader(page, 3)
+          await expectState(page, latest)
+          await expectData(page, latest)
+          expect(await page.evaluate(() => history.length)).toBe(expectedLength)
+          expect(
+            await page.evaluate(() => document.body.dataset.pendingPush)
+          ).toBe('mounted')
+        })
+      }
+    }
+
+    for (const decision of ['cancel', 'proceed'] as const) {
+      it(`restores blocked Back from a shallow push while its deep replace waits (${decision})`, async ({
+        page
+      }) => {
+        const documents: string[] = []
+        page.on('request', request => {
+          if (
+            request.isNavigationRequest() &&
+            request.frame() === page.mainFrame()
+          ) {
+            documents.push(request.url())
+          }
+        })
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=replace&panelHistory=push'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => {
+          document.body.dataset.pendingPush = 'mounted'
+          return history.length
+        })
+        const initialDocuments = documents.length
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page.locator('#panel-open').click()
+        const withPanel = { ...qOnly, panel: 'open' }
+        await expectState(page, withPanel)
+        await expectRequests(page, 1)
+        await page.locator('#block-navigation').check()
+        await page.evaluate(() => history.back())
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, withPanel)
+        expect(documents).toHaveLength(initialDocuments)
+        await releaseLoader(page, 1)
+        await expectData(page, qOnly)
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, withPanel)
+        await expectRequests(page, 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        await page.locator(`#${decision}`).click()
+        if (decision === 'cancel') {
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+          await expectState(page, withPanel)
+          await expectRequests(page, 1)
+          await page.evaluate(() => history.back())
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await page.locator('#proceed').click()
+        }
+        await releaseLoader(page, 2)
+        await expectState(page, qOnly)
+        await expectData(page, qOnly)
+        await page.locator('#block-navigation').uncheck()
+        await page.goForward()
+        await releaseLoader(page, 3)
+        await expectState(page, withPanel)
+        await expectData(page, withPanel)
+        await page.goBack()
+        await releaseLoader(page, 4)
+        await expectState(page, qOnly)
+        await expectData(page, qOnly)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(documents).toHaveLength(initialDocuments)
+        expect(
+          await page.evaluate(() => document.body.dataset.pendingPush)
+        ).toBe('mounted')
+      })
+    }
+
+    for (const decision of ['cancel', 'proceed'] as const) {
+      it(`keeps blocked Back open when its accepted push loader finishes after a shallow replace (${decision})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=push&panelHistory=replace'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => {
+          document.body.dataset.pendingPush = 'mounted'
+          return history.length
+        })
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page.locator('#panel-open').click()
+        const withPanel = { ...qOnly, panel: 'open' }
+        await expectState(page, withPanel)
+        await page.locator('#block-navigation').check()
+        await page.evaluate(() => history.back())
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, withPanel)
+        await releaseLoader(page, 1)
+        await expectData(page, qOnly)
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, withPanel)
+        await expectRequests(page, 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        await page.locator(`#${decision}`).click()
+        if (decision === 'cancel') {
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+          await expectState(page, withPanel)
+          await expectRequests(page, 1)
+          await page.evaluate(() => history.back())
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await page.locator('#proceed').click()
+        }
+        await expectState(page, initial)
+        await expectData(page, initial)
+        await expectRequests(page, 1)
+        await page.locator('#block-navigation').uncheck()
+        await page.goForward()
+        await releaseLoader(page, 2)
+        await expectState(page, withPanel)
+        await expectData(page, withPanel)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(
+          await page.evaluate(() => document.body.dataset.pendingPush)
+        ).toBe('mounted')
+      })
+    }
+
+    for (const decision of ['cancel', 'proceed'] as const) {
+      it(`keeps replace continuity when its pending loader precedes a blocked push (${decision})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=replace&pageHistory=push'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => {
+          document.body.dataset.pendingPush = 'mounted'
+          return history.length
+        })
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page.locator('#block-navigation').check()
+        await page.locator('#set-page').click()
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, bothDeep)
+        if (decision === 'cancel') {
+          await page.locator('#cancel').click()
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+        }
+        await releaseLoader(page, 1)
+        await expectData(page, qOnly)
+        await expectState(page, bothDeep)
+        if (decision === 'proceed') {
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await page.locator('#proceed').click()
+          await releaseLoader(page, 2)
+          await expectData(page, bothDeep)
+        }
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        await page.evaluate(() => history.back())
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, bothDeep)
+        await page.locator('#cancel').click()
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        await expectState(page, bothDeep)
+        await page.evaluate(() => history.back())
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await page.locator('#proceed').click()
+        await releaseLoader(page, decision === 'proceed' ? 3 : 2)
+        await expectState(page, qOnly)
+        await expectData(page, qOnly)
+        expect(
+          await page.evaluate(() => document.body.dataset.pendingPush)
+        ).toBe('mounted')
+      })
+    }
+
+    it('finishes the accepted push without an extra entry after shallow replace and cancelled Back', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&panelHistory=replace'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-open').click()
+      const withPanel = { ...qOnly, panel: 'open' }
+      await expectState(page, withPanel)
+      await page.locator('#block-navigation').check()
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, withPanel)
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectState(page, withPanel)
+      await releaseLoader(page, 1)
+      await expectData(page, qOnly)
+      await expectState(page, withPanel)
+      expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, withPanel)
+      await page.locator('#proceed').click()
+      await expectState(page, initial)
+      await expectData(page, initial)
+      await expectRequests(page, 1)
+      await page.locator('#block-navigation').uncheck()
+      await page.goForward()
+      await releaseLoader(page, 2)
+      await expectState(page, withPanel)
+      await expectData(page, withPanel)
+    })
+
+    it('discards the accepted loader when the coalesced blocked second deep push proceeds first', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&pageHistory=push'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#block-navigation').check()
+      await page.locator('#set-page').click()
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, bothDeep)
+      await page.locator('#proceed').click()
+      await expectRequests(page, 2)
+      expect(
+        await page.evaluate(
+          () => window.pendingLoaderControl!.requests[0]!.aborted
+        )
+      ).toBe(true)
+      await releaseLoader(page, 2)
+      await expectData(page, bothDeep)
+      await releaseRequests(page, [1])
+      await expectData(page, bothDeep)
+      await expectState(page, bothDeep)
+      expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      await page.locator('#block-navigation').uncheck()
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
+      await expectRequests(page, 2)
+      await page.goForward()
+      await releaseLoader(page, 3)
+      await expectState(page, bothDeep)
+      await expectData(page, bothDeep)
+    })
+
+    for (const decision of ['cancel', 'proceed'] as const) {
+      it(`keeps a coalesced blocked second deep push open while the accepted loader finishes (${decision})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=push&pageHistory=push'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => history.length)
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page.locator('#block-navigation').check()
+        await page.locator('#set-page').click()
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, bothDeep)
+        await releaseLoader(page, 1)
+        await expectData(page, qOnly)
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, bothDeep)
+        await expectRequests(page, 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        await page.locator(`#${decision}`).click()
+        if (decision === 'proceed') {
+          await releaseLoader(page, 2)
+          await expectData(page, bothDeep)
+        }
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        await expectState(page, bothDeep)
+        await page.locator('#block-navigation').uncheck()
+        await page.goBack()
+        await expectState(page, initial)
+        await expectData(page, initial)
+        await expectRequests(page, decision === 'proceed' ? 2 : 1)
+        await page.goForward()
+        await releaseLoader(page, decision === 'proceed' ? 3 : 2)
+        await expectState(page, bothDeep)
+        await expectData(page, bothDeep)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      })
+    }
+
+    for (const cancelBack of [false, true]) {
+      it(`keeps one coalesced entry when a blocked second deep push is cancelled before the accepted loader finishes (cancel Back: ${cancelBack})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=push&pageHistory=push'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => history.length)
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page.locator('#block-navigation').check()
+        await page.locator('#set-page').click()
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, bothDeep)
+        await expectRequests(page, 1)
+        await page.locator('#cancel').click()
+        await expect(page.locator('#blocker')).toHaveText('unblocked')
+        if (cancelBack) {
+          await page.evaluate(() => history.back())
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await expectState(page, bothDeep)
+          await page.locator('#cancel').click()
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+          await expectState(page, bothDeep)
+        }
+        await releaseLoader(page, 1)
+        await expectData(page, qOnly)
+        await expectState(page, bothDeep)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        await page.locator('#block-navigation').uncheck()
+        await page.goBack()
+        await expectState(page, initial)
+        await expectData(page, initial)
+        await expectRequests(page, 1)
+        await page.goForward()
+        await releaseLoader(page, 2)
+        await expectState(page, bothDeep)
+        await expectData(page, bothDeep)
+        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      })
+    }
+  }
+)

--- a/packages/e2e/shared/specs/react-router/redirect-queue.defs.ts
+++ b/packages/e2e/shared/specs/react-router/redirect-queue.defs.ts
@@ -1,0 +1,44 @@
+import { parseAsStringLiteral } from 'nuqs/server'
+
+export const panelDebounceMs = 1000
+export const redirectQueueOptions = {
+  qHistory: parseAsStringLiteral(['push', 'replace']).withDefault('replace')
+}
+
+export function readRedirectQueueRequest(request: Request) {
+  const search = new URL(request.url).searchParams
+  return { q: search.get('q'), panel: search.get('panel') }
+}
+
+export type RedirectQueueData = ReturnType<typeof readRedirectQueueRequest>
+
+declare global {
+  interface Window {
+    redirectQueueControl?: {
+      requests: RedirectQueueData[]
+      release: () => void
+    }
+  }
+}
+
+export async function redirectQueueLoader({ request }: { request: Request }) {
+  const data = readRedirectQueueRequest(request)
+  const control = (window.redirectQueueControl ??= {
+    requests: [],
+    release: () => {}
+  })
+  control.requests.push(data)
+  if (data.q !== 'tea') {
+    return data
+  }
+  await new Promise<void>(resolve => {
+    control.release = resolve
+  })
+  if (new URL(request.url).searchParams.get('redirect') === 'true') {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: '?q=redirected&panel=server' }
+    })
+  }
+  return data
+}

--- a/packages/e2e/shared/specs/react-router/redirect-queue.spec.ts
+++ b/packages/e2e/shared/specs/react-router/redirect-queue.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test as it, type Page } from '@playwright/test'
+import { defineTest } from '../../define-test'
+import { expectSearch } from '../../playwright/expect-url'
+import { navigateTo } from '../../playwright/navigate'
+import { panelDebounceMs } from './redirect-queue.defs'
+
+async function queuePanelDuringNavigation(page: Page) {
+  await page.locator('#set-q').click()
+  await expect(page.locator('#navigation-state')).toHaveText('loading')
+  await expectSearch(page, { q: 'tea' })
+  await expect(page).toHaveURL(url => !url.searchParams.has('panel'))
+  await expect(page.locator('#loader-data')).toHaveText(
+    JSON.stringify({ q: 'init', panel: null })
+  )
+  await page.clock.install({ time: 0 })
+  await page.clock.pauseAt(1)
+  await page.locator('#queue-panel').click()
+  await expect(page.locator('#panel-state')).toHaveText('local')
+  await expectSearch(page, { q: 'tea' })
+  await expect(page).toHaveURL(url => !url.searchParams.has('panel'))
+  expect(
+    await page.evaluate(() => window.redirectQueueControl?.requests)
+  ).toEqual([{ q: 'tea', panel: null }])
+}
+
+export const testRedirectQueue = defineTest('Redirect queue', ({ path }) => {
+  for (const history of ['replace', 'push'] as const) {
+    it(`cancels a debounced panel edit when a deep ${history} redirects`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, `?q=init&qHistory=${history}&redirect=true`)
+      await queuePanelDuringNavigation(page)
+      await page.evaluate(() => window.redirectQueueControl!.release())
+      await expect(page.locator('#navigation-state')).toHaveText('idle')
+      await expect(page).toHaveURL(
+        url =>
+          url.pathname === path && url.search === '?q=redirected&panel=server'
+      )
+      await expect(page.locator('#loader-data')).toHaveText(
+        JSON.stringify({ q: 'redirected', panel: 'server' })
+      )
+
+      await page.clock.runFor(panelDebounceMs + 100)
+      await expect(page).toHaveURL(
+        url =>
+          url.pathname === path && url.search === '?q=redirected&panel=server'
+      )
+      await expect(page.locator('#q-state')).toHaveText('redirected')
+      await expect(page.locator('#panel-state')).toHaveText('server')
+      await expect(page.locator('#loader-data')).toHaveText(
+        JSON.stringify({ q: 'redirected', panel: 'server' })
+      )
+      expect(
+        await page.evaluate(() => window.redirectQueueControl?.requests)
+      ).toEqual([
+        { q: 'tea', panel: null },
+        { q: 'redirected', panel: 'server' }
+      ])
+    })
+
+    it(`keeps a debounced panel edit when a deep ${history} commits its request`, async ({
+      page
+    }) => {
+      await navigateTo(page, path, `?q=init&qHistory=${history}`)
+      await queuePanelDuringNavigation(page)
+      await page.evaluate(() => window.redirectQueueControl!.release())
+      await expect(page.locator('#navigation-state')).toHaveText('idle')
+      await expect(page.locator('#loader-data')).toHaveText(
+        JSON.stringify({ q: 'tea', panel: null })
+      )
+      await expect(page.locator('#q-state')).toHaveText('tea')
+      await expect(page.locator('#panel-state')).toHaveText('local')
+      await expect(page).toHaveURL(
+        url =>
+          url.pathname === path && url.search === `?q=tea&qHistory=${history}`
+      )
+
+      await page.clock.runFor(panelDebounceMs + 100)
+      await expect(page).toHaveURL(
+        url =>
+          url.pathname === path &&
+          url.search === `?q=tea&qHistory=${history}&panel=local`
+      )
+      await expect(page.locator('#q-state')).toHaveText('tea')
+      await expect(page.locator('#panel-state')).toHaveText('local')
+      await expect(page.locator('#loader-data')).toHaveText(
+        JSON.stringify({ q: 'tea', panel: null })
+      )
+      await expect(page.locator('#navigation-state')).toHaveText('idle')
+      expect(
+        await page.evaluate(() => window.redirectQueueControl?.requests)
+      ).toEqual([{ q: 'tea', panel: null }])
+    })
+  }
+})

--- a/packages/e2e/shared/specs/react-router/redirect-queue.tsx
+++ b/packages/e2e/shared/specs/react-router/redirect-queue.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { debounce, useQueryState, useQueryStates } from 'nuqs'
+import {
+  panelDebounceMs,
+  redirectQueueOptions,
+  type RedirectQueueData
+} from './redirect-queue.defs'
+
+export function RedirectQueue({
+  data,
+  navigationState
+}: {
+  data: RedirectQueueData
+  navigationState: string
+}) {
+  const [{ qHistory }] = useQueryStates(redirectQueueOptions)
+  const [q, setQ] = useQueryState('q', {
+    shallow: false,
+    history: qHistory
+  })
+  const [panel, setPanel] = useQueryState('panel', {
+    shallow: true,
+    history: 'replace',
+    limitUrlUpdates: debounce(panelDebounceMs)
+  })
+
+  return (
+    <>
+      <button id="set-q" onClick={() => setQ('tea')}>
+        Search for tea
+      </button>
+      <button id="queue-panel" onClick={() => setPanel('local')}>
+        Queue panel edit
+      </button>
+      <output id="q-state">{q}</output>
+      <output id="panel-state">{panel}</output>
+      <output id="loader-data">{JSON.stringify(data)}</output>
+      <output id="navigation-state">{navigationState}</output>
+    </>
+  )
+}

--- a/packages/e2e/shared/specs/react-router/repro-1563.defs.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.defs.ts
@@ -1,3 +1,13 @@
+import { parseAsStringLiteral } from 'nuqs/server'
+
+const history = parseAsStringLiteral(['push', 'replace'])
+
+export const reproHistoryOptions = {
+  testHistory: history.withDefault('push'),
+  otherHistory: history.withDefault('replace'),
+  shallowHistory: history.withDefault('replace')
+}
+
 const loaderCalls = new Map<string, number>()
 
 export function countLoaderCall(request: Request): number {

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -4,8 +4,20 @@ import { expectSearch } from '../../playwright/expect-url'
 import { readHistoryIndex } from '../../playwright/history'
 import { navigateTo } from '../../playwright/navigate'
 
-async function navigateToRepro(page: Page, path: string, search: string) {
+async function navigateToRepro(
+  page: Page,
+  path: string,
+  search: string,
+  options: {
+    testHistory?: 'push' | 'replace'
+    otherHistory?: 'push' | 'replace'
+    shallowHistory?: 'push' | 'replace'
+  } = {}
+) {
   const searchParams = new URLSearchParams(search)
+  for (const [key, value] of Object.entries(options)) {
+    searchParams.set(key, value)
+  }
   searchParams.set('loaderId', crypto.randomUUID())
   await navigateTo(page, path, `?${searchParams}`)
 }
@@ -175,7 +187,9 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
 
   for (const history of ['replace', 'push'] as const) {
     it(`does not run loaders for shallow ${history}`, async ({ page }) => {
-      await navigateToRepro(page, path, '?test=init&delay=1000')
+      await navigateToRepro(page, path, '?test=init&delay=1000', {
+        shallowHistory: history
+      })
       const initialLoaderCall = await readLoaderCall(page)
 
       await page.locator(`#shallow-${history}`).click()
@@ -206,7 +220,10 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('adds an entry when a deep push takes over a pending deep replace', async ({
     page
   }) => {
-    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      testHistory: 'replace',
+      otherHistory: 'push'
+    })
     const initialIndex = await readHistoryIndex(page)
     const initialHistoryLength = await page.evaluate(() => history.length)
     await page.locator('#deep-replace').click()
@@ -273,7 +290,9 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('keeps a shallow replace made while a deep replace is pending', async ({
     page
   }) => {
-    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      testHistory: 'replace'
+    })
     const initialIndex = await readHistoryIndex(page)
     const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#deep-replace').click()
@@ -286,10 +305,12 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
   })
 
-  it('keeps a shallow push made while a deep push is pending', async ({
+  it('currently coalesces a shallow push with a pending deep push', async ({
     page
   }) => {
-    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      shallowHistory: 'push'
+    })
     const initialIndex = await readHistoryIndex(page)
     const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#push').click()
@@ -308,7 +329,10 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('keeps a shallow push made while a deep replace is pending', async ({
     page
   }) => {
-    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      testHistory: 'replace',
+      shallowHistory: 'push'
+    })
     const initialLoaderCall = await readLoaderCall(page)
     const initialHistoryLength = await page.evaluate(() => history.length)
     await page.locator('#deep-replace').click()
@@ -326,7 +350,10 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('does not let a pending deep replace mutate history after Back', async ({
     page
   }) => {
-    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      testHistory: 'replace',
+      shallowHistory: 'push'
+    })
     const initialIndex = await readHistoryIndex(page)
     const initialLoaderCall = await readLoaderCall(page)
     await page.locator('#deep-replace').click()
@@ -422,7 +449,9 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('shallow-pushes after Back cancelled a pending deep push', async ({
     page
   }) => {
-    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      shallowHistory: 'push'
+    })
     const initialIndex = await readHistoryIndex(page)
     await page.locator('#push').click()
     await expect(page).toHaveURL(url => url.searchParams.get('test') === 'pass')

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -14,6 +14,123 @@ async function readLoaderCall(page: Page): Promise<number> {
   return Number(await page.locator('#loader-call').textContent())
 }
 
+export const testRepro1563Link = defineTest('repro-1563-link', ({ path }) => {
+  it('keeps a queued update when a separate Link is canceled', async ({
+    page
+  }) => {
+    it.setTimeout(10_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#debounced-other').click()
+    await page.locator('#block-links').check()
+    await page.locator('#router-link').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel-link').click()
+    await page.locator('#block-links').uncheck()
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+    await expectSearch(page, { test: 'pass', other: 'pass' })
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+  })
+
+  it('reuses the pending search entry for its own redirect', async ({
+    page
+  }) => {
+    it.setTimeout(10_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000&redirect=true')
+    await page.locator('#push').click()
+    await expectSearch(page, { test: 'redirected' })
+    await expect(page.locator('#loader-state')).toHaveText('redirected')
+    await page.goBack()
+    await expectSearch(page, { test: 'init' })
+    await expect(page.locator('#loader-state')).toHaveText('init')
+  })
+
+  it('keeps the pending search before a separate Link redirect', async ({
+    page
+  }) => {
+    it.setTimeout(10_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#router-redirect-link').click()
+    await expectSearch(page, { test: 'redirected' })
+    await expect(page.locator('#loader-state')).toHaveText('redirected')
+    await page.goBack()
+    await expectSearch(page, { test: 'pass' })
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+    await page.goBack()
+    await expectSearch(page, { test: 'init' })
+  })
+
+  it('lets the pending search finish when a separate Link is canceled', async ({
+    page
+  }) => {
+    it.setTimeout(10_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#block-links').check()
+    await page.locator('#router-link').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#cancel-link').click()
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+
+    await page.locator('#block-links').uncheck()
+    await page.goBack()
+    await expectSearch(page, { test: 'init' })
+    await expect(page.locator('#loader-state')).toHaveText('init')
+  })
+
+  it('keeps the pending search when a blocked Link proceeds', async ({
+    page
+  }) => {
+    it.setTimeout(10_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#block-links').check()
+    await page.locator('#router-link').click()
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#proceed-link').click()
+    await expect(page).toHaveURL(url => url.pathname === '/')
+    await expect(page.locator('#router-link')).toHaveCount(0)
+
+    await page.goBack()
+    await expectSearch(page, { test: 'pass' })
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+    await page.goBack()
+    await expectSearch(page, { test: 'init' })
+  })
+
+  it('keeps a pending push before a separate Link push', async ({ page }) => {
+    it.setTimeout(10_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000')
+    await expect(page.locator('#loader-state')).toHaveText('init')
+
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#router-link').click()
+    await expect(page).toHaveURL(url => url.pathname === '/')
+    await expect(page.locator('#router-link')).toHaveCount(0)
+
+    await page.goBack()
+    await expectSearch(page, { test: 'pass' })
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+
+    await page.goBack()
+    await expectSearch(page, { test: 'init' })
+    await expect(page.locator('#loader-state')).toHaveText('init')
+    await page.goForward()
+    await expectSearch(page, { test: 'pass' })
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+    await page.goForward()
+    await expect(page).toHaveURL(url => url.pathname === '/')
+  })
+})
+
 export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
   it('advances the router history index on push with shallow: false', async ({
     page

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { debounce, useQueryState } from 'nuqs'
+import { debounce, useQueryState, useQueryStates } from 'nuqs'
 import { useState } from 'react'
+import { reproHistoryOptions } from './repro-1563.defs'
 
 type Repro1563Props = {
   loaderCall: number
@@ -27,12 +28,21 @@ export function Repro1563({
   useNavigationType,
   useBlocker
 }: Repro1563Props) {
+  const [{ testHistory, otherHistory, shallowHistory }] =
+    useQueryStates(reproHistoryOptions)
   const [state, setState] = useQueryState('test', {
-    history: 'push',
+    history: testHistory,
     shallow: false
   })
-  const [, setOther] = useQueryState('other', { shallow: false })
-  const [shallow, setShallow] = useQueryState('shallow')
+  const [, setOther] = useQueryState('other', {
+    history: otherHistory,
+    shallow: false
+  })
+  const [shallow, setShallow] = useQueryState('shallow', {
+    history: shallowHistory,
+    shallow: true,
+    limitUrlUpdates: debounce(100)
+  })
   const navigate = useNavigate()
   const navigation = useNavigation()
   const navigationType = useNavigationType()
@@ -43,8 +53,11 @@ export function Repro1563({
 
   return (
     <>
-      <button id="push" onClick={() => setState('pass')}>
-        Push
+      <button
+        id={testHistory === 'push' ? 'push' : 'deep-replace'}
+        onClick={() => setState('pass')}
+      >
+        Update test
       </button>
       <button
         id="router-replace"
@@ -66,43 +79,16 @@ export function Repro1563({
         Push then replace
       </button>
       <button
-        id="deep-replace"
-        onClick={() => setState('pass', { history: 'replace' })}
+        id={`shallow-${shallowHistory}`}
+        onClick={() => setShallow('pass')}
       >
-        Deep replace
+        Update shallow
       </button>
       <button
-        id="push-other"
-        onClick={() => setOther('pass', { history: 'push' })}
+        id={otherHistory === 'push' ? 'push-other' : 'replace'}
+        onClick={() => setOther('pass')}
       >
-        Push other
-      </button>
-      <button
-        id="shallow-replace"
-        onClick={() =>
-          setShallow('pass', {
-            history: 'replace',
-            shallow: true,
-            limitUrlUpdates: debounce(100)
-          })
-        }
-      >
-        Shallow replace
-      </button>
-      <button
-        id="shallow-push"
-        onClick={() =>
-          setShallow('pass', {
-            history: 'push',
-            shallow: true,
-            limitUrlUpdates: debounce(100)
-          })
-        }
-      >
-        Shallow push
-      </button>
-      <button id="replace" onClick={() => setOther('pass')}>
-        Replace
+        Update other
       </button>
       <pre id="state">{state}</pre>
       <pre id="shallow-state">{shallow}</pre>

--- a/packages/e2e/shared/specs/react-router/repro-1563.tsx
+++ b/packages/e2e/shared/specs/react-router/repro-1563.tsx
@@ -1,22 +1,31 @@
 'use client'
 
 import { debounce, useQueryState } from 'nuqs'
+import { useState } from 'react'
 
 type Repro1563Props = {
   loaderCall: number
+  loaderState?: string | null
   useNavigate: () => (
     to: string,
     options?: { replace?: boolean }
   ) => void | Promise<void>
   useNavigation: () => { state: string }
   useNavigationType: () => string
+  useBlocker?: (enabled: boolean) => {
+    state: string
+    reset?: () => void
+    proceed?: () => void
+  }
 }
 
 export function Repro1563({
   loaderCall,
+  loaderState,
   useNavigate,
   useNavigation,
-  useNavigationType
+  useNavigationType,
+  useBlocker
 }: Repro1563Props) {
   const [state, setState] = useQueryState('test', {
     history: 'push',
@@ -46,6 +55,12 @@ export function Repro1563({
         }}
       >
         Router replace
+      </button>
+      <button
+        id="debounced-other"
+        onClick={() => setOther('pass', { limitUrlUpdates: debounce(2000) })}
+      >
+        Debounced replace
       </button>
       <button id="push-then-replace" onClick={pushThenReplace}>
         Push then replace
@@ -92,8 +107,43 @@ export function Repro1563({
       <pre id="state">{state}</pre>
       <pre id="shallow-state">{shallow}</pre>
       <pre id="loader-call">{loaderCall}</pre>
+      <pre id="loader-state">{loaderState}</pre>
       <pre id="navigation-state">{navigation.state}</pre>
       <pre id="navigation-type">{navigationType}</pre>
+      {useBlocker && <LinkBlocker useBlocker={useBlocker} />}
+    </>
+  )
+}
+
+function LinkBlocker({
+  useBlocker
+}: {
+  useBlocker: NonNullable<Repro1563Props['useBlocker']>
+}) {
+  const [enabled, setEnabled] = useState(false)
+  const blocker = useBlocker(enabled)
+  return (
+    <>
+      <label>
+        <input
+          id="block-links"
+          type="checkbox"
+          checked={enabled}
+          onChange={event => setEnabled(event.target.checked)}
+        />
+        Block navigation
+      </label>
+      <output id="blocker">{blocker.state}</output>
+      {blocker.state === 'blocked' && (
+        <>
+          <button id="cancel-link" onClick={() => blocker.reset?.()}>
+            Cancel
+          </button>
+          <button id="proceed-link" onClick={() => blocker.proceed?.()}>
+            Proceed
+          </button>
+        </>
+      )}
     </>
   )
 }

--- a/packages/e2e/shared/specs/react-router/stitching.slow-loader.spec.ts
+++ b/packages/e2e/shared/specs/react-router/stitching.slow-loader.spec.ts
@@ -9,7 +9,7 @@ export const testStitchingSlowLoader = defineTest(
   'Stitching - slow loader',
   ({ path }) => {
     for (const hook of ['useQueryState', 'useQueryStates'] as const) {
-      it(`keeps stitching updates while a deep push loader is pending (${hook})`, async ({
+      it(`currently coalesces deep pushes across keys while a loader is pending (${hook})`, async ({
         page
       }) => {
         await navigateTo(

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -58,7 +58,7 @@ function traverse(action: () => void): Promise<void> {
 
 describe('patchHistory: pending navigation', () => {
   beforeAll(() => {
-    patchHistory(emitter, 'test')
+    patchHistory(emitter, 'test', { trackRouterHistory: true })
     window.addEventListener('popstate', () =>
       indexSeenOnPop(history.state?.idx)
     )

--- a/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.browser.test.ts
@@ -6,9 +6,11 @@ import {
   markPendingPush,
   markPendingReplace,
   patchHistory,
+  setPendingNavigationBlocker,
   type SearchParamsSyncEmitterEvents
 } from './patch-history'
 
+const go = vi.spyOn(history, 'go')
 const pushState = vi.spyOn(history, 'pushState')
 const replaceState = vi.spyOn(history, 'replaceState')
 const emitter = createEmitter<SearchParamsSyncEmitterEvents>()
@@ -29,6 +31,14 @@ function optimisticPush(search: string) {
   const url = new URL(search, location.href)
   history.pushState(markPendingPush(url), historyUpdateMarker, url)
   pushState.mockClear()
+}
+
+function expectRepairedState(idx: number): void {
+  expect(history.state).toEqual({
+    idx,
+    [historyUpdateMarker]: expect.any(Number),
+    __nuqs_offset__: 0
+  })
 }
 
 function traverse(action: () => void): Promise<void> {
@@ -57,6 +67,7 @@ describe('patchHistory: pending navigation', () => {
     routerReplace('?')
     routerPush('?')
     expect(hasPendingPush()).toBe(false)
+    go.mockClear()
     pushState.mockClear()
     replaceState.mockClear()
     onUpdate.mockClear()
@@ -82,6 +93,124 @@ describe('patchHistory: pending navigation', () => {
       new URLSearchParams('?a=1')
     )
     expect(hasPendingPush()).toBe(false)
+  })
+
+  for (const end of [
+    'cancel',
+    'push',
+    'replace',
+    'supersede',
+    'pop'
+  ] as const) {
+    it(`stops tracking the blocker on ${end}`, () => {
+      optimisticPush('?a=1')
+      const onEnd = vi.fn()
+      setPendingNavigationBlocker({
+        isCancelled: () => end === 'cancel',
+        unsubscribe: onEnd
+      })
+      if (end === 'push') routerPush('?a=1')
+      if (end === 'replace') routerReplace('?a=1')
+      if (end === 'supersede') optimisticPush('?b=1')
+      if (end === 'pop') window.dispatchEvent(new PopStateEvent('popstate'))
+      hasPendingPush()
+      expect(onEnd).toHaveBeenCalledOnce()
+    })
+  }
+
+  it('repairs a cancelled push when React Router blocks Back', async () => {
+    optimisticPush('?a=1')
+    setPendingNavigationBlocker({ isCancelled: () => true })
+    expect(hasPendingPush()).toBe(false)
+    await new Promise<void>((resolve, reject) => {
+      let pops = 0
+      const timeout = setTimeout(() => {
+        window.removeEventListener('popstate', onPop)
+        reject(new Error('history was not restored within 2s'))
+      }, 2000)
+      function onPop() {
+        pops++
+        if (pops === 1) {
+          history.go(0)
+        } else {
+          clearTimeout(timeout)
+          window.removeEventListener('popstate', onPop)
+          resolve()
+        }
+      }
+      window.addEventListener('popstate', onPop)
+      history.back()
+    })
+    expect(go).toHaveBeenCalledExactlyOnceWith(1)
+    expect(history.state?.idx).toBe(2)
+    expect(location.search).toBe('?a=1')
+  })
+
+  it.each([
+    ['null', null],
+    ['number', 42],
+    ['array', ['value']],
+    ['object', { value: true }]
+  ])('preserves %s state in an unmarked URL-less push', (_, state) => {
+    optimisticPush('?a=1')
+    setPendingNavigationBlocker({ isCancelled: () => true })
+    expect(hasPendingPush()).toBe(false)
+    history.pushState(state, '')
+    expect(history.state).toEqual(state)
+  })
+
+  it.each([
+    ['null', null],
+    ['number', 42],
+    ['array', ['draft']],
+    ['object', { value: true }],
+    ['date', new Date('2026-01-01')],
+    ['map', new Map([['value', true]])]
+  ])('preserves %s state in a marked shallow push', (_, state) => {
+    history.replaceState(state, '', '?before')
+    history.pushState(history.state, historyUpdateMarker, '?after')
+    expect(history.state).toEqual(state)
+  })
+
+  it('stops folding a cancelled navigation without a query hook update', () => {
+    optimisticPush('?a=1')
+    setPendingNavigationBlocker({ isCancelled: () => true })
+    routerPush('?b=1')
+    expect(pushState).toHaveBeenCalledExactlyOnceWith({ idx: 1 }, '', '?b=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith(
+      { idx: 2, [historyUpdateMarker]: expect.any(Number), __nuqs_offset__: 0 },
+      '',
+      undefined
+    )
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('keeps a navigation that has not been cancelled', () => {
+    optimisticPush('?a=1')
+    setPendingNavigationBlocker({ isCancelled: () => false })
+    expect(hasPendingPush()).toBe(true)
+    routerPush('?a=1')
+    expect(pushState).not.toHaveBeenCalled()
+    expect(hasPendingPush()).toBe(false)
+  })
+
+  it('does not cancel a superseding navigation', () => {
+    optimisticPush('?a=1')
+    setPendingNavigationBlocker({ isCancelled: () => true })
+    optimisticPush('?b=1')
+    expect(hasPendingPush()).toBe(true)
+    routerPush('?b=1')
+    expect(pushState).not.toHaveBeenCalled()
+  })
+
+  it('does not retarget a cancelled replace', () => {
+    markPendingReplace(new URL('?a=1', location.href))
+    history.replaceState(history.state, historyUpdateMarker, '?a=1')
+    history.replaceState(history.state, historyUpdateMarker, '?a=2')
+    replaceState.mockClear()
+    setPendingNavigationBlocker({ isCancelled: () => true })
+    routerReplace('?a=1')
+    expect(replaceState).toHaveBeenCalledExactlyOnceWith({ idx: 1 }, '', '?a=1')
   })
 
   it('replaces the pending entry with a redirected commit', () => {
@@ -140,7 +269,7 @@ describe('patchHistory: pending navigation', () => {
     )
     await traverse(() => history.back())
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 5 })
+    expectRepairedState(5)
     expect(hasPendingPush()).toBe(false)
   })
 
@@ -159,7 +288,7 @@ describe('patchHistory: pending navigation', () => {
     await traverse(() => history.back())
     history.replaceState({ idx: 4, usr: 'unrelated' }, '', '?')
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 5 })
+    expectRepairedState(5)
     expect(hasPendingPush()).toBe(false)
   })
 
@@ -171,7 +300,7 @@ describe('patchHistory: pending navigation', () => {
     history.replaceState(history.state, historyUpdateMarker, '?b=1')
     history.replaceState({ idx: 4 }, '', '?b=1')
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 5 })
+    expectRepairedState(5)
     expect(hasPendingPush()).toBe(false)
   })
 
@@ -181,7 +310,7 @@ describe('patchHistory: pending navigation', () => {
     history.replaceState(history.state, historyUpdateMarker, '?a=1&b=2')
     await traverse(() => history.back())
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 5 })
+    expectRepairedState(5)
     expect(hasPendingPush()).toBe(false)
   })
 
@@ -204,18 +333,17 @@ describe('patchHistory: pending navigation', () => {
     history.pushState(history.state, historyUpdateMarker, '?a=1&shallow=1')
     history.replaceState(history.state, historyUpdateMarker, '?a=1&shallow=2')
     await traverse(() => history.back())
-    expect(history.state).toEqual({ idx: 5 })
+    expectRepairedState(5)
     expect(hasPendingPush()).toBe(false)
   })
 
-  it('does not repair an entry that only shares the pending marker', async () => {
+  it('repairs a shallow entry using its own offset when it shares the pending marker', async () => {
     history.replaceState({ idx: 4 }, historyUpdateMarker, '?')
     optimisticPush('?a=1')
     history.pushState(history.state, historyUpdateMarker, '?a=1&shallow=1')
     history.pushState(history.state, historyUpdateMarker, '?a=1&shallow=2')
     await traverse(() => history.back())
-    expect(history.state.idx).toBe(4)
-    expect(history.state[historyUpdateMarker]).toBeDefined()
+    expectRepairedState(6)
   })
 
   it('clears a pending push when a replace lands elsewhere without a pop', () => {
@@ -255,7 +383,10 @@ describe('patchHistory: pending navigation', () => {
     optimisticPush('?a=1')
     await traverse(() => history.back())
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ [historyUpdateMarker]: expect.any(Number) })
+    expect(history.state).toEqual({
+      [historyUpdateMarker]: expect.any(Number),
+      __nuqs_offset__: 0
+    })
     expect(hasPendingPush()).toBe(false)
     pushState.mockClear()
     replaceState.mockClear()
@@ -394,7 +525,7 @@ describe('patchHistory: pending navigation', () => {
     )
     await traverse(() => history.back())
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 1 })
+    expectRepairedState(1)
     expect(hasPendingPush()).toBe(false)
   })
 
@@ -490,7 +621,7 @@ describe('patchHistory: pending navigation', () => {
       '?a=1&shallow=pass'
     )
     await traverse(() => history.forward())
-    expect(history.state).toEqual({ idx: 1 })
+    expectRepairedState(1)
     expect(hasPendingPush()).toBe(false)
   })
 

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -3,7 +3,6 @@ import { createEmitter, type Emitter } from '../../lib/emitter'
 import { error } from '../../lib/errors'
 import { globalSingleton } from '../../lib/global-singleton'
 import {
-  getQueueResetMutex,
   resetQueues,
   setQueueResetMutex,
   spinQueueResetMutex
@@ -138,9 +137,8 @@ export function interruptPendingPush(): () => boolean {
     return () => false
   }
   const state = history.state
-  const queueResetMutex = getQueueResetMutex()
   const interrupted = { ...current, unsubscribe: undefined }
-  cancelPendingNavigation()
+  const queueResetMutex = cancelPendingNavigation()
   return () => {
     if (
       pendingNavigation.current ||
@@ -158,11 +156,9 @@ export function interruptPendingPush(): () => boolean {
   }
 }
 
-export function cancelPendingNavigation(onPop = false): void {
+export function cancelPendingNavigation(onPop = false): number | undefined {
   const current = pendingNavigation.current
-  if (current) {
-    setQueueResetMutex(1)
-  }
+  const queueResetMutex = current ? setQueueResetMutex(1) : undefined
   if (current?.history === 'push' && (onPop || isPendingPushEntry(current))) {
     const isAnyBlockerProceeding = current.isAnyBlockerProceeding
     clearCurrentPendingNavigation()
@@ -171,9 +167,10 @@ export function cancelPendingNavigation(onPop = false): void {
     if (!onPop) {
       repairPendingPushIndex(current)
     }
-    return
+    return queueResetMutex
   }
   clearCurrentPendingNavigation()
+  return queueResetMutex
 }
 
 function getPendingNavigation(): PendingNavigation | null {

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -3,6 +3,7 @@ import { createEmitter, type Emitter } from '../../lib/emitter'
 import { error } from '../../lib/errors'
 import { globalSingleton } from '../../lib/global-singleton'
 import {
+  getQueueResetMutex,
   resetQueues,
   setQueueResetMutex,
   spinQueueResetMutex
@@ -115,6 +116,45 @@ export function setPendingNavigationBlocker({
     current.isOriginalBlockerOpen = isOriginalBlockerOpen
   } else {
     unsubscribe?.()
+  }
+}
+
+export function onPendingNavigationEnd(onEnd: () => void): void {
+  const current = pendingNavigation.current
+  if (!current) {
+    onEnd()
+    return
+  }
+  const unsubscribe = current.unsubscribe
+  current.unsubscribe = () => {
+    unsubscribe?.()
+    onEnd()
+  }
+}
+
+export function interruptPendingPush(): () => boolean {
+  const current = getPendingNavigation()
+  if (current?.history !== 'push' || !isPendingPushEntry(current)) {
+    return () => false
+  }
+  const state = history.state
+  const queueResetMutex = getQueueResetMutex()
+  const interrupted = { ...current, unsubscribe: undefined }
+  cancelPendingNavigation()
+  return () => {
+    if (
+      pendingNavigation.current ||
+      pendingNavigation.cancelledPush !== current ||
+      !isPendingPushEntry(current) ||
+      interrupted.isCancelled?.()
+    ) {
+      return false
+    }
+    clearCancelledPush()
+    history.replaceState(state, historyUpdateMarker)
+    pendingNavigation.current = interrupted
+    setQueueResetMutex(queueResetMutex)
+    return true
   }
 }
 

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -259,7 +259,7 @@ function getHistoryStateOffset(state: History['state']): number {
     : 0
 }
 
-function repairHistoryIndex(): number | undefined {
+export function repairHistoryIndex(): number | undefined {
   const index = history.state?.idx
   if (typeof index !== 'number') {
     return

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -419,7 +419,8 @@ export function markHistoryAsPatched(adapter: string): void {
 
 export function patchHistory(
   emitter: Emitter<SearchParamsSyncEmitterEvents>,
-  adapter: string
+  adapter: string,
+  { trackRouterHistory = false }: { trackRouterHistory?: boolean } = {}
 ): void {
   if (!shouldPatchHistory(adapter)) {
     return
@@ -435,8 +436,10 @@ export function patchHistory(
     'popstate',
     () => {
       lastSearchSeen = location.search
-      handlePopOnPendingNavigation()
-      repairHistoryIndex()
+      if (trackRouterHistory) {
+        handlePopOnPendingNavigation()
+        repairHistoryIndex()
+      }
       resetQueues()
     },
     { capture: true }
@@ -456,6 +459,19 @@ export function patchHistory(
     } catch (e) {
       console.error(e)
     }
+  }
+  if (!trackRouterHistory) {
+    for (const method of ['pushState', 'replaceState'] as const) {
+      const original = history[method]
+      history[method] = function nuqs_history(state, marker, url) {
+        original.call(history, state, '', url)
+        if (marker !== historyUpdateMarker && url) {
+          sync(url)
+        }
+      }
+    }
+    markHistoryAsPatched(adapter)
+    return
   }
   const originalPushState = history.pushState
   const originalReplaceState = history.replaceState

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -10,7 +10,10 @@ import {
 import { getSearchParams } from '../../lib/search-params'
 import { version } from '../../lib/version'
 
-export type SearchParamsSyncEmitterEvents = { update: URLSearchParams }
+export type SearchParamsSyncEmitterEvents = {
+  update: URLSearchParams
+  pop: { index: number; delta: number }
+}
 
 export function getHistorySyncEmitter(
   adapter: string
@@ -40,19 +43,21 @@ type PendingNavigationBase = Partial<PendingNavigationBlocker> & {
   entryHref: string
 }
 
-type PendingPush = PendingNavigationBase & {
-  history: 'push'
-  id: number
+type PendingNavigation = PendingNavigationBase & {
+  history: 'push' | 'replace'
+  id: number | undefined
   offset: number
   routerIndex: number | undefined
 }
 
-type PendingNavigation =
-  PendingPush | (PendingNavigationBase & { history: 'replace' })
-
 const pendingNavigation = globalSingleton('pending-navigation', () => ({
   current: null as PendingNavigation | null,
-  cancelledPush: null as PendingPush | null,
+  accepted: null as
+    | (Pick<PendingNavigation, 'history' | 'requestedHref'> & {
+        onCommit?: () => void
+      })
+    | null,
+  cancelledPush: null as PendingNavigation | null,
   cancelledPushTraversal: null as
     'departing' | 'restoring' | 'proceeding' | null,
   cancelledPushDistance: null as number | null,
@@ -61,6 +66,41 @@ const pendingNavigation = globalSingleton('pending-navigation', () => ({
 
 function withoutEmptyFragment(href: string): string {
   return href.replace(/^([^#]*)#$/, '$1')
+}
+
+export function capturePendingNavigation(): (onCommit: () => void) => void {
+  const current = getPendingNavigation()
+  const accepted =
+    pendingNavigation.accepted ??
+    (current?.isOriginalBlockerOpen?.() ? null : current)
+  pendingNavigation.accepted = null
+  return onCommit => {
+    pendingNavigation.accepted = accepted ? { ...accepted, onCommit } : null
+  }
+}
+
+export function discardAcceptedNavigation(): void {
+  pendingNavigation.accepted = null
+}
+
+function preserveAcceptedCommit(
+  url: string | URL,
+  history: 'push' | 'replace'
+): boolean {
+  const accepted = pendingNavigation.accepted
+  if (
+    accepted?.history !== history ||
+    withoutEmptyFragment(new URL(url, location.href).href) !==
+      withoutEmptyFragment(accepted.requestedHref)
+  ) {
+    return false
+  }
+  pendingNavigation.accepted = null
+  accepted.onCommit?.()
+  if (pendingNavigation.cancelledPush) {
+    repairPendingPushIndex(pendingNavigation.cancelledPush)
+  }
+  return true
 }
 
 export function markPendingPush(
@@ -97,7 +137,10 @@ export function markPendingReplace(url: URL): void {
   pendingNavigation.current = {
     history: 'replace',
     requestedHref: url.href,
-    entryHref: url.href
+    entryHref: url.href,
+    id: history.state?.[historyUpdateMarker],
+    offset: getHistoryStateOffset(history.state),
+    routerIndex: history.state?.idx
   }
 }
 
@@ -115,6 +158,14 @@ export function setPendingNavigationBlocker({
     current.isOriginalBlockerOpen = isOriginalBlockerOpen
   } else {
     unsubscribe?.()
+  }
+}
+
+export function setPendingPopBlocker(
+  isAnyBlockerProceeding: () => boolean
+): void {
+  if (pendingNavigation.current) {
+    pendingNavigation.current.isAnyBlockerProceeding = isAnyBlockerProceeding
   }
 }
 
@@ -164,7 +215,7 @@ export function cancelPendingNavigation(onPop = false): number | undefined {
     clearCurrentPendingNavigation()
     current.isAnyBlockerProceeding = isAnyBlockerProceeding
     pendingNavigation.cancelledPush = current
-    if (!onPop) {
+    if (!onPop && !pendingNavigation.accepted) {
       repairPendingPushIndex(current)
     }
     return queueResetMutex
@@ -180,10 +231,12 @@ function getPendingNavigation(): PendingNavigation | null {
   return pendingNavigation.current
 }
 
-function isPendingPushEntry(pending: PendingPush): boolean {
+function isPendingPushEntry(pending: PendingNavigation): boolean {
   return (
     history.state?.[historyUpdateMarker] === pending.id &&
-    history.state?.[historyUpdateOffsetMarker] === pending.offset &&
+    (pending.history === 'replace'
+      ? getHistoryStateOffset(history.state)
+      : history.state?.[historyUpdateOffsetMarker]) === pending.offset &&
     history.state?.idx === pending.routerIndex &&
     location.href === pending.entryHref
   )
@@ -213,10 +266,8 @@ function movePendingHref(): void {
       continue
     }
     pending.entryHref = location.href
-    if (
-      pending.history === 'push' &&
-      history.state?.[historyUpdateMarker] === pending.id
-    ) {
+    if (history.state?.[historyUpdateMarker] === pending.id) {
+      pending.routerIndex = history.state.idx
       pending.offset =
         history.state[historyUpdateOffsetMarker] ?? pending.offset
     }
@@ -249,6 +300,7 @@ function clearCancelledPush(): void {
 }
 
 function clearPendingNavigation(): void {
+  pendingNavigation.accepted = null
   clearCurrentPendingNavigation()
   clearCancelledPush()
 }
@@ -278,7 +330,7 @@ export function repairHistoryIndex(): number | undefined {
   return index + offset
 }
 
-function repairPendingPushIndex(pending: PendingPush): void {
+function repairPendingPushIndex(pending: PendingNavigation): void {
   const index = repairHistoryIndex()
   if (index !== undefined) {
     pending.routerIndex = index
@@ -286,7 +338,7 @@ function repairPendingPushIndex(pending: PendingPush): void {
   }
 }
 
-function getCancelledPushDistance(pending: PendingPush): number | null {
+function getCancelledPushDistance(pending: PendingNavigation): number | null {
   const targetOffset = history.state?.[historyUpdateOffsetMarker]
   if (
     typeof pending.routerIndex === 'number' &&
@@ -315,16 +367,48 @@ function handlePopOnPendingNavigation(): void {
   ) {
     cancelPendingNavigation(true)
   }
+  if (
+    !pendingNavigation.cancelledPush &&
+    pendingNavigation.current?.isAnyBlockerProceeding
+  ) {
+    pendingNavigation.cancelledPush = pendingNavigation.current
+  }
   const cancelledPush = pendingNavigation.cancelledPush
   if (cancelledPush) {
     if (pendingNavigation.cancelledPushTraversal === 'restoring') {
       if (isPendingPushEntry(cancelledPush)) {
         repairPendingPushIndex(cancelledPush)
         pendingNavigation.cancelledPushTraversal = null
+        if (
+          (pendingNavigation.current === cancelledPush &&
+            cancelledPush.history === 'push') ||
+          pendingNavigation.accepted?.history === 'push'
+        ) {
+          queueMicrotask(() => {
+            if (
+              (pendingNavigation.current === cancelledPush ||
+                (pendingNavigation.accepted &&
+                  pendingNavigation.cancelledPush === cancelledPush)) &&
+              isPendingPushEntry(cancelledPush) &&
+              typeof cancelledPush.routerIndex === 'number'
+            ) {
+              history.replaceState(
+                {
+                  ...history.state,
+                  idx: cancelledPush.routerIndex - 1,
+                  [historyUpdateOffsetMarker]: 1
+                },
+                historyUpdateMarker
+              )
+            }
+          })
+        }
       }
       return
     }
     if (pendingNavigation.cancelledPushTraversal === 'proceeding') {
+      pendingNavigation.accepted = null
+      clearCurrentPendingNavigation()
       clearCancelledPush()
     } else if (!isPendingPushEntry(cancelledPush)) {
       const distance = getCancelledPushDistance(cancelledPush)
@@ -339,12 +423,21 @@ function handlePopOnPendingNavigation(): void {
           pendingNavigation.cancelledPushTraversal === 'departing' &&
           pendingNavigation.cancelledPush === cancelledPush
         ) {
+          pendingNavigation.accepted = null
+          if (pendingNavigation.current === cancelledPush) {
+            clearCurrentPendingNavigation()
+          }
           clearCancelledPush()
         }
       }, 0)
     }
   }
-  clearCurrentPendingNavigation()
+  if (pendingNavigation.current !== cancelledPush) {
+    clearCurrentPendingNavigation()
+  }
+  if (!cancelledPush) {
+    pendingNavigation.accepted = null
+  }
 }
 
 function retargetPendingCommit(
@@ -352,10 +445,14 @@ function retargetPendingCommit(
   url: string | URL
 ): string {
   const href = new URL(url, location.href).href
-  return withoutEmptyFragment(href) ===
-    withoutEmptyFragment(pending.requestedHref)
-    ? pending.entryHref
-    : href
+  if (
+    withoutEmptyFragment(href) === withoutEmptyFragment(pending.requestedHref)
+  ) {
+    return pending.entryHref
+  }
+  // Redirects must not inherit the expected commit's queue protection.
+  setQueueResetMutex(1)
+  return href
 }
 
 function pendingPushCommitUrl(url: string | URL): string | null {
@@ -426,6 +523,11 @@ export function patchHistory(
     return
   }
   let lastSearchSeen = typeof location === 'object' ? location.search : ''
+  const readIndex = () =>
+    typeof history.state?.idx === 'number'
+      ? history.state.idx + getHistoryStateOffset(history.state)
+      : undefined
+  let lastHistoryIndex = readIndex()
 
   emitter.on('update', search => {
     const searchString = search.toString()
@@ -437,6 +539,12 @@ export function patchHistory(
     () => {
       lastSearchSeen = location.search
       if (trackRouterHistory) {
+        const index = readIndex()
+        const previousIndex = lastHistoryIndex
+        lastHistoryIndex = index
+        if (index !== undefined && previousIndex !== undefined) {
+          emitter.emit('pop', { index, delta: index - previousIndex })
+        }
         handlePopOnPendingNavigation()
         repairHistoryIndex()
       }
@@ -473,8 +581,16 @@ export function patchHistory(
     markHistoryAsPatched(adapter)
     return
   }
-  const originalPushState = history.pushState
-  const originalReplaceState = history.replaceState
+  const nativePushState = history.pushState
+  const nativeReplaceState = history.replaceState
+  const originalPushState: History['pushState'] = function (...args) {
+    nativePushState.apply(history, args)
+    lastHistoryIndex = readIndex()
+  }
+  const originalReplaceState: History['replaceState'] = function (...args) {
+    nativeReplaceState.apply(history, args)
+    lastHistoryIndex = readIndex()
+  }
   const originalGo = history.go
   history.go = function nuqs_go(delta) {
     const cancelledPush = pendingNavigation.cancelledPush
@@ -522,7 +638,12 @@ export function patchHistory(
       if (onTrackedEntry) {
         movePendingHref()
       }
-      if (onCancelledPush && pendingNavigation.cancelledPush) {
+      if (
+        onCancelledPush &&
+        pendingNavigation.cancelledPush &&
+        pendingNavigation.current !== pendingNavigation.cancelledPush &&
+        !pendingNavigation.accepted
+      ) {
         repairPendingPushIndex(pendingNavigation.cancelledPush)
       }
       if (onCancelledPush && pendingNavigation.cancelledPushDistance !== null) {
@@ -532,6 +653,10 @@ export function patchHistory(
     }
     if (!url) {
       originalPushState.call(history, state, '', url)
+      return
+    }
+    if (preserveAcceptedCommit(url, 'push')) {
+      sync(location.href)
       return
     }
     // The router committing an optimistic deep push must not add
@@ -552,6 +677,10 @@ export function patchHistory(
       if (onTrackedEntry) {
         movePendingHref()
       }
+      return
+    }
+    if (preserveAcceptedCommit(url, 'replace')) {
+      sync(location.href)
       return
     }
     const commitUrl = pendingReplaceCommit(url)

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -2,7 +2,11 @@ import { debug } from '../../lib/debug'
 import { createEmitter, type Emitter } from '../../lib/emitter'
 import { error } from '../../lib/errors'
 import { globalSingleton } from '../../lib/global-singleton'
-import { resetQueues, spinQueueResetMutex } from '../../lib/queues/reset'
+import {
+  resetQueues,
+  setQueueResetMutex,
+  spinQueueResetMutex
+} from '../../lib/queues/reset'
 import { getSearchParams } from '../../lib/search-params'
 import { version } from '../../lib/version'
 
@@ -17,19 +21,29 @@ export function getHistorySyncEmitter(
 }
 
 export const historyUpdateMarker = '__nuqs__'
+const historyUpdateOffsetMarker = '__nuqs_offset__'
 
 type PendingPushState = {
   [historyUpdateMarker]: number
+  [historyUpdateOffsetMarker]: number
 }
 
-type PendingNavigationBase = {
-  href: string
-  currentHref: string
+type PendingNavigationBlocker = {
+  isCancelled: () => boolean
+  unsubscribe?: () => void
+  isAnyBlockerProceeding?: () => boolean
+  isOriginalBlockerOpen?: () => boolean
+}
+
+type PendingNavigationBase = Partial<PendingNavigationBlocker> & {
+  requestedHref: string
+  entryHref: string
 }
 
 type PendingPush = PendingNavigationBase & {
   history: 'push'
   id: number
+  offset: number
   routerIndex: number | undefined
 }
 
@@ -38,7 +52,10 @@ type PendingNavigation =
 
 const pendingNavigation = globalSingleton('pending-navigation', () => ({
   current: null as PendingNavigation | null,
-  popped: null as PendingPush | null,
+  cancelledPush: null as PendingPush | null,
+  cancelledPushTraversal: null as
+    'departing' | 'restoring' | 'proceeding' | null,
+  cancelledPushDistance: null as number | null,
   nextId: 0
 }))
 
@@ -46,89 +63,251 @@ function withoutEmptyFragment(href: string): string {
   return href.replace(/^([^#]*)#$/, '$1')
 }
 
-export function markPendingPush(url: URL): PendingPushState {
+export function markPendingPush(
+  url: URL,
+  mode: 'push' | 'replace' = 'push'
+): PendingPushState {
+  clearCurrentPendingNavigation()
+  clearCancelledPush()
   const id = ++pendingNavigation.nextId
+  const state = { ...history.state }
+  let routerIndex = state.idx
+  if (typeof routerIndex === 'number') {
+    routerIndex += getHistoryStateOffset(state) - (mode === 'replace' ? 1 : 0)
+    state.idx = routerIndex
+  }
+  const offset = typeof routerIndex === 'number' ? 1 : 0
   pendingNavigation.current = {
     history: 'push',
-    href: url.href,
-    currentHref: url.href,
+    requestedHref: url.href,
+    entryHref: url.href,
     id,
-    routerIndex: history.state?.idx
+    offset,
+    routerIndex
   }
-  return { ...history.state, [historyUpdateMarker]: id }
+  return {
+    ...state,
+    [historyUpdateMarker]: id,
+    [historyUpdateOffsetMarker]: offset
+  }
 }
 
 export function markPendingReplace(url: URL): void {
+  clearCurrentPendingNavigation()
   pendingNavigation.current = {
     history: 'replace',
-    href: url.href,
-    currentHref: url.href
+    requestedHref: url.href,
+    entryHref: url.href
   }
+}
+
+export function setPendingNavigationBlocker({
+  isCancelled,
+  unsubscribe,
+  isAnyBlockerProceeding,
+  isOriginalBlockerOpen
+}: PendingNavigationBlocker): void {
+  const current = pendingNavigation.current
+  if (current) {
+    current.isCancelled = isCancelled
+    current.unsubscribe = unsubscribe
+    current.isAnyBlockerProceeding = isAnyBlockerProceeding
+    current.isOriginalBlockerOpen = isOriginalBlockerOpen
+  } else {
+    unsubscribe?.()
+  }
+}
+
+export function cancelPendingNavigation(onPop = false): void {
+  const current = pendingNavigation.current
+  if (current) {
+    setQueueResetMutex(1)
+  }
+  if (current?.history === 'push' && (onPop || isPendingPushEntry(current))) {
+    const isAnyBlockerProceeding = current.isAnyBlockerProceeding
+    clearCurrentPendingNavigation()
+    current.isAnyBlockerProceeding = isAnyBlockerProceeding
+    pendingNavigation.cancelledPush = current
+    if (!onPop) {
+      repairPendingPushIndex(current)
+    }
+    return
+  }
+  clearCurrentPendingNavigation()
+}
+
+function getPendingNavigation(): PendingNavigation | null {
+  if (pendingNavigation.current?.isCancelled?.()) {
+    cancelPendingNavigation()
+  }
+  return pendingNavigation.current
 }
 
 function isPendingPushEntry(pending: PendingPush): boolean {
   return (
     history.state?.[historyUpdateMarker] === pending.id &&
-    // Shallow updates pass the starting state to pushState or replaceState.
-    // The URL distinguishes the pending entry from the resulting marker copies.
-    location.href === pending.currentHref
+    history.state?.[historyUpdateOffsetMarker] === pending.offset &&
+    history.state?.idx === pending.routerIndex &&
+    location.href === pending.entryHref
   )
 }
 
 function isOnPendingPushEntry(): boolean {
-  const pending = pendingNavigation.current
+  const pending = getPendingNavigation()
   return pending?.history === 'push' && isPendingPushEntry(pending)
 }
 
 function isOnPendingReplaceEntry(): boolean {
-  const pending = pendingNavigation.current
-  return pending?.history === 'replace' && location.href === pending.currentHref
+  const pending = getPendingNavigation()
+  return pending?.history === 'replace' && location.href === pending.entryHref
+}
+
+function isOnCancelledPushEntry(): boolean {
+  const pending = pendingNavigation.cancelledPush
+  return pending !== null && isPendingPushEntry(pending)
 }
 
 function movePendingHref(): void {
-  const pending = pendingNavigation.current
-  if (pending) {
-    pending.currentHref = location.href
+  for (const pending of [
+    getPendingNavigation(),
+    pendingNavigation.cancelledPush
+  ]) {
+    if (!pending) {
+      continue
+    }
+    pending.entryHref = location.href
+    if (
+      pending.history === 'push' &&
+      history.state?.[historyUpdateMarker] === pending.id
+    ) {
+      pending.offset =
+        history.state[historyUpdateOffsetMarker] ?? pending.offset
+    }
   }
 }
 
 export function hasPendingPush(): boolean {
-  return pendingNavigation.current?.history === 'push'
+  return getPendingNavigation()?.history === 'push'
+}
+
+function clearCurrentPendingNavigation(): void {
+  const current = pendingNavigation.current
+  if (current) {
+    current.unsubscribe?.()
+    current.unsubscribe = undefined
+    current.isCancelled = undefined
+    current.isAnyBlockerProceeding = undefined
+    current.isOriginalBlockerOpen = undefined
+  }
+  pendingNavigation.current = null
+}
+
+function clearCancelledPush(): void {
+  if (pendingNavigation.cancelledPush) {
+    pendingNavigation.cancelledPush.isAnyBlockerProceeding = undefined
+  }
+  pendingNavigation.cancelledPush = null
+  pendingNavigation.cancelledPushTraversal = null
+  pendingNavigation.cancelledPushDistance = null
 }
 
 function clearPendingNavigation(): void {
-  pendingNavigation.current = null
-  pendingNavigation.popped = null
+  clearCurrentPendingNavigation()
+  clearCancelledPush()
+}
+
+function getHistoryStateOffset(state: History['state']): number {
+  return typeof state?.[historyUpdateOffsetMarker] === 'number'
+    ? state[historyUpdateOffsetMarker]
+    : 0
+}
+
+function repairHistoryIndex(): number | undefined {
+  const index = history.state?.idx
+  if (typeof index !== 'number') {
+    return
+  }
+  const offset = getHistoryStateOffset(history.state)
+  if (offset !== 0) {
+    history.replaceState(
+      {
+        ...history.state,
+        idx: index + offset,
+        [historyUpdateOffsetMarker]: 0
+      },
+      historyUpdateMarker
+    )
+  }
+  return index + offset
 }
 
 function repairPendingPushIndex(pending: PendingPush): void {
-  if (typeof pending.routerIndex !== 'number') {
-    return
+  const index = repairHistoryIndex()
+  if (index !== undefined) {
+    pending.routerIndex = index
+    pending.offset = 0
   }
-  const { [historyUpdateMarker]: _, ...state } = history.state
-  history.replaceState(
-    { ...state, idx: pending.routerIndex + 1 },
-    historyUpdateMarker
-  )
 }
 
-// Traversing forward onto an entry the router never committed leaves it
-// with the index nuqs cloned from its predecessor. Repair it before
-// the router reads it, so traversal deltas stay right (#1563).
-function handlePopOnPendingNavigation(): void {
-  const { current, popped } = pendingNavigation
-  if (popped && isPendingPushEntry(popped)) {
-    repairPendingPushIndex(popped)
-    pendingNavigation.popped = null
+function getCancelledPushDistance(pending: PendingPush): number | null {
+  const targetOffset = history.state?.[historyUpdateOffsetMarker]
+  if (
+    typeof pending.routerIndex === 'number' &&
+    typeof history.state?.idx === 'number'
+  ) {
+    return (
+      pending.routerIndex +
+      pending.offset -
+      history.state.idx -
+      getHistoryStateOffset(history.state)
+    )
   }
-  if (current?.history === 'push') {
-    if (isPendingPushEntry(current)) {
-      repairPendingPushIndex(current)
-    } else {
-      pendingNavigation.popped = current
+  if (
+    history.state?.[historyUpdateMarker] === pending.id &&
+    typeof targetOffset === 'number'
+  ) {
+    return pending.offset - targetOffset
+  }
+  return null
+}
+
+function handlePopOnPendingNavigation(): void {
+  if (
+    pendingNavigation.current?.isOriginalBlockerOpen?.() ||
+    pendingNavigation.current?.isCancelled?.()
+  ) {
+    cancelPendingNavigation(true)
+  }
+  const cancelledPush = pendingNavigation.cancelledPush
+  if (cancelledPush) {
+    if (pendingNavigation.cancelledPushTraversal === 'restoring') {
+      if (isPendingPushEntry(cancelledPush)) {
+        repairPendingPushIndex(cancelledPush)
+        pendingNavigation.cancelledPushTraversal = null
+      }
+      return
+    }
+    if (pendingNavigation.cancelledPushTraversal === 'proceeding') {
+      clearCancelledPush()
+    } else if (!isPendingPushEntry(cancelledPush)) {
+      const distance = getCancelledPushDistance(cancelledPush)
+      if (distance === null || distance < 1) {
+        clearCancelledPush()
+        return
+      }
+      pendingNavigation.cancelledPushDistance = distance
+      pendingNavigation.cancelledPushTraversal = 'departing'
+      setTimeout(() => {
+        if (
+          pendingNavigation.cancelledPushTraversal === 'departing' &&
+          pendingNavigation.cancelledPush === cancelledPush
+        ) {
+          clearCancelledPush()
+        }
+      }, 0)
     }
   }
-  pendingNavigation.current = null
+  clearCurrentPendingNavigation()
 }
 
 function retargetPendingCommit(
@@ -136,35 +315,32 @@ function retargetPendingCommit(
   url: string | URL
 ): string {
   const href = new URL(url, location.href).href
-  return withoutEmptyFragment(href) === withoutEmptyFragment(pending.href)
-    ? pending.currentHref
+  return withoutEmptyFragment(href) ===
+    withoutEmptyFragment(pending.requestedHref)
+    ? pending.entryHref
     : href
 }
 
 function pendingPushCommitUrl(url: string | URL): string | null {
-  const pending = pendingNavigation.current
+  const pending = getPendingNavigation()
   return pending?.history === 'push' && isPendingPushEntry(pending)
     ? retargetPendingCommit(pending, url)
     : null
 }
 
 function pendingReplaceCommit(url: string | URL): string | URL {
-  const pending = pendingNavigation.current
+  const pending = getPendingNavigation()
   return pending?.history === 'replace'
     ? retargetPendingCommit(pending, url)
     : url
 }
 
-// React Router reads the optimistic entry's idx into its private index before
-// it calls replaceState.
-// This function can repair only the persisted entry.
-// The router stays one behind until its next traversal reads the landed entry.
-// The first Back computes a zero delta, so a blocker calls history.go(0).
-// That call reloads the page; later traversals see the repaired indices.
+// This repairs the entry, not React Router's private index.
+// The first blocked Back can still call history.go(0) and reload.
 function repairPendingPushReplaceState(
   state: History['state']
 ): History['state'] {
-  const pending = pendingNavigation.current
+  const pending = getPendingNavigation()
   return pending?.history === 'push' &&
     isPendingPushEntry(pending) &&
     typeof pending.routerIndex === 'number' &&
@@ -223,6 +399,7 @@ export function patchHistory(
     () => {
       lastSearchSeen = location.search
       handlePopOnPendingNavigation()
+      repairHistoryIndex()
       resetQueues()
     },
     { capture: true }
@@ -245,13 +422,63 @@ export function patchHistory(
   }
   const originalPushState = history.pushState
   const originalReplaceState = history.replaceState
+  const originalGo = history.go
+  history.go = function nuqs_go(delta) {
+    const cancelledPush = pendingNavigation.cancelledPush
+    const distance = pendingNavigation.cancelledPushDistance
+    if (
+      cancelledPush &&
+      distance !== null &&
+      pendingNavigation.cancelledPushTraversal === 'departing'
+    ) {
+      pendingNavigation.cancelledPushTraversal = 'restoring'
+      originalGo.call(history, distance)
+      return
+    }
+    if (
+      cancelledPush &&
+      distance !== null &&
+      isPendingPushEntry(cancelledPush) &&
+      cancelledPush.isAnyBlockerProceeding?.()
+    ) {
+      pendingNavigation.cancelledPushTraversal = 'proceeding'
+      originalGo.call(history, -distance)
+      return
+    }
+    originalGo.call(history, delta)
+  }
   history.pushState = function nuqs_pushState(state, marker, url) {
-    if (marker === historyUpdateMarker || !url) {
-      const onPendingReplaceEntry = isOnPendingReplaceEntry()
-      originalPushState.call(history, state, '', url)
-      if (onPendingReplaceEntry) {
+    if (marker === historyUpdateMarker) {
+      const onCancelledPush = isOnCancelledPushEntry()
+      const onTrackedEntry = isOnPendingReplaceEntry() || onCancelledPush
+      const current = getPendingNavigation()
+      const isMarkedPendingPush =
+        current?.history === 'push' &&
+        !isPendingPushEntry(current) &&
+        state?.[historyUpdateMarker] === current.id &&
+        state?.[historyUpdateOffsetMarker] === current.offset
+      const nextState =
+        isMarkedPendingPush || typeof state?.idx !== 'number'
+          ? state
+          : {
+              ...state,
+              [historyUpdateOffsetMarker]:
+                getHistoryStateOffset(history.state) + 1
+            }
+      originalPushState.call(history, nextState, '', url)
+      if (onTrackedEntry) {
         movePendingHref()
       }
+      if (onCancelledPush && pendingNavigation.cancelledPush) {
+        repairPendingPushIndex(pendingNavigation.cancelledPush)
+      }
+      if (onCancelledPush && pendingNavigation.cancelledPushDistance !== null) {
+        pendingNavigation.cancelledPushDistance++
+      }
+      return
+    }
+    if (!url) {
+      originalPushState.call(history, state, '', url)
       return
     }
     // The router committing an optimistic deep push must not add
@@ -263,10 +490,13 @@ export function patchHistory(
     sync(commitUrl ?? url)
   }
   history.replaceState = function nuqs_replaceState(state, marker, url) {
-    const onPendingEntry = isOnPendingPushEntry() || isOnPendingReplaceEntry()
+    const onTrackedEntry =
+      isOnPendingPushEntry() ||
+      isOnPendingReplaceEntry() ||
+      isOnCancelledPushEntry()
     if (!url || marker === historyUpdateMarker) {
       originalReplaceState.call(history, state, '', url)
-      if (onPendingEntry) {
+      if (onTrackedEntry) {
         movePendingHref()
       }
       return
@@ -278,7 +508,8 @@ export function patchHistory(
       '',
       commitUrl
     )
-    pendingNavigation.current = null
+    clearCurrentPendingNavigation()
+    clearCancelledPush()
     sync(commitUrl)
   }
   markHistoryAsPatched(adapter)

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -7,6 +7,8 @@ import type { AdapterInterface, AdapterOptions } from './defs'
 import { applyChange, filterSearchParams } from './key-isolation'
 import {
   cancelPendingNavigation,
+  capturePendingNavigation,
+  discardAcceptedNavigation,
   getHistorySyncEmitter,
   hasPendingPush,
   historyUpdateMarker,
@@ -16,6 +18,7 @@ import {
   onPendingNavigationEnd,
   repairHistoryIndex,
   setPendingNavigationBlocker,
+  setPendingPopBlocker,
   patchHistory as applyHistoryPatch
 } from './patch-history'
 
@@ -55,11 +58,100 @@ type DataRouter = {
 }
 
 const navigationCleanups = new WeakMap<DataRouter, () => void>()
+const popSubscriptions = new WeakMap<
+  DataRouter,
+  { count: number; unsubscribe: () => void }
+>()
+
+function trackRouterPopBlockers(
+  router: DataRouter | undefined,
+  emitter: ReturnType<typeof getHistorySyncEmitter>
+): () => void {
+  if (!router) return () => {}
+  let subscription = popSubscriptions.get(router)
+  if (!subscription) {
+    let pending: {
+      index: number
+      restoreIndex: number | undefined
+      blockers: DataRouter['state']['blockers']
+      key?: string
+      location?: unknown
+    } | null = null
+    const onPop = ({ index, delta }: { index: number; delta: number }) => {
+      if (pending?.restoreIndex === index) {
+        pending.restoreIndex = undefined
+        return
+      }
+      if (!delta || !router.state.navigation?.location) {
+        return
+      }
+      pending = {
+        index,
+        restoreIndex: index - delta,
+        blockers: router.state.blockers
+      }
+    }
+    const unsubscribe = router.subscribe(() => {
+      if (!pending) return
+      if (!pending.key) {
+        for (const [key, blocker] of router.state.blockers ?? []) {
+          if (
+            blocker.state === 'blocked' &&
+            blocker !== pending.blockers?.get(key)
+          ) {
+            pending.key = key
+            pending.location = blocker.location
+            return
+          }
+        }
+        pending = null
+        return
+      }
+      const blocker = router.state.blockers?.get(pending.key)
+      if (
+        blocker?.state === 'blocked' &&
+        blocker.location === pending.location
+      ) {
+        return
+      }
+      const index = pending.index
+      pending = null
+      if (
+        blocker?.state === 'unblocked' &&
+        !router.state.navigation?.location &&
+        typeof history.state?.idx === 'number'
+      ) {
+        history.go(index - history.state.idx)
+      }
+    })
+    emitter.on('pop', onPop)
+    subscription = {
+      count: 0,
+      unsubscribe: () => {
+        emitter.off('pop', onPop)
+        unsubscribe()
+      }
+    }
+    popSubscriptions.set(router, subscription)
+  }
+  subscription.count++
+  return () => {
+    if (--subscription.count === 0) {
+      subscription.unsubscribe()
+      popSubscriptions.delete(router)
+    }
+  }
+}
 
 function trackRouterNavigations(router: DataRouter | undefined): void {
   if (!router || navigationCleanups.has(router)) {
     return
   }
+  setPendingPopBlocker(() =>
+    Array.from(router.state.blockers?.values() ?? []).some(
+      blocker => blocker.state === 'proceeding'
+    )
+  )
   const navigate = router.navigate
   const navigateOutsideNuqs: DataRouter['navigate'] = (to, options) => {
     if (typeof to === 'number') {
@@ -109,7 +201,9 @@ function trackRouterNavigations(router: DataRouter | undefined): void {
 
 function trackNewNavigationBlocker(
   router: DataRouter | undefined,
-  blockersBeforeNavigation: DataRouter['state']['blockers']
+  blockersBeforeNavigation: DataRouter['state']['blockers'],
+  preserveAcceptedNavigation: (onCommit: () => void) => void,
+  retryNavigation: () => unknown
 ): void {
   if (!router) {
     return
@@ -121,8 +215,13 @@ function trackNewNavigationBlocker(
     if (blocker.state !== 'blocked') {
       continue
     }
+    let acceptedCommit = false
+    preserveAcceptedNavigation(() => {
+      acceptedCommit = true
+    })
     let didProceed = false
     const isCancelled = () =>
+      !acceptedCommit &&
       !didProceed &&
       router.state.blockers?.get(key)?.location !== blocker.location
     const isAnyBlockerProceeding = () => {
@@ -135,9 +234,19 @@ function trackNewNavigationBlocker(
     }
     const handleBlockerDecision = () => {
       const current = router.state.blockers?.get(key)
+      if (acceptedCommit && current?.state === 'unblocked') {
+        unsubscribe()
+        setPendingNavigationBlocker({ isCancelled: () => false })
+        const before = router.state.blockers
+        retryNavigation()
+        trackNewNavigationBlocker(router, before, () => {}, retryNavigation)
+        trackRouterNavigations(router)
+        return
+      }
       didProceed ||=
         current?.state === 'proceeding' && current.location === blocker.location
       if (didProceed) {
+        discardAcceptedNavigation()
         unsubscribe()
       } else if (isCancelled()) {
         cancelPendingNavigation()
@@ -198,6 +307,7 @@ export function createReactRouterBasedAdapter({
   ): AdapterInterface {
     const navigate = useNavigate()
     const router = useRouter()
+    useEffect(() => trackRouterPopBlockers(router, emitter), [router])
     const searchParams = useOptimisticSearchParams(watchKeys)
     const updateUrl = useCallback(
       (search: URLSearchParams, options: AdapterOptions) => {
@@ -220,6 +330,9 @@ export function createReactRouterBasedAdapter({
             ? history.pushState
             : history.replaceState
         setQueueResetMutex(requiresRouterNavigation ? 2 : 1)
+        const preserveAcceptedNavigation = requiresRouterNavigation
+          ? capturePendingNavigation()
+          : () => {}
         const historyState = routerCommitsPush
           ? markPendingPush(url, hasUncommittedPush ? 'replace' : 'push')
           : history.state
@@ -248,20 +361,29 @@ export function createReactRouterBasedAdapter({
             markPendingReplace(url)
           }
           const blockersBeforeNavigation = router?.state.blockers
-          const result = navigate(
-            {
-              // Somehow passing the full URL object here strips the search params
-              // when accessing the request.url in loaders.
-              hash: url.hash,
-              search: url.search
-            },
-            {
-              replace: !routerCommitsPush,
-              preventScrollReset: true,
-              state: history.state?.usr
-            }
+          const retryNavigation = () => {
+            if (router) navigationCleanups.get(router)?.()
+            return navigate(
+              {
+                // Somehow passing the full URL object here strips the search params
+                // when accessing the request.url in loaders.
+                hash: url.hash,
+                search: url.search
+              },
+              {
+                replace: !routerCommitsPush,
+                preventScrollReset: true,
+                state: history.state?.usr
+              }
+            )
+          }
+          const result = retryNavigation()
+          trackNewNavigationBlocker(
+            router,
+            blockersBeforeNavigation,
+            preserveAcceptedNavigation,
+            retryNavigation
           )
-          trackNewNavigationBlocker(router, blockersBeforeNavigation)
           // Return the router's promise; waiting for a commit can deadlock.
           if (result instanceof Promise) {
             navigationPromise = result

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -6,11 +6,13 @@ import { createAdapterProvider, type AdapterProvider } from './context'
 import type { AdapterInterface, AdapterOptions } from './defs'
 import { applyChange, filterSearchParams } from './key-isolation'
 import {
+  cancelPendingNavigation,
   getHistorySyncEmitter,
   hasPendingPush,
   historyUpdateMarker,
   markPendingPush,
   markPendingReplace,
+  setPendingNavigationBlocker,
   patchHistory as applyHistoryPatch
 } from './patch-history'
 
@@ -36,7 +38,85 @@ type UseSearchParams = (initial: URLSearchParams) => [URLSearchParams, {}]
 
 // --
 
+type DataRouter = {
+  state: {
+    blockers?: Map<string, { state: string; location?: unknown }>
+  }
+  subscribe: (listener: () => void) => () => void
+  deleteBlocker: (key: string) => void
+}
+
+function trackNewNavigationBlocker(
+  router: DataRouter | undefined,
+  blockersBeforeNavigation: DataRouter['state']['blockers']
+): void {
+  if (!router) {
+    return
+  }
+  for (const [key, blocker] of router.state.blockers ?? []) {
+    if (blocker === blockersBeforeNavigation?.get(key)) {
+      continue
+    }
+    if (blocker.state !== 'blocked') {
+      continue
+    }
+    let didProceed = false
+    const isCancelled = () =>
+      !didProceed &&
+      router.state.blockers?.get(key)?.location !== blocker.location
+    const isAnyBlockerProceeding = () => {
+      for (const current of router.state.blockers?.values() ?? []) {
+        if (current.state === 'proceeding') {
+          return true
+        }
+      }
+      return false
+    }
+    const handleBlockerDecision = () => {
+      const current = router.state.blockers?.get(key)
+      didProceed ||=
+        current?.state === 'proceeding' && current.location === blocker.location
+      if (didProceed) {
+        unsubscribe()
+      } else if (isCancelled()) {
+        cancelPendingNavigation()
+      }
+    }
+    const unsubscribe = subscribeToBlockerUpdatesAndRemoval(
+      router,
+      handleBlockerDecision
+    )
+    setPendingNavigationBlocker({
+      isCancelled,
+      unsubscribe,
+      isAnyBlockerProceeding,
+      isOriginalBlockerOpen: () => router.state.blockers?.get(key) === blocker
+    })
+    break
+  }
+}
+
+function subscribeToBlockerUpdatesAndRemoval(
+  router: DataRouter,
+  onChange: () => void
+): () => void {
+  const unsubscribe = router.subscribe(onChange)
+  const deleteBlocker = router.deleteBlocker
+  const removeBlocker = (key: string) => {
+    deleteBlocker.call(router, key)
+    onChange()
+  }
+  router.deleteBlocker = removeBlocker
+  return () => {
+    unsubscribe()
+    if (router.deleteBlocker === removeBlocker) {
+      router.deleteBlocker = deleteBlocker
+    }
+  }
+}
+
 type CreateReactRouterBasedAdapterArgs = {
+  useRouter?: () => DataRouter | undefined
   adapter: string
   useNavigate: UseNavigate
   useSearchParams: UseSearchParams
@@ -45,7 +125,8 @@ type CreateReactRouterBasedAdapterArgs = {
 export function createReactRouterBasedAdapter({
   adapter,
   useNavigate,
-  useSearchParams
+  useSearchParams,
+  useRouter = () => undefined
 }: CreateReactRouterBasedAdapterArgs): {
   NuqsAdapter: AdapterProvider
   useOptimisticSearchParams: () => URLSearchParams
@@ -55,6 +136,7 @@ export function createReactRouterBasedAdapter({
     watchKeys: string[]
   ): AdapterInterface {
     const navigate = useNavigate()
+    const router = useRouter()
     const searchParams = useOptimisticSearchParams(watchKeys)
     const updateUrl = useCallback(
       (search: URLSearchParams, options: AdapterOptions) => {
@@ -64,41 +146,32 @@ export function createReactRouterBasedAdapter({
         const url = new URL(location.href)
         url.search = renderQueryString(search)
         debug(20, adapter, url)
-        // First, update the URL locally without triggering a network request,
-        // this allows keeping a reactive URL if the network is slow.
-        //
-        // While a deep push is pending, later writes must target the same top
-        // entry: shallow pushes fold as replaces and deep replaces keep push
-        // semantics. Otherwise the router commit would overwrite an entry
-        // stacked above its optimistic entry (#1563).
-        const isDeep = options.shallow === false
-        const pendingPush = hasPendingPush()
-        const commitsAsPush =
-          isDeep && (options.history === 'push' || pendingPush)
-        const updateMethod =
-          options.history === 'push' && !pendingPush
+        const requiresRouterNavigation = options.shallow === false
+        const hasUncommittedPush = hasPendingPush()
+        const routerCommitsPush =
+          requiresRouterNavigation &&
+          (options.history === 'push' || hasUncommittedPush)
+        const writeOptimisticHistory =
+          options.history === 'push' && !hasUncommittedPush
             ? history.pushState
             : history.replaceState
-        setQueueResetMutex(isDeep ? 2 : 1)
-        const historyState = commitsAsPush
-          ? markPendingPush(url)
+        setQueueResetMutex(requiresRouterNavigation ? 2 : 1)
+        const historyState = routerCommitsPush
+          ? markPendingPush(url, hasUncommittedPush ? 'replace' : 'push')
           : history.state
-        updateMethod.call(
+        writeOptimisticHistory.call(
           history,
-          historyState, // Maintain the history state
+          historyState,
           historyUpdateMarker,
           url
         )
-        let navigationSettled: Promise<void> | undefined
-        // A shallow push with no deep navigation skips the router and its loaders.
-        // It cannot advance the router's private history index.
-        // On the first blocked traversal, React Router computes a zero delta.
-        // It calls history.go(0), which reloads the page.
-        if (isDeep) {
-          if (!commitsAsPush) {
+        let navigationPromise: Promise<void> | undefined
+        if (requiresRouterNavigation) {
+          if (!routerCommitsPush) {
             markPendingReplace(url)
           }
-          const maybePromise = navigate(
+          const blockersBeforeNavigation = router?.state.blockers
+          const result = navigate(
             {
               // Somehow passing the full URL object here strips the search params
               // when accessing the request.url in loaders.
@@ -106,27 +179,23 @@ export function createReactRouterBasedAdapter({
               search: url.search
             },
             {
-              replace: !commitsAsPush,
+              replace: !routerCommitsPush,
               preventScrollReset: true,
               state: history.state?.usr
             }
           )
-          // Returning the navigation promise (v7+) turns the user's
-          // startTransition into an async action, keeping isPending true
-          // until loaders have settled (#1184). It must come from the router,
-          // not from observing a commit: while the action is pending, React
-          // entangles the router's own transition-wrapped state updates with
-          // it, so waiting on a commit would deadlock.
-          if (maybePromise instanceof Promise) {
-            navigationSettled = maybePromise
+          trackNewNavigationBlocker(router, blockersBeforeNavigation)
+          // Return the router's promise; waiting for a commit can deadlock.
+          if (result instanceof Promise) {
+            navigationPromise = result
           }
         }
         if (options.scroll) {
           window.scrollTo(0, 0)
         }
-        return navigationSettled
+        return navigationPromise
       },
-      [navigate]
+      [navigate, router]
     )
     return {
       searchParams,

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -10,8 +10,10 @@ import {
   getHistorySyncEmitter,
   hasPendingPush,
   historyUpdateMarker,
+  interruptPendingPush,
   markPendingPush,
   markPendingReplace,
+  onPendingNavigationEnd,
   setPendingNavigationBlocker,
   patchHistory as applyHistoryPatch
 } from './patch-history'
@@ -44,6 +46,54 @@ type DataRouter = {
   }
   subscribe: (listener: () => void) => () => void
   deleteBlocker: (key: string) => void
+  navigate(
+    to: string | NavigateUrl | number,
+    options?: NavigateOptions
+  ): void | Promise<void>
+}
+
+function trackRouterNavigations(router: DataRouter | undefined): void {
+  if (!router) {
+    return
+  }
+  const navigate = router.navigate
+  const navigateOutsideNuqs: DataRouter['navigate'] = (to, options) => {
+    if (typeof to === 'number') {
+      return navigate.call(router, to, options)
+    }
+    const blockersBeforeNavigation = router.state.blockers
+    const restorePendingPush = interruptPendingPush()
+    const result = navigate.call(router, to, options)
+    for (const [key, blocker] of router.state.blockers ?? []) {
+      if (
+        blocker.state === 'blocked' &&
+        blocker !== blockersBeforeNavigation?.get(key) &&
+        restorePendingPush()
+      ) {
+        trackRouterNavigations(router)
+        const unsubscribe = subscribeToBlockerUpdatesAndRemoval(router, () => {
+          const current = router.state.blockers?.get(key)
+          if (
+            current?.state === 'proceeding' &&
+            current.location === blocker.location
+          ) {
+            cancelPendingNavigation()
+          } else if (current?.location !== blocker.location) {
+            unsubscribe()
+          }
+        })
+        onPendingNavigationEnd(unsubscribe)
+        break
+      }
+    }
+    return result
+  }
+  router.navigate = navigateOutsideNuqs
+  onPendingNavigationEnd(() => {
+    if (router.navigate === navigateOutsideNuqs) {
+      router.navigate = navigate
+    }
+  })
 }
 
 function trackNewNavigationBlocker(
@@ -185,6 +235,9 @@ export function createReactRouterBasedAdapter({
             }
           )
           trackNewNavigationBlocker(router, blockersBeforeNavigation)
+          if (routerCommitsPush) {
+            trackRouterNavigations(router)
+          }
           // Return the router's promise; waiting for a commit can deadlock.
           if (result instanceof Promise) {
             navigationPromise = result

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -14,6 +14,7 @@ import {
   markPendingPush,
   markPendingReplace,
   onPendingNavigationEnd,
+  repairHistoryIndex,
   setPendingNavigationBlocker,
   patchHistory as applyHistoryPatch
 } from './patch-history'
@@ -43,6 +44,7 @@ type UseSearchParams = (initial: URLSearchParams) => [URLSearchParams, {}]
 type DataRouter = {
   state: {
     blockers?: Map<string, { state: string; location?: unknown }>
+    navigation?: { location?: { key: string } }
   }
   subscribe: (listener: () => void) => () => void
   deleteBlocker: (key: string) => void
@@ -52,8 +54,10 @@ type DataRouter = {
   ): void | Promise<void>
 }
 
+const navigationCleanups = new WeakMap<DataRouter, () => void>()
+
 function trackRouterNavigations(router: DataRouter | undefined): void {
-  if (!router) {
+  if (!router || navigationCleanups.has(router)) {
     return
   }
   const navigate = router.navigate
@@ -61,8 +65,10 @@ function trackRouterNavigations(router: DataRouter | undefined): void {
     if (typeof to === 'number') {
       return navigate.call(router, to, options)
     }
+    cleanup()
     const blockersBeforeNavigation = router.state.blockers
     const restorePendingPush = interruptPendingPush()
+    repairHistoryIndex()
     const result = navigate.call(router, to, options)
     for (const [key, blocker] of router.state.blockers ?? []) {
       if (
@@ -88,12 +94,17 @@ function trackRouterNavigations(router: DataRouter | undefined): void {
     }
     return result
   }
-  router.navigate = navigateOutsideNuqs
-  onPendingNavigationEnd(() => {
+  const cleanup = () => {
     if (router.navigate === navigateOutsideNuqs) {
       router.navigate = navigate
+      navigationCleanups.delete(router)
     }
-  })
+  }
+  router.navigate = navigateOutsideNuqs
+  navigationCleanups.set(router, cleanup)
+  if (hasPendingPush()) {
+    onPendingNavigationEnd(cleanup)
+  }
 }
 
 function trackNewNavigationBlocker(
@@ -190,6 +201,9 @@ export function createReactRouterBasedAdapter({
     const searchParams = useOptimisticSearchParams(watchKeys)
     const updateUrl = useCallback(
       (search: URLSearchParams, options: AdapterOptions) => {
+        if (router && options.shallow === false) {
+          navigationCleanups.get(router)?.()
+        }
         startTransition(() => {
           emitter.emit('update', search)
         })
@@ -215,6 +229,19 @@ export function createReactRouterBasedAdapter({
           historyUpdateMarker,
           url
         )
+        const pendingLocation = router?.state.navigation?.location
+        if (
+          !hasUncommittedPush &&
+          !routerCommitsPush &&
+          (requiresRouterNavigation ||
+            (pendingLocation &&
+              pendingLocation.key !== (history.state?.key || 'default')) ||
+            Array.from(router?.state.blockers?.values() ?? []).some(
+              blocker => blocker.state !== 'unblocked'
+            ))
+        ) {
+          repairHistoryIndex()
+        }
         let navigationPromise: Promise<void> | undefined
         if (requiresRouterNavigation) {
           if (!routerCommitsPush) {
@@ -235,14 +262,12 @@ export function createReactRouterBasedAdapter({
             }
           )
           trackNewNavigationBlocker(router, blockersBeforeNavigation)
-          if (routerCommitsPush) {
-            trackRouterNavigations(router)
-          }
           // Return the router's promise; waiting for a commit can deadlock.
           if (result instanceof Promise) {
             navigationPromise = result
           }
         }
+        trackRouterNavigations(router)
         if (options.scroll) {
           window.scrollTo(0, 0)
         }

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -327,7 +327,7 @@ export function createReactRouterBasedAdapter({
    *
    * Note: this is actually required in React Router frameworks to follow Link navigations.
    */
-  applyHistoryPatch(emitter, adapter)
+  applyHistoryPatch(emitter, adapter, { trackRouterHistory: true })
 
   return {
     NuqsAdapter: createAdapterProvider(useNuqsReactRouterBasedAdapter),

--- a/packages/nuqs/src/adapters/react-router/v6.ts
+++ b/packages/nuqs/src/adapters/react-router/v6.ts
@@ -1,11 +1,16 @@
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { createContext, useContext } from 'react'
+import * as ReactRouter from 'react-router-dom'
 import type { AdapterProvider } from '../lib/context'
 import { createReactRouterBasedAdapter } from '../lib/react-router'
 
+const DataRouterContext =
+  ReactRouter.UNSAFE_DataRouterContext ?? createContext(null)
+
 const adapter = createReactRouterBasedAdapter({
   adapter: 'react-router-v6',
-  useNavigate,
-  useSearchParams
+  useNavigate: ReactRouter.useNavigate,
+  useSearchParams: ReactRouter.useSearchParams,
+  useRouter: () => useContext(DataRouterContext)?.router
 })
 
 export const NuqsAdapter: AdapterProvider = adapter.NuqsAdapter

--- a/packages/nuqs/src/adapters/react-router/v7.ts
+++ b/packages/nuqs/src/adapters/react-router/v7.ts
@@ -1,11 +1,17 @@
-import { useNavigate, useSearchParams } from 'react-router'
+import { useContext } from 'react'
+import {
+  UNSAFE_DataRouterContext,
+  useNavigate,
+  useSearchParams
+} from 'react-router'
 import type { AdapterProvider } from '../lib/context'
 import { createReactRouterBasedAdapter } from '../lib/react-router'
 
 const adapter = createReactRouterBasedAdapter({
   adapter: 'react-router-v7',
   useNavigate,
-  useSearchParams
+  useSearchParams,
+  useRouter: () => useContext(UNSAFE_DataRouterContext)?.router
 })
 
 export const NuqsAdapter: AdapterProvider = adapter.NuqsAdapter

--- a/packages/nuqs/src/lib/queues/reset.test.ts
+++ b/packages/nuqs/src/lib/queues/reset.test.ts
@@ -6,6 +6,17 @@ describe('queue reset mutex across duplicate library copies', () => {
     setQueueResetMutex(0)
   })
 
+  it('returns the previous protection level when another copy changes it', async () => {
+    const copyA = await import('./reset')
+    vi.resetModules()
+    const copyB = await import('./reset')
+    copyA.setQueueResetMutex(2)
+    expect(copyB.setQueueResetMutex()).toBe(2)
+    const onReset = vi.fn()
+    copyA.spinQueueResetMutex(onReset)
+    expect(onReset).toHaveBeenCalledOnce()
+  })
+
   it('suppresses resets spun from another copy', async () => {
     const copyA = await import('./reset')
     vi.resetModules()

--- a/packages/nuqs/src/lib/queues/reset.ts
+++ b/packages/nuqs/src/lib/queues/reset.ts
@@ -5,6 +5,10 @@ import { globalThrottleQueue } from './throttle'
 
 const state = globalSingleton('queue-reset', () => ({ mutex: 0 }))
 
+export function getQueueResetMutex(): number {
+  return state.mutex
+}
+
 export function setQueueResetMutex(value = 1): void {
   state.mutex = value
 }

--- a/packages/nuqs/src/lib/queues/reset.ts
+++ b/packages/nuqs/src/lib/queues/reset.ts
@@ -5,12 +5,10 @@ import { globalThrottleQueue } from './throttle'
 
 const state = globalSingleton('queue-reset', () => ({ mutex: 0 }))
 
-export function getQueueResetMutex(): number {
-  return state.mutex
-}
-
-export function setQueueResetMutex(value = 1): void {
+export function setQueueResetMutex(value = 1): number {
+  const previous = state.mutex
   state.mutex = value
+  return previous
 }
 
 export function spinQueueResetMutex(onReset: () => void = resetQueues): void {


### PR DESCRIPTION
Keep pending query entries through blockers and later Links. Loader timing should not change which searches Back can restore.

Stacked on #1570.