### PR TITLE
doc: add Sury parser page

### DIFF
--- a/packages/docs/content/docs/parsers/built-in.mdx
+++ b/packages/docs/content/docs/parsers/built-in.mdx
@@ -333,7 +333,7 @@ setJson({
 </HumanContent>
 
 Using other validation libraries is possible: `parseAsJson{:ts}` accepts
-any Standard Schema compatible input (eg: ArkType, Valibot),
+any Standard Schema compatible input (eg: ArkType, Valibot, Sury),
 or a custom validation function (eg: Yup, Joi, etc):
 
 ```ts

--- a/packages/docs/content/docs/parsers/community/meta.json
+++ b/packages/docs/content/docs/parsers/community/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Community",
-  "pages": ["tanstack-table", "effect-schema", "zod-codecs"]
+  "pages": ["tanstack-table", "effect-schema", "zod-codecs", "sury"]
 }

--- a/packages/docs/content/docs/parsers/community/sury-demo.tsx
+++ b/packages/docs/content/docs/parsers/community/sury-demo.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { CodeBlock } from '@/src/components/code-block.client'
+import { QuerySpy } from '@/src/components/query-spy'
+import { ContainerQueryHelper } from '@/src/components/responsive-helpers'
+import { Button } from '@/src/components/ui/button'
+import { Label } from '@/src/components/ui/label'
+import { cn } from '@/src/lib/utils'
+import { createParser, useQueryState } from 'nuqs'
+import React from 'react'
+import * as S from 'sury'
+
+function createSuryParser<Output>(schema: S.Schema<string, Output>) {
+  return createParser<Output>({
+    parse: S.parseOrThrow(schema),
+    serialize: S.encodeOrThrow(schema),
+    eq: S.isEqualOutput(schema)
+  })
+}
+
+const userSchema = S.schema({
+  name: S.string.with(S.nonEmpty),
+  age: S.int32.with(S.gte, 1)
+})
+
+const schema = S.base64url.with(S.to, S.jsonString).with(S.to, userSchema)
+const parser = createSuryParser(schema).withDefault({
+  name: 'John Vim',
+  age: 25
+})
+
+type DemoContainerProps = React.ComponentProps<'section'> & {
+  demoKey: string
+}
+
+function DemoContainer({
+  children,
+  className,
+  demoKey,
+  ...props
+}: DemoContainerProps) {
+  return (
+    <section
+      className={cn(
+        'not-prose flex flex-wrap items-center gap-2 rounded-xl border border-dashed p-2',
+        className
+      )}
+      {...props}
+    >
+      <QuerySpy className="rounded-md" keepKeys={[demoKey]} />
+      {children}
+      <ContainerQueryHelper />
+    </section>
+  )
+}
+
+export function SuryDemo() {
+  const [user, setUser] = useQueryState('suryUser', parser)
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const name = e.target.value
+    if (!name) {
+      setUser(null) // S.nonEmpty would reject an empty name
+      return
+    }
+    setUser({ name, age: user.age })
+  }
+
+  const handleAgeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const age = parseInt(e.target.value)
+    if (!age || age < 1) {
+      return // S.gte(1) would reject it
+    }
+    setUser({ name: user.name, age })
+  }
+
+  return (
+    <DemoContainer className="flex-col items-stretch gap-4" demoKey="suryUser">
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <div className="flex-1 space-y-2">
+          <Label htmlFor="sury-user-name">Name</Label>
+          <input
+            id="sury-user-name"
+            className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            value={user.name}
+            onChange={handleNameChange}
+            placeholder="Enter your name..."
+            autoComplete="off"
+          />
+        </div>
+        <div className="flex-1 space-y-2">
+          <Label htmlFor="sury-user-age">Age (positive integer)</Label>
+          <input
+            id="sury-user-age"
+            type="number"
+            min="1"
+            className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            value={user.age}
+            onChange={handleAgeChange}
+            placeholder="Enter your age..."
+            autoComplete="off"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-4 lg:flex-row">
+        <CodeBlock
+          title="Parsed User Object"
+          code={JSON.stringify(user, null, 2)}
+          className="flex-1"
+          allowCopy={false}
+        />
+        <Button variant="secondary" onClick={() => setUser(null)}>
+          Clear
+        </Button>
+      </div>
+    </DemoContainer>
+  )
+}

--- a/packages/docs/content/docs/parsers/community/sury.mdx
+++ b/packages/docs/content/docs/parsers/community/sury.mdx
@@ -1,0 +1,75 @@
+---
+title: Sury Parsers
+description: Use Sury to parse, serialize and compare URL state.
+---
+
+import { HumanContent, LLMContent } from '@/src/components/audience'
+
+A [Sury](https://github.com/DZakh/sury) schema reads a value, writes it back and
+compares two of them, which is everything a nuqs parser needs:
+
+```ts
+import { createParser } from 'nuqs'
+import * as S from 'sury'
+
+function createSuryParser<Output>(schema: S.Schema<string, Output>) {
+  return createParser<Output>({
+    parse: S.parseOrThrow(schema),
+    serialize: S.encodeOrThrow(schema),
+    eq: S.isEqualOutput(schema)
+  })
+}
+```
+
+Coercions come built in, so a query value arrives as the type you asked for,
+and anything the schema rejects reads back as `null{:ts}`:
+
+```ts
+createSuryParser(S.string.with(S.to, S.number)) // ?page=2 → 2
+createSuryParser(S.string.with(S.to, S.date)) // ?from=2025-06-12 → Date
+createSuryParser(S.union(['asc', 'desc'])) // ?sort=sideways → null
+createSuryParser(S.string.with(S.to, S.int32.with(S.gte, 1))) // ?page=0 → null
+```
+
+## Example
+
+Schemas compose, so an encoding several steps deep is still one schema:
+
+```ts
+const schema = S.base64url.with(S.to, S.jsonString).with(
+  S.to,
+  S.schema({
+    name: S.string.with(S.nonEmpty),
+    age: S.int32.with(S.gte, 1)
+  })
+)
+
+const [user, setUser] = useQueryState(
+  'user',
+  createSuryParser(schema).withDefault({ name: 'John Vim', age: 25 })
+)
+
+// ?user=eyJuYW1lIjoiSm9obiBWaW0iLCJhZ2UiOjI1fQ
+```
+
+Setting the state back to `{ name: 'John Vim', age: 25 }{:ts}` clears the query
+param, even though it's a different object than the default: the schema knows
+how to compare two users.
+
+import { Suspense } from 'react'
+import { SuryDemo } from './sury-demo'
+
+<HumanContent>
+
+## Interactive Demo
+
+<Suspense>
+  <SuryDemo />
+</Suspense>
+
+</HumanContent>
+
+<LLMContent>
+Interactive demo omitted. The examples above show how to bridge a Sury schema
+with `createParser`.
+</LLMContent>

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -64,6 +64,7 @@
     "remark-smartypants": "^3.0.2",
     "scripts": "workspace:*",
     "server-only": "^0.0.1",
+    "sury": "^11.0.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/nuqs/package.json
+++ b/packages/nuqs/package.json
@@ -203,6 +203,7 @@
     "react-dom": "catalog:react19",
     "react-router-dom": "6.30.6",
     "size-limit": "^12.1.0",
+    "sury": "^11.0.0",
     "tsdown": "^0.22.9",
     "tsnapi": "^1.0.0",
     "typescript": "catalog:typescript",

--- a/packages/nuqs/src/parsers.test.ts
+++ b/packages/nuqs/src/parsers.test.ts
@@ -1,4 +1,5 @@
 import { type } from 'arktype'
+import * as S from 'sury'
 import * as v from 'valibot'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
@@ -264,6 +265,31 @@ describe('parsers', () => {
     const schema = v.object({
       foo: v.string(),
       bar: v.number()
+    })
+    const parser = parseAsJson(schema) // note: using the schema directly
+    expect(parser.parse('')).toBeNull()
+    expect(parser.parse('{"foo":"abc","bar":42}')).toEqual({
+      foo: 'abc',
+      bar: 42
+    })
+    expect(parser.parse('{"foo":"abc","bar":"not-a-number"}')).toBeNull()
+    expect(parser.serialize({ foo: 'abc', bar: 42 })).toBe(
+      '{"foo":"abc","bar":42}'
+    )
+    expect(testParseThenSerialize(parser, '{"foo":"abc","bar":42}')).toBe(true)
+    expect(testSerializeThenParse(parser, { foo: 'abc', bar: 42 })).toBe(true)
+    expect(
+      isParserBijective(parser, '{"foo":"abc","bar":42}', {
+        foo: 'abc',
+        bar: 42
+      })
+    ).toBe(true)
+  })
+
+  it('parseAsJson (validator: Sury)', () => {
+    const schema = S.schema({
+      foo: S.string,
+      bar: S.number
     })
     const parser = parseAsJson(schema) // note: using the schema directly
     expect(parser.parse('')).toBeNull()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sury:
+        specifier: ^11.0.0
+        version: 11.0.0
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -921,6 +924,9 @@ importers:
       size-limit:
         specifier: ^12.1.0
         version: 12.1.0(jiti@2.7.0)
+      sury:
+        specifier: ^11.0.0
+        version: 11.0.0
       tsdown:
         specifier: ^0.22.9
         version: 0.22.9(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)
@@ -8973,6 +8979,14 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  sury@11.0.0:
+    resolution: {integrity: sha512-ixo9P04kr1VB15m+9OX1llkGYityBl5z79XBZqU4hIUjixbdoaoK92wO25DsPqVH8UjyB1rbotf8Gqj0K/uRwA==}
+    peerDependencies:
+      rescript: 12.x
+    peerDependenciesMeta:
+      rescript:
+        optional: true
 
   systeminformation@5.31.17:
     resolution: {integrity: sha512-TvFA9iwDWlMjqZVlKIJ0Cy+Zgm9ttlMx0SMRwJDMNKyhlEKWBMb3+WRwDi/3dvHdWbexpos4Osp4U49p5WjB5g==}
@@ -18232,6 +18246,8 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  sury@11.0.0: {}
 
   systeminformation@5.31.17: {}
 


### PR DESCRIPTION
Hi, Nuqs was a big inspiration for me when shaping the latest versions of Sury, and now that there's a stable release, I think Nuqs and Sury are a perfect match. I'd like to add a custom parser page to show how nicely the library fits Nuqs usecase. Let me know if you have any comments; I'm personally excited simply from looking at the code example.

Sury also implements Standard Schema, so parseAsJson takes a schema directly: covered alongside ArkType and Valibot.
