### PR TITLE
chore(ci): constrain Actions cache access

### DIFF
--- a/.github/workflows/analyse-nextjs-release.yml
+++ b/.github/workflows/analyse-nextjs-release.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: read # for actions/checkout
 
+cache-mode: none
+
 env:
   FORCE_COLOR: 3 # Diplay chalk colors
   VERSION: ${{ inputs.version }}
@@ -40,7 +42,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version-file: .node-version
-          cache: pnpm
+          package-manager-cache: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts --filter scripts...
       - name: Check for changes in app router

--- a/.github/workflows/backlog-cleaner.yml
+++ b/.github/workflows/backlog-cleaner.yml
@@ -30,6 +30,8 @@ on:
 # Default to no token scope; each job grants only what it writes.
 permissions: {}
 
+cache-mode: none
+
 env:
   BACKLOG_MILESTONE_NUMBER: 3 # "🪵 Backlog"
 

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -9,6 +9,8 @@ concurrency:
   group: pkg-pr-new-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+cache-mode: read
+
 jobs:
   deploy-preview:
     name: Deploy to pkg.pr.new

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   contents: read
 
+cache-mode: read
+
 jobs:
   lint-pr-title:
     name: Lint PR Title

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -90,6 +90,7 @@ jobs:
     name: CI gate
     needs: [compute-version, generate-notes]
     if: ${{ needs.compute-version.outputs.needsReleasing == 'true' }}
+    cache-mode: read
     permissions:
       contents: read
       actions: read # ci-cd.yml's docs build reads the workflow-run status when rendering the landing-page CI component.
@@ -103,6 +104,7 @@ jobs:
   stage:
     name: Stage to npm
     runs-on: ubuntu-24.04-arm
+    cache-mode: none
     needs: [compute-version, ci]
     if: ${{ needs.compute-version.outputs.needsReleasing == 'true' }}
     permissions:
@@ -205,6 +207,7 @@ jobs:
   create-draft:
     name: Draft GitHub release
     runs-on: ubuntu-24.04-arm
+    cache-mode: none
     needs: [compute-version, generate-notes, stage]
     permissions:
       contents: write # create the draft GitHub release

--- a/.github/workflows/release-edited.yml
+++ b/.github/workflows/release-edited.yml
@@ -19,6 +19,8 @@ concurrency:
 permissions:
   contents: read
 
+cache-mode: none
+
 jobs:
   refresh-changelog:
     name: Bust the releases ISR cache

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -23,6 +23,8 @@ concurrency:
   group: release-finalize-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
+cache-mode: none
+
 jobs:
   finalize:
     name: Comment + label impacted issues/PRs

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -11,6 +11,8 @@ on:
 
 permissions: {}
 
+cache-mode: none
+
 concurrency:
   group: bundle-size-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true

--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -14,6 +14,8 @@ concurrency:
 permissions:
   contents: read
 
+cache-mode: read
+
 jobs:
   measure-base:
     name: Measure (base)

--- a/.github/workflows/test-against-nextjs-release.yml
+++ b/.github/workflows/test-against-nextjs-release.yml
@@ -12,6 +12,8 @@ on:
 permissions:
   contents: read
 
+cache-mode: none
+
 env:
   FORCE_COLOR: 3 # Diplay chalk colors
   VERSION: ${{ inputs.version }}
@@ -20,6 +22,7 @@ jobs:
   test_against_nextjs_release:
     name: CI (next@${{ inputs.version }}${{ (matrix.base-path || matrix.cache-components || matrix.react-compiler) && ' ' || ''}}${{ matrix.base-path && '⚾' || ''}}${{ matrix.react-compiler && '⚛️' || ''}}${{ matrix.cache-components && '💾' || ''}})
     runs-on: ubuntu-24.04-arm
+    cache-mode: read
     permissions:
       contents: read
     strategy:
@@ -88,6 +91,7 @@ jobs:
     name: Docs (next@${{ inputs.version }})
     if: ${{ startsWith(inputs.version, '16.') }}
     runs-on: ubuntu-24.04-arm
+    cache-mode: read
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## Summary

- disable GitHub Actions cache access for release and other privileged jobs
- make caller-selected Next.js tests restore-only while leaving secret-only jobs cacheless
- cap PR-controlled cache users at read-only and preserve trusted CI as the cache writer

## Validation

- parsed all 12 workflow files and asserted the effective cache-mode layout
- `git diff --check`
- Prettier check on changed workflows
- actionlint v1.7.12, ignoring only its stale unknown `cache-mode` diagnostic
- zizmor v1.30.1 offline audit, with no findings added relative to `origin/next`

`actionlint` and the editor GitHub Actions schema do not support the new key yet. GitHub's current workflow syntax documentation does.
