### PR TITLE
fix: preserve separate React Router pushes

### DIFF
--- a/packages/docs/content/docs/options.mdx
+++ b/packages/docs/content/docs/options.mdx
@@ -53,6 +53,15 @@ updates:
 useQueryState('foo', { history: 'push' })
 ```
 
+[Batched updates](/docs/batching#multiple-updates-batching) share one URL write and
+one history entry.
+
+In React Router based frameworks, each separate URL write with `history: 'push'{:ts}`
+adds an entry, even while a loader waits. For example, a deep `q=tea` push followed
+by a shallow `panel=open` push adds two entries. Back removes `panel` and keeps
+`q=tea`. The shallow push does not run a loader. Loader data still comes from the
+URL that started the request.
+
 <Callout title="Watch out!" type="warn">
 Breaking the Back button can lead to a bad user experience. Make sure to use this
 option only if the search params to update contribute to a navigation-like

--- a/packages/e2e/shared/specs/react-router/blocker.spec.ts
+++ b/packages/e2e/shared/specs/react-router/blocker.spec.ts
@@ -392,7 +392,7 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     await expectCount(page, 1)
     await page.locator('#deep').click()
     await expectCount(page, 2)
-    expect(await page.evaluate(() => history.length)).toBe(before + 1)
+    expect(await page.evaluate(() => history.length)).toBe(before + 2)
     await page.locator('#cancel').click()
     await expect(page.locator('#blocker')).toHaveText('unblocked')
     await page.evaluate(() => {
@@ -401,6 +401,12 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
     })
     await expect(page.locator('#blocker')).toHaveText('blocked')
     await expectCount(page, 2)
+    await page.locator('#proceed').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectCount(page, 1)
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectCount(page, 1)
     await page.locator('#proceed').click()
     await expect(page.locator('#blocker')).toHaveText('unblocked')
     await expectCount(page, 0)
@@ -827,10 +833,10 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
         await expect(page.locator('#blocker')).toHaveText('unblocked')
       }
       await shallowPush(page, 3)
-      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      expect(await page.evaluate(() => history.length)).toBe(before + 3)
       await expect(page.locator('#navigation')).toHaveText('idle')
       await expectCount(page, 3)
-      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      expect(await page.evaluate(() => history.length)).toBe(before + 3)
       await expectTwoShallowPushes(page, 3)
     })
   }
@@ -851,10 +857,14 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
       if (shallow) {
         await shallowPush(page, 2)
       }
-      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      expect(await page.evaluate(() => history.length)).toBe(
+        before + (shallow ? 2 : 1)
+      )
       await expect(page.locator('#navigation')).toHaveText('idle')
       await expectCount(page, shallow ? 2 : 1)
-      expect(await page.evaluate(() => history.length)).toBe(before + 1)
+      expect(await page.evaluate(() => history.length)).toBe(
+        before + (shallow ? 2 : 1)
+      )
       await expectTwoShallowPushes(page, shallow ? 2 : 1)
     })
   }
@@ -862,8 +872,8 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
   for (const blocked of [false, true]) {
     it(
       blocked
-        ? 'keeps shallow pushes in the pending entry through Proceed'
-        : 'keeps shallow pushes in a pending loader navigation',
+        ? 'keeps each shallow push entry through Proceed'
+        : 'keeps each shallow push entry during a pending loader navigation',
       async ({ page }) => {
         it.setTimeout(10_000)
         await navigateTo(page, path, '?count=0&delay=1000')
@@ -876,22 +886,27 @@ export const testBlocker = defineTest('React Router blockers', ({ path }) => {
         if (blocked) {
           await expect(page.locator('#blocker')).toHaveText('blocked')
           await shallowPush(page, 2)
-          expect(await page.evaluate(() => history.length)).toBe(before + 1)
+          expect(await page.evaluate(() => history.length)).toBe(before + 2)
           await page.locator('#proceed').click()
           await expect(page.locator('#blocker')).toHaveText('proceeding')
         }
         await expect(page.locator('#navigation')).toHaveText('loading')
         const count = blocked ? 3 : 2
         await shallowPush(page, count)
-        expect(await page.evaluate(() => history.length)).toBe(before + 1)
+        expect(await page.evaluate(() => history.length)).toBe(before + count)
         await expect(page.locator('#navigation')).toHaveText('idle')
         await expect(page.locator('#blocker')).toHaveText('unblocked')
         await expectCount(page, count)
-        expect(await page.evaluate(() => history.length)).toBe(before + 1)
+        expect(await page.evaluate(() => history.length)).toBe(before + count)
         await page.locator('#enabled').uncheck()
-        await page.goBack()
-        await expectCount(page, 0)
-        await page.goForward()
+        for (let previous = count - 1; previous >= 0; previous--) {
+          await page.goBack()
+          await expectCount(page, previous)
+        }
+        for (let next = 1; next <= count; next++) {
+          await page.goForward()
+          await expectCount(page, next)
+        }
         await expectCount(page, count)
         await expect(page.locator('#navigation')).toHaveText('idle')
         await expectTwoShallowPushes(page, count)

--- a/packages/e2e/shared/specs/react-router/pending-push.spec.ts
+++ b/packages/e2e/shared/specs/react-router/pending-push.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test as it, type Page } from '@playwright/test'
 import { defineTest } from '../../define-test'
 import { expectSearch } from '../../playwright/expect-url'
+import { readHistoryIndex } from '../../playwright/history'
 import { navigateTo } from '../../playwright/navigate'
 import type { LoaderRequestData } from './pending-loader.defs'
 
@@ -63,9 +64,50 @@ const qOnly = { q: 'tea', page: '1', panel: null }
 const bothDeep = { q: 'tea', page: '2', panel: null }
 
 export const testPendingPush = defineTest(
-  'Pending navigation blockers',
+  'Separate pending pushes',
   ({ path }) => {
-    for (const qHistory of ['replace'] as const) {
+    it('uses the latest repeated Back target after another shallow push', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-before').click()
+      const previous = { ...qOnly, panel: 'before' }
+      await expectState(page, previous)
+      await page.locator('#block-navigation').check()
+      await blockedBack(page)
+      await expectState(page, previous)
+      await page.locator('#panel-open').click()
+      const latest = { ...qOnly, panel: 'open' }
+      await expectState(page, latest)
+      await blockedBack(page)
+      await expectState(page, latest)
+      await releaseLoader(page, 1)
+      await expectData(page, qOnly)
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, latest)
+      await expectRequests(page, 1)
+      await page.locator('#proceed').click()
+      await releaseLoader(page, 2)
+      await expectState(page, previous)
+      await expectData(page, previous)
+      await page.locator('#block-navigation').uncheck()
+      await page.goForward()
+      await releaseLoader(page, 3)
+      await expectState(page, latest)
+      await expectData(page, latest)
+      expect(await page.evaluate(() => history.length)).toBe(length + 3)
+    })
+
+    for (const qHistory of ['push', 'replace'] as const) {
       for (const decision of ['cancel', 'proceed'] as const) {
         it(`keeps repeated Back blocked through accepted completion (${qHistory}, ${decision})`, async ({
           page
@@ -80,7 +122,7 @@ export const testPendingPush = defineTest(
             document.body.dataset.pendingPush = 'mounted'
             return history.length
           })
-          const expectedLength = length + 1
+          const expectedLength = length + (qHistory === 'push' ? 2 : 1)
           await page.locator('#set-q').click()
           await expectRequests(page, 1)
           await expectState(page, qOnly)
@@ -127,6 +169,103 @@ export const testPendingPush = defineTest(
           ).toBe('mounted')
         })
       }
+    }
+
+    it('keeps the blocked Back target when another shallow push precedes the accepted commit', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-before').click()
+      await expectState(page, { ...qOnly, panel: 'before' })
+      await page.locator('#block-navigation').check()
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, { ...qOnly, panel: 'before' })
+      await page.locator('#panel-open').click()
+      const latest = { ...qOnly, panel: 'open' }
+      await expectState(page, latest)
+      await releaseLoader(page, 1)
+      await expectData(page, qOnly)
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, latest)
+      await expectRequests(page, 1)
+      await page.locator('#proceed').click()
+      await releaseLoader(page, 2)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.locator('#block-navigation').uncheck()
+      await page.goForward()
+      await releaseLoader(page, 3)
+      await expectState(page, { ...qOnly, panel: 'before' })
+      await expectData(page, { ...qOnly, panel: 'before' })
+      await page.goForward()
+      await releaseLoader(page, 4)
+      await expectState(page, latest)
+      await expectData(page, latest)
+      expect(await page.evaluate(() => history.length)).toBe(length + 3)
+    })
+
+    for (const decision of ['cancel', 'proceed'] as const) {
+      it(`keeps blocked Forward open when the accepted Back loader finishes (${decision})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=push&panelHistory=push'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => {
+          document.body.dataset.pendingPush = 'mounted'
+          return history.length
+        })
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page.locator('#panel-open').click()
+        const withPanel = { ...qOnly, panel: 'open' }
+        await expectState(page, withPanel)
+        await page.goBack()
+        await expectRequests(page, 2)
+        await expectState(page, qOnly)
+        await page.locator('#block-navigation').check()
+        await page.evaluate(() => history.forward())
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, qOnly)
+        await releaseLoader(page, 2)
+        await expectData(page, qOnly)
+        await expect(page.locator('#blocker')).toHaveText('blocked')
+        await expectState(page, qOnly)
+        await expectRequests(page, 2)
+        await page.locator(`#${decision}`).click()
+        if (decision === 'cancel') {
+          await expect(page.locator('#blocker')).toHaveText('unblocked')
+          await expectState(page, qOnly)
+          await expectRequests(page, 2)
+          await page.evaluate(() => history.forward())
+          await expect(page.locator('#blocker')).toHaveText('blocked')
+          await page.locator('#proceed').click()
+        }
+        await releaseLoader(page, 3)
+        await expectState(page, withPanel)
+        await expectData(page, withPanel)
+        await releaseRequests(page, [1])
+        await expectState(page, withPanel)
+        await expectData(page, withPanel)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
+        expect(
+          await page.evaluate(() => document.body.dataset.pendingPush)
+        ).toBe('mounted')
+      })
     }
 
     for (const decision of ['cancel', 'proceed'] as const) {
@@ -201,13 +340,13 @@ export const testPendingPush = defineTest(
     }
 
     for (const decision of ['cancel', 'proceed'] as const) {
-      it(`keeps blocked Back open when its accepted push loader finishes after a shallow replace (${decision})`, async ({
+      it(`keeps blocked Back open when its accepted push loader finishes (${decision})`, async ({
         page
       }) => {
         await navigateTo(
           page,
           path,
-          '?q=init&page=1&qHistory=push&panelHistory=replace'
+          '?q=init&page=1&qHistory=push&panelHistory=push'
         )
         await expectData(page, initial)
         const length = await page.evaluate(() => {
@@ -229,7 +368,7 @@ export const testPendingPush = defineTest(
         await expect(page.locator('#blocker')).toHaveText('blocked')
         await expectState(page, withPanel)
         await expectRequests(page, 1)
-        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
         await page.locator(`#${decision}`).click()
         if (decision === 'cancel') {
           await expect(page.locator('#blocker')).toHaveText('unblocked')
@@ -239,15 +378,15 @@ export const testPendingPush = defineTest(
           await expect(page.locator('#blocker')).toHaveText('blocked')
           await page.locator('#proceed').click()
         }
-        await expectState(page, initial)
-        await expectData(page, initial)
-        await expectRequests(page, 1)
+        await releaseLoader(page, 2)
+        await expectState(page, qOnly)
+        await expectData(page, qOnly)
         await page.locator('#block-navigation').uncheck()
         await page.goForward()
-        await releaseLoader(page, 2)
+        await releaseLoader(page, 3)
         await expectState(page, withPanel)
         await expectData(page, withPanel)
-        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
         expect(
           await page.evaluate(() => document.body.dataset.pendingPush)
         ).toBe('mounted')
@@ -307,13 +446,13 @@ export const testPendingPush = defineTest(
       })
     }
 
-    it('finishes the accepted push without an extra entry after shallow replace and cancelled Back', async ({
+    it('finishes the accepted push without an extra entry after blocked Back is cancelled', async ({
       page
     }) => {
       await navigateTo(
         page,
         path,
-        '?q=init&page=1&qHistory=push&panelHistory=replace'
+        '?q=init&page=1&qHistory=push&panelHistory=push'
       )
       await expectData(page, initial)
       const length = await page.evaluate(() => history.length)
@@ -333,22 +472,75 @@ export const testPendingPush = defineTest(
       await releaseLoader(page, 1)
       await expectData(page, qOnly)
       await expectState(page, withPanel)
-      expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
       await page.evaluate(() => history.back())
       await expect(page.locator('#blocker')).toHaveText('blocked')
       await expectState(page, withPanel)
       await page.locator('#proceed').click()
+      await releaseLoader(page, 2)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.locator('#block-navigation').uncheck()
+      await page.goBack()
       await expectState(page, initial)
       await expectData(page, initial)
-      await expectRequests(page, 1)
-      await page.locator('#block-navigation').uncheck()
-      await page.goForward()
-      await releaseLoader(page, 2)
-      await expectState(page, withPanel)
-      await expectData(page, withPanel)
     })
 
-    it('discards the accepted loader when the coalesced blocked second deep push proceeds first', async ({
+    it('restores blocked Forward while the allowed Back loader waits', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => {
+        document.body.dataset.pendingPush = 'mounted'
+        return history.length
+      })
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-open').click()
+      const withPanel = { ...qOnly, panel: 'open' }
+      await expectState(page, withPanel)
+      await page.goBack()
+      await expectRequests(page, 2)
+      await expectState(page, qOnly)
+      await page.locator('#block-navigation').check()
+      await page.evaluate(() => history.forward())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, qOnly)
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectState(page, qOnly)
+      await expectRequests(page, 2)
+      await page.evaluate(() => history.forward())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, qOnly)
+      await page.locator('#proceed').click()
+      await releaseLoader(page, 3)
+      await expectState(page, withPanel)
+      await expectData(page, withPanel)
+      await releaseRequests(page, [1, 2])
+      await expectState(page, withPanel)
+      await expectData(page, withPanel)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      expect(await page.evaluate(() => document.body.dataset.pendingPush)).toBe(
+        'mounted'
+      )
+      await page.locator('#block-navigation').uncheck()
+      await page.goBack()
+      await releaseLoader(page, 4)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
+    })
+
+    it('discards the accepted loader when the blocked second deep push proceeds first', async ({
       page
     }) => {
       await navigateTo(
@@ -377,20 +569,76 @@ export const testPendingPush = defineTest(
       await releaseRequests(page, [1])
       await expectData(page, bothDeep)
       await expectState(page, bothDeep)
-      expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
       await page.locator('#block-navigation').uncheck()
+      await page.goBack()
+      await releaseLoader(page, 3)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
       await page.goBack()
       await expectState(page, initial)
       await expectData(page, initial)
-      await expectRequests(page, 2)
+    })
+
+    it('restores blocked Back before the deep and shallow push loaders finish', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => {
+        document.body.dataset.pendingPush = 'mounted'
+        return history.length
+      })
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-open').click()
+      const withPanel = { ...qOnly, panel: 'open' }
+      await expectState(page, withPanel)
+      await expectRequests(page, 1)
+      await page.locator('#block-navigation').check()
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, withPanel)
+      await page.locator('#cancel').click()
+      await expect(page.locator('#blocker')).toHaveText('unblocked')
+      await expectState(page, withPanel)
+      await expectRequests(page, 1)
+      await page.evaluate(() => history.back())
+      await expect(page.locator('#blocker')).toHaveText('blocked')
+      await expectState(page, withPanel)
+      await page.locator('#proceed').click()
+      await expectState(page, qOnly)
+      await releaseLoader(page, 2)
+      await expectData(page, qOnly)
+      await releaseRequests(page, [1])
+      await expectData(page, qOnly)
+      await expectState(page, qOnly)
+      await page.locator('#block-navigation').uncheck()
       await page.goForward()
       await releaseLoader(page, 3)
-      await expectState(page, bothDeep)
-      await expectData(page, bothDeep)
+      await expectData(page, withPanel)
+      await expectState(page, withPanel)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      expect(await page.evaluate(() => document.body.dataset.pendingPush)).toBe(
+        'mounted'
+      )
+      await page.locator('#block-navigation').uncheck()
+      await page.goBack()
+      await releaseLoader(page, 4)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
     })
 
     for (const decision of ['cancel', 'proceed'] as const) {
-      it(`keeps a coalesced blocked second deep push open while the accepted loader finishes (${decision})`, async ({
+      it(`keeps a blocked second deep push open while the accepted loader finishes (${decision})`, async ({
         page
       }) => {
         await navigateTo(
@@ -412,7 +660,7 @@ export const testPendingPush = defineTest(
         await expect(page.locator('#blocker')).toHaveText('blocked')
         await expectState(page, bothDeep)
         await expectRequests(page, 1)
-        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
         await page.locator(`#${decision}`).click()
         if (decision === 'proceed') {
           await releaseLoader(page, 2)
@@ -422,19 +670,25 @@ export const testPendingPush = defineTest(
         await expectState(page, bothDeep)
         await page.locator('#block-navigation').uncheck()
         await page.goBack()
+        await expectState(page, qOnly)
+        await releaseLoader(page, decision === 'proceed' ? 3 : 2)
+        await expectData(page, qOnly)
+        await page.goBack()
         await expectState(page, initial)
         await expectData(page, initial)
-        await expectRequests(page, decision === 'proceed' ? 2 : 1)
         await page.goForward()
-        await releaseLoader(page, decision === 'proceed' ? 3 : 2)
+        await releaseLoader(page, decision === 'proceed' ? 4 : 3)
+        await expectData(page, qOnly)
+        await page.goForward()
+        await releaseLoader(page, decision === 'proceed' ? 5 : 4)
         await expectState(page, bothDeep)
         await expectData(page, bothDeep)
-        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
       })
     }
 
     for (const cancelBack of [false, true]) {
-      it(`keeps one coalesced entry when a blocked second deep push is cancelled before the accepted loader finishes (cancel Back: ${cancelBack})`, async ({
+      it(`keeps both entries when a blocked second deep push is cancelled before the accepted loader finishes (cancel Back: ${cancelBack})`, async ({
         page
       }) => {
         await navigateTo(
@@ -465,18 +719,364 @@ export const testPendingPush = defineTest(
         await releaseLoader(page, 1)
         await expectData(page, qOnly)
         await expectState(page, bothDeep)
-        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
         await page.locator('#block-navigation').uncheck()
+        await page.goBack()
+        await expectState(page, qOnly)
+        await releaseLoader(page, 2)
+        await expectData(page, qOnly)
         await page.goBack()
         await expectState(page, initial)
         await expectData(page, initial)
-        await expectRequests(page, 1)
         await page.goForward()
-        await releaseLoader(page, 2)
+        await releaseLoader(page, 3)
+        await expectData(page, qOnly)
+        await page.goForward()
+        await releaseLoader(page, 4)
         await expectState(page, bothDeep)
         await expectData(page, bothDeep)
-        expect(await page.evaluate(() => history.length)).toBe(length + 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
       })
     }
+
+    it('keeps every entry when deep and shallow pushes alternate', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&pageHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const index = await readHistoryIndex(page)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-before').click()
+      await expectState(page, { ...qOnly, panel: 'before' })
+      await page.locator('#set-page').click()
+      await expectRequests(page, 2)
+      await expectState(page, { ...bothDeep, panel: 'before' })
+      await page.locator('#panel-open').click()
+      const latest = { ...bothDeep, panel: 'open' }
+      await expectState(page, latest)
+      expect(await page.evaluate(() => history.length)).toBe(length + 4)
+      await releaseLoader(page, 2)
+      await expectData(page, { ...bothDeep, panel: 'before' })
+      await releaseRequests(page, [1])
+      await expectState(page, latest)
+      await expectData(page, { ...bothDeep, panel: 'before' })
+      await expectRequests(page, 2)
+      expect(await readHistoryIndex(page)).toBe(index + 4)
+      expect(await page.evaluate(() => history.length)).toBe(length + 4)
+      await page.goBack()
+      await releaseLoader(page, 3)
+      await expectState(page, { ...bothDeep, panel: 'before' })
+      await expectData(page, { ...bothDeep, panel: 'before' })
+      await page.goBack()
+      await releaseLoader(page, 4)
+      await expectState(page, { ...qOnly, panel: 'before' })
+      await expectData(page, { ...qOnly, panel: 'before' })
+      await page.goBack()
+      await releaseLoader(page, 5)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
+      expect(await readHistoryIndex(page)).toBe(index)
+    })
+
+    it('batches same-tick push setters into one URL entry', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&pageHistory=push'
+      )
+      await expectData(page, initial)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-both').click()
+      await expectRequests(page, 1)
+      await expectState(page, bothDeep)
+      expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      await releaseLoader(page, 1)
+      await expectData(page, bothDeep)
+      await expectRequests(page, 1)
+      expect(await page.evaluate(() => history.length)).toBe(length + 1)
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
+    })
+
+    it('drops forward entries when a new push follows Back during a loader', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&pageHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const index = await readHistoryIndex(page)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-open').click()
+      await expectState(page, { ...qOnly, panel: 'open' })
+      await page.goBack()
+      await expectState(page, qOnly)
+      await expectRequests(page, 2)
+      await page.locator('#set-page').click()
+      await releaseLoader(page, 3)
+      await expectState(page, bothDeep)
+      await expectData(page, bothDeep)
+      await releaseRequests(page, [1, 2])
+      await expectState(page, bothDeep)
+      await expectData(page, bothDeep)
+      expect(await readHistoryIndex(page)).toBe(index + 2)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      await page.goBack()
+      await releaseLoader(page, 4)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.goForward()
+      await releaseLoader(page, 5)
+      await expectState(page, bothDeep)
+      await expectData(page, bothDeep)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+    })
+
+    for (const secondKey of ['page', 'panel'] as const) {
+      it(`keeps Back and Forward entries before loaders finish (${secondKey})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=push&pageHistory=push&panelHistory=push'
+        )
+        await expectData(page, initial)
+        const index = await readHistoryIndex(page)
+        const length = await page.evaluate(() => history.length)
+        await page.locator('#set-q').click()
+        await expectRequests(page, 1)
+        await expectState(page, qOnly)
+        await page
+          .locator(secondKey === 'page' ? '#set-page' : '#panel-open')
+          .click()
+        const latest =
+          secondKey === 'page' ? bothDeep : { ...qOnly, panel: 'open' }
+        await expectState(page, latest)
+        await expectRequests(page, secondKey === 'page' ? 2 : 1)
+        await page.goBack()
+        await expectState(page, qOnly)
+        await expectRequests(page, secondKey === 'page' ? 3 : 2)
+        expect(await readHistoryIndex(page)).toBe(index + 1)
+        await page.goForward()
+        await expectState(page, latest)
+        const forwardRequest = secondKey === 'page' ? 4 : 3
+        await releaseLoader(page, forwardRequest)
+        await expectData(page, latest)
+        await releaseRequests(page, secondKey === 'page' ? [1, 2, 3] : [1, 2])
+        await expectState(page, latest)
+        await expectData(page, latest)
+        expect(await readHistoryIndex(page)).toBe(index + 2)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
+        expect(
+          await page.evaluate(() =>
+            window.pendingLoaderControl!.requests.map(
+              request => request.aborted
+            )
+          )
+        ).toEqual(
+          secondKey === 'page' ? [true, true, true, false] : [true, true, false]
+        )
+        await page.goBack()
+        await releaseLoader(page, forwardRequest + 1)
+        await expectData(page, qOnly)
+        await expectState(page, qOnly)
+        await page.goBack()
+        await expectData(page, initial)
+        await expectState(page, initial)
+      })
+    }
+
+    for (const firstHistory of ['replace', 'push'] as const) {
+      for (const secondKey of ['page', 'panel'] as const) {
+        const secondHistory = firstHistory === 'push' ? 'replace' : 'push'
+        it(`keeps one added entry for ${firstHistory} then ${secondHistory} (${secondKey})`, async ({
+          page
+        }) => {
+          await navigateTo(
+            page,
+            path,
+            `?q=init&page=1&qHistory=${firstHistory}&pageHistory=${secondHistory}&panelHistory=${secondHistory}`
+          )
+          await expectData(page, initial)
+          const index = await readHistoryIndex(page)
+          const length = await page.evaluate(() => history.length)
+          await page.locator('#set-q').click()
+          await expectRequests(page, 1)
+          await expectState(page, qOnly)
+          await page
+            .locator(secondKey === 'page' ? '#set-page' : '#panel-open')
+            .click()
+          const latest =
+            secondKey === 'page' ? bothDeep : { ...qOnly, panel: 'open' }
+          await expectState(page, latest)
+          expect(await page.evaluate(() => history.length)).toBe(length + 1)
+          await releaseLoader(page, secondKey === 'page' ? 2 : 1)
+          await expectData(page, secondKey === 'page' ? latest : qOnly)
+          await expectState(page, latest)
+          expect(await readHistoryIndex(page)).toBe(index + 1)
+          expect(await page.evaluate(() => history.length)).toBe(length + 1)
+          await page.goBack()
+          const previous = firstHistory === 'push' ? initial : qOnly
+          await expectState(page, previous)
+          if (firstHistory === 'replace') {
+            await releaseLoader(page, secondKey === 'page' ? 3 : 2)
+          }
+          await expectData(page, previous)
+          expect(await readHistoryIndex(page)).toBe(index)
+        })
+      }
+    }
+
+    for (const secondKey of ['page', 'panel'] as const) {
+      it(`keeps both push entries when the first loader has settled (${secondKey})`, async ({
+        page
+      }) => {
+        await navigateTo(
+          page,
+          path,
+          '?q=init&page=1&qHistory=push&pageHistory=push&panelHistory=push'
+        )
+        await expectData(page, initial)
+        const length = await page.evaluate(() => history.length)
+        await page.locator('#set-q').click()
+        await releaseLoader(page, 1)
+        await expectState(page, qOnly)
+        await expectData(page, qOnly)
+        await page
+          .locator(secondKey === 'page' ? '#set-page' : '#panel-open')
+          .click()
+        const latest =
+          secondKey === 'page' ? bothDeep : { ...qOnly, panel: 'open' }
+        await expectState(page, latest)
+        if (secondKey === 'page') {
+          await releaseLoader(page, 2)
+        }
+        await expectData(page, secondKey === 'page' ? latest : qOnly)
+        await expectRequests(page, secondKey === 'page' ? 2 : 1)
+        expect(await page.evaluate(() => history.length)).toBe(length + 2)
+        await page.goBack()
+        await expectState(page, qOnly)
+        await releaseLoader(page, secondKey === 'page' ? 3 : 2)
+        await expectData(page, qOnly)
+        await page.goBack()
+        await expectState(page, initial)
+        await expectData(page, initial)
+      })
+    }
+
+    it('keeps a deep push and a shallow push without another loader or commit entry', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&panelHistory=push'
+      )
+      await expectData(page, initial)
+      const index = await readHistoryIndex(page)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#panel-open').click()
+      const withPanel = { ...qOnly, panel: 'open' }
+      await expectState(page, withPanel)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      await expectRequests(page, 1)
+      await expect(page.locator('#loader-data')).toHaveText(
+        JSON.stringify(initial)
+      )
+      await expect(page.locator('#navigation-state')).toHaveText('loading')
+      await releaseLoader(page, 1)
+      await expectData(page, qOnly)
+      await expectState(page, withPanel)
+      expect(await readHistoryIndex(page)).toBe(index + 2)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      await page.goBack()
+      await expectState(page, qOnly)
+      await releaseLoader(page, 2)
+      await expectData(page, qOnly)
+      expect(await readHistoryIndex(page)).toBe(index + 1)
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
+      await page.goForward()
+      await releaseLoader(page, 3)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.goForward()
+      await releaseLoader(page, 4)
+      await expectState(page, withPanel)
+      await expectData(page, withPanel)
+      expect(await readHistoryIndex(page)).toBe(index + 2)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+    })
+
+    it('keeps both deep push entries when the first loader finishes last', async ({
+      page
+    }) => {
+      await navigateTo(
+        page,
+        path,
+        '?q=init&page=1&qHistory=push&pageHistory=push'
+      )
+      await expectData(page, initial)
+      const index = await readHistoryIndex(page)
+      const length = await page.evaluate(() => history.length)
+      await page.locator('#set-q').click()
+      await expectRequests(page, 1)
+      await expectState(page, qOnly)
+      await page.locator('#set-page').click()
+      await expectRequests(page, 2)
+      await expectState(page, bothDeep)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      await releaseLoader(page, 2)
+      await expectData(page, bothDeep)
+      await releaseRequests(page, [1])
+      await expect
+        .poll(() => page.evaluate(() => window.pendingLoaderControl!.completed))
+        .toEqual([2, 1])
+      await expectState(page, bothDeep)
+      expect(await readHistoryIndex(page)).toBe(index + 2)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+      await page.goBack()
+      await expectState(page, qOnly)
+      await releaseLoader(page, 3)
+      await expectData(page, qOnly)
+      expect(await readHistoryIndex(page)).toBe(index + 1)
+      await page.goBack()
+      await expectState(page, initial)
+      await expectData(page, initial)
+      expect(await readHistoryIndex(page)).toBe(index)
+      await page.goForward()
+      await releaseLoader(page, 4)
+      await expectState(page, qOnly)
+      await expectData(page, qOnly)
+      await page.goForward()
+      await releaseLoader(page, 5)
+      await expectState(page, bothDeep)
+      await expectData(page, bothDeep)
+      expect(await readHistoryIndex(page)).toBe(index + 2)
+      expect(await page.evaluate(() => history.length)).toBe(length + 2)
+    })
   }
 )

--- a/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
+++ b/packages/e2e/shared/specs/react-router/repro-1563.spec.ts
@@ -27,6 +27,52 @@ async function readLoaderCall(page: Page): Promise<number> {
 }
 
 export const testRepro1563Link = defineTest('repro-1563-link', ({ path }) => {
+  it('blocks Back and Forward through separate deep and shallow pushes after commit', async ({
+    page
+  }) => {
+    it.setTimeout(15_000)
+    await navigateToRepro(page, path, '?test=init&delay=1000', {
+      shallowHistory: 'push'
+    })
+    await page.locator('#push').click()
+    await expect(page.locator('#navigation-state')).toHaveText('loading')
+    await page.locator('#shallow-push').click()
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await page.locator('#block-links').check()
+    await page.evaluate(() => {
+      document.body.dataset.pushTest = 'mounted'
+      history.back()
+    })
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
+    await page.locator('#cancel-link').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
+    await page.evaluate(() => history.back())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#proceed-link').click()
+    await expectSearch(page, { test: 'pass', shallow: null })
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page.locator('#state')).toHaveText('pass')
+    await expect(page.locator('#shallow-state')).toBeEmpty()
+    await page.evaluate(() => history.forward())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await expectSearch(page, { test: 'pass', shallow: null })
+    await page.locator('#cancel-link').click()
+    await expect(page.locator('#blocker')).toHaveText('unblocked')
+    await page.evaluate(() => history.forward())
+    await expect(page.locator('#blocker')).toHaveText('blocked')
+    await page.locator('#proceed-link').click()
+    await expectSearch(page, { test: 'pass', shallow: 'pass' })
+    await expect(page.locator('#navigation-state')).toHaveText('idle')
+    await expect(page.locator('#state')).toHaveText('pass')
+    await expect(page.locator('#shallow-state')).toHaveText('pass')
+    expect(await page.evaluate(() => document.body.dataset.pushTest)).toBe(
+      'mounted'
+    )
+  })
+
   it('keeps a queued update when a separate Link is canceled', async ({
     page
   }) => {
@@ -305,7 +351,7 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
   })
 
-  it('currently coalesces a shallow push with a pending deep push', async ({
+  it('keeps separate shallow and pending deep push entries', async ({
     page
   }) => {
     await navigateToRepro(page, path, '?test=init&delay=1000', {
@@ -319,8 +365,13 @@ export const testRepro1563 = defineTest('repro-1563', ({ path }) => {
     await expectSearch(page, { test: 'pass', shallow: 'pass' })
     await expect(page.locator('#navigation-state')).toHaveText('idle')
     await expectSearch(page, { test: 'pass', shallow: 'pass' })
-    expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+    expect(await readHistoryIndex(page)).toBe(initialIndex + 2)
     expect(await readLoaderCall(page)).toBe(initialLoaderCall + 1)
+    await page.goBack()
+    await expectSearch(page, { test: 'pass', shallow: null })
+    await expect(page.locator('#state')).toHaveText('pass')
+    await expect(page.locator('#loader-state')).toHaveText('pass')
+    expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
     await page.goBack()
     await expect(page.locator('#state')).toHaveText('init')
     expect(await readHistoryIndex(page)).toBe(initialIndex)

--- a/packages/e2e/shared/specs/react-router/stitching.slow-loader.spec.ts
+++ b/packages/e2e/shared/specs/react-router/stitching.slow-loader.spec.ts
@@ -9,7 +9,7 @@ export const testStitchingSlowLoader = defineTest(
   'Stitching - slow loader',
   ({ path }) => {
     for (const hook of ['useQueryState', 'useQueryStates'] as const) {
-      it(`currently coalesces deep pushes across keys while a loader is pending (${hook})`, async ({
+      it(`keeps each deep push across keys while a loader is pending (${hook})`, async ({
         page
       }) => {
         await navigateTo(
@@ -22,17 +22,33 @@ export const testStitchingSlowLoader = defineTest(
         await expectSearch(page, { a: '1' })
         await expectSearch(page, { a: '1', b: '1' })
         await expectSearch(page, { a: '1', b: '1', c: '1' })
-        await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 1)
+        await expect.poll(() => readHistoryIndex(page)).toBe(initialIndex + 3)
         await expect(page.locator('#client-state')).toHaveText('1,1,1')
         await expectSearch(page, { a: '1', b: '1', c: '1' })
+        await page.goBack()
+        await expect(page.locator('#client-state')).toHaveText('1,1,0')
+        await expectSearch(page, { a: '1', b: '1', c: null })
+        expect(await readHistoryIndex(page)).toBe(initialIndex + 2)
+        await page.goBack()
+        await expect(page.locator('#client-state')).toHaveText('1,0,0')
+        await expectSearch(page, { a: '1', b: null, c: null })
+        expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
         await page.goBack()
         await expect(page.locator('#client-state')).toHaveText('0,0,0')
         await expectUrl(page, url => !url.searchParams.has('a'))
         expect(await readHistoryIndex(page)).toBe(initialIndex)
         await page.goForward()
+        await expect(page.locator('#client-state')).toHaveText('1,0,0')
+        await expectSearch(page, { a: '1', b: null, c: null })
+        expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+        await page.goForward()
+        await expect(page.locator('#client-state')).toHaveText('1,1,0')
+        await expectSearch(page, { a: '1', b: '1', c: null })
+        expect(await readHistoryIndex(page)).toBe(initialIndex + 2)
+        await page.goForward()
         await expect(page.locator('#client-state')).toHaveText('1,1,1')
         await expectSearch(page, { a: '1', b: '1', c: '1' })
-        expect(await readHistoryIndex(page)).toBe(initialIndex + 1)
+        expect(await readHistoryIndex(page)).toBe(initialIndex + 3)
       })
     }
   }

--- a/packages/nuqs/src/adapters/lib/patch-history.ts
+++ b/packages/nuqs/src/adapters/lib/patch-history.ts
@@ -618,8 +618,10 @@ export function patchHistory(
   }
   history.pushState = function nuqs_pushState(state, marker, url) {
     if (marker === historyUpdateMarker) {
+      const onPendingPush = isOnPendingPushEntry()
       const onCancelledPush = isOnCancelledPushEntry()
-      const onTrackedEntry = isOnPendingReplaceEntry() || onCancelledPush
+      const onTrackedEntry =
+        onPendingPush || isOnPendingReplaceEntry() || onCancelledPush
       const current = getPendingNavigation()
       const isMarkedPendingPush =
         current?.history === 'push' &&
@@ -629,11 +631,17 @@ export function patchHistory(
       const nextState =
         isMarkedPendingPush || typeof state?.idx !== 'number'
           ? state
-          : {
-              ...state,
-              [historyUpdateOffsetMarker]:
-                getHistoryStateOffset(history.state) + 1
-            }
+          : onPendingPush
+            ? {
+                ...state,
+                idx: state.idx + getHistoryStateOffset(state),
+                [historyUpdateOffsetMarker]: 1
+              }
+            : {
+                ...state,
+                [historyUpdateOffsetMarker]:
+                  getHistoryStateOffset(history.state) + 1
+              }
       originalPushState.call(history, nextState, '', url)
       if (onTrackedEntry) {
         movePendingHref()

--- a/packages/nuqs/src/adapters/lib/react-router.ts
+++ b/packages/nuqs/src/adapters/lib/react-router.ts
@@ -326,15 +326,13 @@ export function createReactRouterBasedAdapter({
           requiresRouterNavigation &&
           (options.history === 'push' || hasUncommittedPush)
         const writeOptimisticHistory =
-          options.history === 'push' && !hasUncommittedPush
-            ? history.pushState
-            : history.replaceState
+          options.history === 'push' ? history.pushState : history.replaceState
         setQueueResetMutex(requiresRouterNavigation ? 2 : 1)
         const preserveAcceptedNavigation = requiresRouterNavigation
           ? capturePendingNavigation()
           : () => {}
         const historyState = routerCommitsPush
-          ? markPendingPush(url, hasUncommittedPush ? 'replace' : 'push')
+          ? markPendingPush(url, options.history)
           : history.state
         writeOptimisticHistory.call(
           history,


### PR DESCRIPTION
When a React Router loader is still running, a second `history: 'push'` update replaces the first entry. Back then skips that value.

Keep both history entries. Updates in the same tick still share one entry.

Stacked on #1582.
